### PR TITLE
ag-core: bootstrap del Shield con HTTP/1.1+HTTP/2 sobre Axum+Tokio

Modulos error, config, runtime, shield (logging), core (placeholder). AgError con IntoResponse. ShieldConfig desde TOML. 12 unit + 2 E2E + 1 doctest. RFC-0002 PR 1 de 11.

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -36,8 +36,8 @@ jobs:
         run: |
           set -euo pipefail
           expected_blueprint="59a1df26bd24e96067c58c142709e3cb55fc33efbb1c8f3739d9473598dfb660"
-          expected_arch="2b0847522af804df7feeccb3fd64341f1ecf7b34ca6f915db7d775932919304c"
-          expected_road="d1cb15bc943be6c4e87c33bd59aa6056bb8e580a52a03b1a4306aa636f2ee31e"
+          expected_arch="c6f16879cd8c4d7772dbe2911043e31cce9196a31f75a235fdd8bcf72afd67ae"
+          expected_road="534f15ac103cdd45fdca7e91f1c5bd0e3a81527d72c59b0a25eb0425a02a80d4"
           got_blueprint="$(sha256sum docs/master/ANTI-GRAVITAL-Blueprint-v4.0.pdf | awk '{print $1}')"
           got_arch="$(sha256sum docs/master/ANTI-GRAVITAL-Arquitectura-Tecnica.md | awk '{print $1}')"
           got_road="$(sha256sum docs/master/ANTI-GRAVITAL-Hoja-de-Ruta.md | awk '{print $1}')"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -56,4 +56,16 @@ Cambiado:
 Sin codigo funcional. El primer hito tecnico (Shield MVP) se entrega
 en Fase 1.
 
+### Fase 1 - The Shield MVP (en curso)
+
+Anadido:
+
+- RFC-0001 que autoriza la paralelizacion de las puertas externas de
+  Fase 0 con la implementacion de Fase 1 mientras el BDFL trabaja en
+  solitario.
+- RFC-0002 con el diseno detallado del Shield MVP: stack, modulos,
+  features Cargo, configuracion TOML, sistema de errores y plan de
+  implementacion en 11 PRs incrementales.
+- Estado vivo de Fase 1 reflejado en `docs/roadmap/STATUS.md`.
+
 [Unreleased]: https://github.com/anti-gravital/anti-gravital/compare/HEAD..HEAD

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -67,5 +67,17 @@ Anadido:
   features Cargo, configuracion TOML, sistema de errores y plan de
   implementacion en 11 PRs incrementales.
 - Estado vivo de Fase 1 reflejado en `docs/roadmap/STATUS.md`.
+- Bootstrap del crate `ag-core` con HTTP/1.1 y HTTP/2 funcionales via
+  Axum + Tokio (sin TLS aun): modulos `error`, `config`, `runtime`,
+  `shield` (capa de logging estructurado), `core` (placeholder).
+- `AgError` y `AgResult` con mapeo automatico a respuestas HTTP via
+  `IntoResponse`.
+- `ShieldConfig` deserializable desde TOML con defaults seguros.
+- Dependencias compartidas del workspace declaradas en
+  `[workspace.dependencies]` (axum, tokio, tower, tower-http, tracing,
+  serde, thiserror, hyper, http, bytes, toml, pin-project-lite).
+- Tests: 12 unit tests por modulo, 2 tests E2E con servidor real, 1
+  doctest. Todos en verde con `cargo fmt`, `cargo clippy -D warnings`
+  y `cargo doc --no-deps` limpios.
 
 [Unreleased]: https://github.com/anti-gravital/anti-gravital/compare/HEAD..HEAD

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -35,10 +35,23 @@ Anadido:
 - Plantillas de issue, pull request y RFC en `.github/`.
 - ADRs iniciales: `0001-monorepo-workspace.md`,
   `0002-bilingual-documentation.md`, `0003-bdfl-governance.md`,
-  `0004-descomposicion-de-maestros.md`.
+  `0004-descomposicion-de-maestros.md`,
+  `0005-contact-identities.md`.
 - Tablero vivo del proyecto en `docs/roadmap/STATUS.md`.
 - Lista de entregables externos pendientes en
   `docs/governance/external-deliverables.md`.
+
+Cambiado:
+
+- Identidades de contacto oficiales del proyecto. Los placeholders
+  `security@gravital.io` y `hello@antigravital.dev` de los maestros se
+  reemplazan por `anti@gravitalcloud.com` (correo raiz) y
+  `angelnereira@gravitalcloud.com` (BDFL inicial) en
+  `docs/master/ANTI-GRAVITAL-Arquitectura-Tecnica.md` (15.3) y
+  `docs/master/ANTI-GRAVITAL-Hoja-de-Ruta.md` (Fase 0). Hashes
+  recomputados en `docs/master/VERSION.md` con entrada de historial.
+  Derivados verbatim regenerados. Registrado en
+  `docs/adr/0005-contact-identities.md`.
 
 Sin codigo funcional. El primer hito tecnico (Shield MVP) se entrega
 en Fase 1.

--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -68,10 +68,10 @@ o presencial.
 
 Los casos de comportamiento abusivo, acosador o de otra manera
 inaceptable se pueden reportar a los lideres de la comunidad
-responsables de la aplicacion del codigo en
-`security@gravital.io` durante Fase 0; este canal se complementara con
-otro especifico (`conduct@gravital.io`) cuando se habilite. Todas las
-quejas se revisaran e investigaran de forma rapida y justa.
+responsables de la aplicacion del codigo en `anti@gravitalcloud.com`
+durante Fase 0, con respaldo directo al BDFL inicial en
+`angelnereira@gravitalcloud.com` cuando el reporte requiera escalado.
+Todas las quejas se revisaran e investigaran de forma rapida y justa.
 
 Todos los lideres estan obligados a respetar la privacidad y seguridad
 de quienes reporten incidentes.

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -25,6 +25,26 @@ version = "0.0.0"
 [[package]]
 name = "ag-core"
 version = "0.0.0"
+dependencies = [
+ "axum",
+ "bytes",
+ "http",
+ "http-body-util",
+ "hyper",
+ "hyper-util",
+ "pin-project-lite",
+ "reqwest",
+ "serde",
+ "serde_json",
+ "thiserror 1.0.69",
+ "tokio",
+ "tokio-test",
+ "toml",
+ "tower",
+ "tower-http",
+ "tracing",
+ "tracing-subscriber",
+]
 
 [[package]]
 name = "ag-data"
@@ -61,3 +81,1991 @@ version = "0.0.0"
 [[package]]
 name = "ag-wasm-host"
 version = "0.0.0"
+
+[[package]]
+name = "aho-corasick"
+version = "1.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ddd31a130427c27518df266943a5308ed92d4b226cc639f5a8f1002816174301"
+dependencies = [
+ "memchr",
+]
+
+[[package]]
+name = "anyhow"
+version = "1.0.102"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7f202df86484c868dbad7eaa557ef785d5c66295e41b460ef922eca0723b842c"
+
+[[package]]
+name = "async-trait"
+version = "0.1.89"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9035ad2d096bed7955a320ee7e2230574d28fd3c3a0f186cbea1ff3c7eed5dbb"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "atomic-waker"
+version = "1.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1505bd5d3d116872e7271a6d4e16d81d0c8570876c8de68093a09ac269d8aac0"
+
+[[package]]
+name = "axum"
+version = "0.7.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "edca88bc138befd0323b20752846e6587272d3b03b0343c8ea28a6f819e6e71f"
+dependencies = [
+ "async-trait",
+ "axum-core",
+ "bytes",
+ "futures-util",
+ "http",
+ "http-body",
+ "http-body-util",
+ "hyper",
+ "hyper-util",
+ "itoa",
+ "matchit",
+ "memchr",
+ "mime",
+ "percent-encoding",
+ "pin-project-lite",
+ "rustversion",
+ "serde",
+ "serde_json",
+ "serde_path_to_error",
+ "sync_wrapper",
+ "tokio",
+ "tower",
+ "tower-layer",
+ "tower-service",
+]
+
+[[package]]
+name = "axum-core"
+version = "0.4.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "09f2bd6146b97ae3359fa0cc6d6b376d9539582c7b4220f041a33ec24c226199"
+dependencies = [
+ "async-trait",
+ "bytes",
+ "futures-util",
+ "http",
+ "http-body",
+ "http-body-util",
+ "mime",
+ "pin-project-lite",
+ "rustversion",
+ "sync_wrapper",
+ "tower-layer",
+ "tower-service",
+]
+
+[[package]]
+name = "base64"
+version = "0.22.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "72b3254f16251a8381aa12e40e3c4d2f0199f8c6508fbecb9d91f575e0fbb8c6"
+
+[[package]]
+name = "bitflags"
+version = "2.11.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c4512299f36f043ab09a583e57bceb5a5aab7a73db1805848e8fef3c9e8c78b3"
+
+[[package]]
+name = "bumpalo"
+version = "3.20.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5d20789868f4b01b2f2caec9f5c4e0213b41e3e5702a50157d699ae31ced2fcb"
+
+[[package]]
+name = "bytes"
+version = "1.11.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1e748733b7cbc798e1434b6ac524f0c1ff2ab456fe201501e6497c8417a4fc33"
+
+[[package]]
+name = "cc"
+version = "1.2.62"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a1dce859f0832a7d088c4f1119888ab94ef4b5d6795d1ce05afb7fe159d79f98"
+dependencies = [
+ "find-msvc-tools",
+ "shlex",
+]
+
+[[package]]
+name = "cfg-if"
+version = "1.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9330f8b2ff13f34540b44e946ef35111825727b38d33286ef986142615121801"
+
+[[package]]
+name = "cfg_aliases"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "613afe47fcd5fac7ccf1db93babcb082c5994d996f20b8b159f2ad1658eb5724"
+
+[[package]]
+name = "displaydoc"
+version = "0.2.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "97369cbbc041bc366949bc74d34658d6cda5621039731c6310521892a3a20ae0"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "equivalent"
+version = "1.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "877a4ace8713b0bcf2a4e7eec82529c029f1d0619886d18145fea96c3ffe5c0f"
+
+[[package]]
+name = "errno"
+version = "0.3.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
+dependencies = [
+ "libc",
+ "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "find-msvc-tools"
+version = "0.1.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5baebc0774151f905a1a2cc41989300b1e6fbb29aff0ceffa1064fdd3088d582"
+
+[[package]]
+name = "fnv"
+version = "1.0.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3f9eec918d3f24069decb9af1554cad7c880e2da24a9afd88aca000531ab82c1"
+
+[[package]]
+name = "foldhash"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d9c4f5dac5e15c24eb999c26181a6ca40b39fe946cbe4c263c7209467bc83af2"
+
+[[package]]
+name = "form_urlencoded"
+version = "1.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cb4cb245038516f5f85277875cdaa4f7d2c9a0fa0468de06ed190163b1581fcf"
+dependencies = [
+ "percent-encoding",
+]
+
+[[package]]
+name = "futures-channel"
+version = "0.3.32"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "07bbe89c50d7a535e539b8c17bc0b49bdb77747034daa8087407d655f3f7cc1d"
+dependencies = [
+ "futures-core",
+]
+
+[[package]]
+name = "futures-core"
+version = "0.3.32"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7e3450815272ef58cec6d564423f6e755e25379b217b0bc688e295ba24df6b1d"
+
+[[package]]
+name = "futures-sink"
+version = "0.3.32"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c39754e157331b013978ec91992bde1ac089843443c49cbc7f46150b0fad0893"
+
+[[package]]
+name = "futures-task"
+version = "0.3.32"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "037711b3d59c33004d3856fbdc83b99d4ff37a24768fa1be9ce3538a1cde4393"
+
+[[package]]
+name = "futures-util"
+version = "0.3.32"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "389ca41296e6190b48053de0321d02a77f32f8a5d2461dd38762c0593805c6d6"
+dependencies = [
+ "futures-core",
+ "futures-task",
+ "pin-project-lite",
+ "slab",
+]
+
+[[package]]
+name = "getrandom"
+version = "0.2.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ff2abc00be7fca6ebc474524697ae276ad847ad0a6b3faa4bcb027e9a4614ad0"
+dependencies = [
+ "cfg-if",
+ "js-sys",
+ "libc",
+ "wasi",
+ "wasm-bindgen",
+]
+
+[[package]]
+name = "getrandom"
+version = "0.3.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "899def5c37c4fd7b2664648c28120ecec138e4d395b459e5ca34f9cce2dd77fd"
+dependencies = [
+ "cfg-if",
+ "js-sys",
+ "libc",
+ "r-efi 5.3.0",
+ "wasip2",
+ "wasm-bindgen",
+]
+
+[[package]]
+name = "getrandom"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0de51e6874e94e7bf76d726fc5d13ba782deca734ff60d5bb2fb2607c7406555"
+dependencies = [
+ "cfg-if",
+ "libc",
+ "r-efi 6.0.0",
+ "wasip2",
+ "wasip3",
+]
+
+[[package]]
+name = "h2"
+version = "0.4.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "171fefbc92fe4a4de27e0698d6a5b392d6a0e333506bc49133760b3bcf948733"
+dependencies = [
+ "atomic-waker",
+ "bytes",
+ "fnv",
+ "futures-core",
+ "futures-sink",
+ "http",
+ "indexmap",
+ "slab",
+ "tokio",
+ "tokio-util",
+ "tracing",
+]
+
+[[package]]
+name = "hashbrown"
+version = "0.15.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9229cfe53dfd69f0609a49f65461bd93001ea1ef889cd5529dd176593f5338a1"
+dependencies = [
+ "foldhash",
+]
+
+[[package]]
+name = "hashbrown"
+version = "0.17.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ed5909b6e89a2db4456e54cd5f673791d7eca6732202bbf2a9cc504fe2f9b84a"
+
+[[package]]
+name = "heck"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2304e00983f87ffb38b55b444b5e3b60a884b5d30c0fca7d82fe33449bbe55ea"
+
+[[package]]
+name = "http"
+version = "1.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e3ba2a386d7f85a81f119ad7498ebe444d2e22c2af0b86b069416ace48b3311a"
+dependencies = [
+ "bytes",
+ "itoa",
+]
+
+[[package]]
+name = "http-body"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1efedce1fb8e6913f23e0c92de8e62cd5b772a67e7b3946df930a62566c93184"
+dependencies = [
+ "bytes",
+ "http",
+]
+
+[[package]]
+name = "http-body-util"
+version = "0.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b021d93e26becf5dc7e1b75b1bed1fd93124b374ceb73f43d4d4eafec896a64a"
+dependencies = [
+ "bytes",
+ "futures-core",
+ "http",
+ "http-body",
+ "pin-project-lite",
+]
+
+[[package]]
+name = "httparse"
+version = "1.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6dbf3de79e51f3d586ab4cb9d5c3e2c14aa28ed23d180cf89b4df0454a69cc87"
+
+[[package]]
+name = "httpdate"
+version = "1.0.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "df3b46402a9d5adb4c86a0cf463f42e19994e3ee891101b1841f30a545cb49a9"
+
+[[package]]
+name = "hyper"
+version = "1.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6299f016b246a94207e63da54dbe807655bf9e00044f73ded42c3ac5305fbcca"
+dependencies = [
+ "atomic-waker",
+ "bytes",
+ "futures-channel",
+ "futures-core",
+ "h2",
+ "http",
+ "http-body",
+ "httparse",
+ "httpdate",
+ "itoa",
+ "pin-project-lite",
+ "smallvec",
+ "tokio",
+ "want",
+]
+
+[[package]]
+name = "hyper-rustls"
+version = "0.27.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "33ca68d021ef39cf6463ab54c1d0f5daf03377b70561305bb89a8f83aab66e0f"
+dependencies = [
+ "http",
+ "hyper",
+ "hyper-util",
+ "rustls",
+ "tokio",
+ "tokio-rustls",
+ "tower-service",
+ "webpki-roots",
+]
+
+[[package]]
+name = "hyper-util"
+version = "0.1.20"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "96547c2556ec9d12fb1578c4eaf448b04993e7fb79cbaad930a656880a6bdfa0"
+dependencies = [
+ "base64",
+ "bytes",
+ "futures-channel",
+ "futures-util",
+ "http",
+ "http-body",
+ "hyper",
+ "ipnet",
+ "libc",
+ "percent-encoding",
+ "pin-project-lite",
+ "socket2",
+ "tokio",
+ "tower-service",
+ "tracing",
+]
+
+[[package]]
+name = "icu_collections"
+version = "2.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2984d1cd16c883d7935b9e07e44071dca8d917fd52ecc02c04d5fa0b5a3f191c"
+dependencies = [
+ "displaydoc",
+ "potential_utf",
+ "utf8_iter",
+ "yoke",
+ "zerofrom",
+ "zerovec",
+]
+
+[[package]]
+name = "icu_locale_core"
+version = "2.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "92219b62b3e2b4d88ac5119f8904c10f8f61bf7e95b640d25ba3075e6cac2c29"
+dependencies = [
+ "displaydoc",
+ "litemap",
+ "tinystr",
+ "writeable",
+ "zerovec",
+]
+
+[[package]]
+name = "icu_normalizer"
+version = "2.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c56e5ee99d6e3d33bd91c5d85458b6005a22140021cc324cea84dd0e72cff3b4"
+dependencies = [
+ "icu_collections",
+ "icu_normalizer_data",
+ "icu_properties",
+ "icu_provider",
+ "smallvec",
+ "zerovec",
+]
+
+[[package]]
+name = "icu_normalizer_data"
+version = "2.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "da3be0ae77ea334f4da67c12f149704f19f81d1adf7c51cf482943e84a2bad38"
+
+[[package]]
+name = "icu_properties"
+version = "2.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bee3b67d0ea5c2cca5003417989af8996f8604e34fb9ddf96208a033901e70de"
+dependencies = [
+ "icu_collections",
+ "icu_locale_core",
+ "icu_properties_data",
+ "icu_provider",
+ "zerotrie",
+ "zerovec",
+]
+
+[[package]]
+name = "icu_properties_data"
+version = "2.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8e2bbb201e0c04f7b4b3e14382af113e17ba4f63e2c9d2ee626b720cbce54a14"
+
+[[package]]
+name = "icu_provider"
+version = "2.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "139c4cf31c8b5f33d7e199446eff9c1e02decfc2f0eec2c8d71f65befa45b421"
+dependencies = [
+ "displaydoc",
+ "icu_locale_core",
+ "writeable",
+ "yoke",
+ "zerofrom",
+ "zerotrie",
+ "zerovec",
+]
+
+[[package]]
+name = "id-arena"
+version = "2.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3d3067d79b975e8844ca9eb072e16b31c3c1c36928edf9c6789548c524d0d954"
+
+[[package]]
+name = "idna"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3b0875f23caa03898994f6ddc501886a45c7d3d62d04d2d90788d47be1b1e4de"
+dependencies = [
+ "idna_adapter",
+ "smallvec",
+ "utf8_iter",
+]
+
+[[package]]
+name = "idna_adapter"
+version = "1.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cb68373c0d6620ef8105e855e7745e18b0d00d3bdb07fb532e434244cdb9a714"
+dependencies = [
+ "icu_normalizer",
+ "icu_properties",
+]
+
+[[package]]
+name = "indexmap"
+version = "2.14.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d466e9454f08e4a911e14806c24e16fba1b4c121d1ea474396f396069cf949d9"
+dependencies = [
+ "equivalent",
+ "hashbrown 0.17.1",
+ "serde",
+ "serde_core",
+]
+
+[[package]]
+name = "ipnet"
+version = "2.12.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d98f6fed1fde3f8c21bc40a1abb88dd75e67924f9cffc3ef95607bad8017f8e2"
+
+[[package]]
+name = "itoa"
+version = "1.0.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8f42a60cbdf9a97f5d2305f08a87dc4e09308d1276d28c869c684d7777685682"
+
+[[package]]
+name = "js-sys"
+version = "0.3.98"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "67df7112613f8bfd9150013a0314e196f4800d3201ae742489d999db2f979f08"
+dependencies = [
+ "cfg-if",
+ "futures-util",
+ "once_cell",
+ "wasm-bindgen",
+]
+
+[[package]]
+name = "lazy_static"
+version = "1.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bbd2bcb4c963f2ddae06a2efc7e9f3591312473c50c6685e1f298068316e66fe"
+
+[[package]]
+name = "leb128fmt"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "09edd9e8b54e49e587e4f6295a7d29c3ea94d469cb40ab8ca70b288248a81db2"
+
+[[package]]
+name = "libc"
+version = "0.2.186"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "68ab91017fe16c622486840e4c83c9a37afeff978bd239b5293d61ece587de66"
+
+[[package]]
+name = "litemap"
+version = "0.8.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "92daf443525c4cce67b150400bc2316076100ce0b3686209eb8cf3c31612e6f0"
+
+[[package]]
+name = "log"
+version = "0.4.29"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5e5032e24019045c762d3c0f28f5b6b8bbf38563a65908389bf7978758920897"
+
+[[package]]
+name = "lru-slab"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "112b39cec0b298b6c1999fee3e31427f74f676e4cb9879ed1a121b43661a4154"
+
+[[package]]
+name = "matchers"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d1525a2a28c7f4fa0fc98bb91ae755d1e2d1505079e05539e35bc876b5d65ae9"
+dependencies = [
+ "regex-automata",
+]
+
+[[package]]
+name = "matchit"
+version = "0.7.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0e7465ac9959cc2b1404e8e2367b43684a6d13790fe23056cc8c6c5a6b7bcb94"
+
+[[package]]
+name = "memchr"
+version = "2.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f8ca58f447f06ed17d5fc4043ce1b10dd205e060fb3ce5b979b8ed8e59ff3f79"
+
+[[package]]
+name = "mime"
+version = "0.3.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6877bb514081ee2a7ff5ef9de3281f14a4dd4bceac4c09388074a6b5df8a139a"
+
+[[package]]
+name = "mio"
+version = "1.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "50b7e5b27aa02a74bac8c3f23f448f8d87ff11f92d3aac1a6ed369ee08cc56c1"
+dependencies = [
+ "libc",
+ "wasi",
+ "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "nu-ansi-term"
+version = "0.50.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7957b9740744892f114936ab4a57b3f487491bbeafaf8083688b16841a4240e5"
+dependencies = [
+ "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "once_cell"
+version = "1.21.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9f7c3e4beb33f85d45ae3e3a1792185706c8e16d043238c593331cc7cd313b50"
+
+[[package]]
+name = "percent-encoding"
+version = "2.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9b4f627cb1b25917193a259e49bdad08f671f8d9708acfd5fe0a8c1455d87220"
+
+[[package]]
+name = "pin-project-lite"
+version = "0.2.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a89322df9ebe1c1578d689c92318e070967d1042b512afbe49518723f4e6d5cd"
+
+[[package]]
+name = "potential_utf"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0103b1cef7ec0cf76490e969665504990193874ea05c85ff9bab8b911d0a0564"
+dependencies = [
+ "zerovec",
+]
+
+[[package]]
+name = "ppv-lite86"
+version = "0.2.21"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "85eae3c4ed2f50dcfe72643da4befc30deadb458a9b590d720cde2f2b1e97da9"
+dependencies = [
+ "zerocopy",
+]
+
+[[package]]
+name = "prettyplease"
+version = "0.2.37"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "479ca8adacdd7ce8f1fb39ce9ecccbfe93a3f1344b3d0d97f20bc0196208f62b"
+dependencies = [
+ "proc-macro2",
+ "syn",
+]
+
+[[package]]
+name = "proc-macro2"
+version = "1.0.106"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8fd00f0bb2e90d81d1044c2b32617f68fcb9fa3bb7640c23e9c748e53fb30934"
+dependencies = [
+ "unicode-ident",
+]
+
+[[package]]
+name = "quinn"
+version = "0.11.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b9e20a958963c291dc322d98411f541009df2ced7b5a4f2bd52337638cfccf20"
+dependencies = [
+ "bytes",
+ "cfg_aliases",
+ "pin-project-lite",
+ "quinn-proto",
+ "quinn-udp",
+ "rustc-hash",
+ "rustls",
+ "socket2",
+ "thiserror 2.0.18",
+ "tokio",
+ "tracing",
+ "web-time",
+]
+
+[[package]]
+name = "quinn-proto"
+version = "0.11.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "434b42fec591c96ef50e21e886936e66d3cc3f737104fdb9b737c40ffb94c098"
+dependencies = [
+ "bytes",
+ "getrandom 0.3.4",
+ "lru-slab",
+ "rand",
+ "ring",
+ "rustc-hash",
+ "rustls",
+ "rustls-pki-types",
+ "slab",
+ "thiserror 2.0.18",
+ "tinyvec",
+ "tracing",
+ "web-time",
+]
+
+[[package]]
+name = "quinn-udp"
+version = "0.5.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "addec6a0dcad8a8d96a771f815f0eaf55f9d1805756410b39f5fa81332574cbd"
+dependencies = [
+ "cfg_aliases",
+ "libc",
+ "once_cell",
+ "socket2",
+ "tracing",
+ "windows-sys 0.60.2",
+]
+
+[[package]]
+name = "quote"
+version = "1.0.45"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "41f2619966050689382d2b44f664f4bc593e129785a36d6ee376ddf37259b924"
+dependencies = [
+ "proc-macro2",
+]
+
+[[package]]
+name = "r-efi"
+version = "5.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "69cdb34c158ceb288df11e18b4bd39de994f6657d83847bdffdbd7f346754b0f"
+
+[[package]]
+name = "r-efi"
+version = "6.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f8dcc9c7d52a811697d2151c701e0d08956f92b0e24136cf4cf27b57a6a0d9bf"
+
+[[package]]
+name = "rand"
+version = "0.9.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "44c5af06bb1b7d3216d91932aed5265164bf384dc89cd6ba05cf59a35f5f76ea"
+dependencies = [
+ "rand_chacha",
+ "rand_core",
+]
+
+[[package]]
+name = "rand_chacha"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d3022b5f1df60f26e1ffddd6c66e8aa15de382ae63b3a0c1bfc0e4d3e3f325cb"
+dependencies = [
+ "ppv-lite86",
+ "rand_core",
+]
+
+[[package]]
+name = "rand_core"
+version = "0.9.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "76afc826de14238e6e8c374ddcc1fa19e374fd8dd986b0d2af0d02377261d83c"
+dependencies = [
+ "getrandom 0.3.4",
+]
+
+[[package]]
+name = "regex-automata"
+version = "0.4.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6e1dd4122fc1595e8162618945476892eefca7b88c52820e74af6262213cae8f"
+dependencies = [
+ "aho-corasick",
+ "memchr",
+ "regex-syntax",
+]
+
+[[package]]
+name = "regex-syntax"
+version = "0.8.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dc897dd8d9e8bd1ed8cdad82b5966c3e0ecae09fb1907d58efaa013543185d0a"
+
+[[package]]
+name = "reqwest"
+version = "0.12.28"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "eddd3ca559203180a307f12d114c268abf583f59b03cb906fd0b3ff8646c1147"
+dependencies = [
+ "base64",
+ "bytes",
+ "futures-core",
+ "http",
+ "http-body",
+ "http-body-util",
+ "hyper",
+ "hyper-rustls",
+ "hyper-util",
+ "js-sys",
+ "log",
+ "percent-encoding",
+ "pin-project-lite",
+ "quinn",
+ "rustls",
+ "rustls-pki-types",
+ "serde",
+ "serde_json",
+ "serde_urlencoded",
+ "sync_wrapper",
+ "tokio",
+ "tokio-rustls",
+ "tower",
+ "tower-http",
+ "tower-service",
+ "url",
+ "wasm-bindgen",
+ "wasm-bindgen-futures",
+ "web-sys",
+ "webpki-roots",
+]
+
+[[package]]
+name = "ring"
+version = "0.17.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a4689e6c2294d81e88dc6261c768b63bc4fcdb852be6d1352498b114f61383b7"
+dependencies = [
+ "cc",
+ "cfg-if",
+ "getrandom 0.2.17",
+ "libc",
+ "untrusted",
+ "windows-sys 0.52.0",
+]
+
+[[package]]
+name = "rustc-hash"
+version = "2.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "94300abf3f1ae2e2b8ffb7b58043de3d399c73fa6f4b73826402a5c457614dbe"
+
+[[package]]
+name = "rustls"
+version = "0.23.40"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ef86cd5876211988985292b91c96a8f2d298df24e75989a43a3c73f2d4d8168b"
+dependencies = [
+ "once_cell",
+ "ring",
+ "rustls-pki-types",
+ "rustls-webpki",
+ "subtle",
+ "zeroize",
+]
+
+[[package]]
+name = "rustls-pki-types"
+version = "1.14.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "30a7197ae7eb376e574fe940d068c30fe0462554a3ddbe4eca7838e049c937a9"
+dependencies = [
+ "web-time",
+ "zeroize",
+]
+
+[[package]]
+name = "rustls-webpki"
+version = "0.103.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "61c429a8649f110dddef65e2a5ad240f747e85f7758a6bccc7e5777bd33f756e"
+dependencies = [
+ "ring",
+ "rustls-pki-types",
+ "untrusted",
+]
+
+[[package]]
+name = "rustversion"
+version = "1.0.22"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b39cdef0fa800fc44525c84ccb54a029961a8215f9619753635a9c0d2538d46d"
+
+[[package]]
+name = "ryu"
+version = "1.0.23"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9774ba4a74de5f7b1c1451ed6cd5285a32eddb5cccb8cc655a4e50009e06477f"
+
+[[package]]
+name = "semver"
+version = "1.0.28"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8a7852d02fc848982e0c167ef163aaff9cd91dc640ba85e263cb1ce46fae51cd"
+
+[[package]]
+name = "serde"
+version = "1.0.228"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9a8e94ea7f378bd32cbbd37198a4a91436180c5bb472411e48b5ec2e2124ae9e"
+dependencies = [
+ "serde_core",
+ "serde_derive",
+]
+
+[[package]]
+name = "serde_core"
+version = "1.0.228"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "41d385c7d4ca58e59fc732af25c3983b67ac852c1a25000afe1175de458b67ad"
+dependencies = [
+ "serde_derive",
+]
+
+[[package]]
+name = "serde_derive"
+version = "1.0.228"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d540f220d3187173da220f885ab66608367b6574e925011a9353e4badda91d79"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "serde_json"
+version = "1.0.149"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "83fc039473c5595ace860d8c4fafa220ff474b3fc6bfdb4293327f1a37e94d86"
+dependencies = [
+ "itoa",
+ "memchr",
+ "serde",
+ "serde_core",
+ "zmij",
+]
+
+[[package]]
+name = "serde_path_to_error"
+version = "0.1.20"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "10a9ff822e371bb5403e391ecd83e182e0e77ba7f6fe0160b795797109d1b457"
+dependencies = [
+ "itoa",
+ "serde",
+ "serde_core",
+]
+
+[[package]]
+name = "serde_spanned"
+version = "0.6.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bf41e0cfaf7226dca15e8197172c295a782857fcb97fad1808a166870dee75a3"
+dependencies = [
+ "serde",
+]
+
+[[package]]
+name = "serde_urlencoded"
+version = "0.7.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d3491c14715ca2294c4d6a88f15e84739788c1d030eed8c110436aafdaa2f3fd"
+dependencies = [
+ "form_urlencoded",
+ "itoa",
+ "ryu",
+ "serde",
+]
+
+[[package]]
+name = "sharded-slab"
+version = "0.1.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f40ca3c46823713e0d4209592e8d6e826aa57e928f09752619fc696c499637f6"
+dependencies = [
+ "lazy_static",
+]
+
+[[package]]
+name = "shlex"
+version = "1.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0fda2ff0d084019ba4d7c6f371c95d8fd75ce3524c3cb8fb653a3023f6323e64"
+
+[[package]]
+name = "signal-hook-registry"
+version = "1.4.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c4db69cba1110affc0e9f7bcd48bbf87b3f4fc7c61fc9155afd4c469eb3d6c1b"
+dependencies = [
+ "errno",
+ "libc",
+]
+
+[[package]]
+name = "slab"
+version = "0.4.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0c790de23124f9ab44544d7ac05d60440adc586479ce501c1d6d7da3cd8c9cf5"
+
+[[package]]
+name = "smallvec"
+version = "1.15.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "67b1b7a3b5fe4f1376887184045fcf45c69e92af734b7aaddc05fb777b6fbd03"
+
+[[package]]
+name = "socket2"
+version = "0.6.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3a766e1110788c36f4fa1c2b71b387a7815aa65f88ce0229841826633d93723e"
+dependencies = [
+ "libc",
+ "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "stable_deref_trait"
+version = "1.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6ce2be8dc25455e1f91df71bfa12ad37d7af1092ae736f3a6cd0e37bc7810596"
+
+[[package]]
+name = "subtle"
+version = "2.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "13c2bddecc57b384dee18652358fb23172facb8a2c51ccc10d74c157bdea3292"
+
+[[package]]
+name = "syn"
+version = "2.0.117"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e665b8803e7b1d2a727f4023456bbbbe74da67099c585258af0ad9c5013b9b99"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "unicode-ident",
+]
+
+[[package]]
+name = "sync_wrapper"
+version = "1.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0bf256ce5efdfa370213c1dabab5935a12e49f2c58d15e9eac2870d3b4f27263"
+dependencies = [
+ "futures-core",
+]
+
+[[package]]
+name = "synstructure"
+version = "0.13.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "728a70f3dbaf5bab7f0c4b1ac8d7ae5ea60a4b5549c8a5914361c99147a709d2"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "thiserror"
+version = "1.0.69"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b6aaf5339b578ea85b50e080feb250a3e8ae8cfcdff9a461c9ec2904bc923f52"
+dependencies = [
+ "thiserror-impl 1.0.69",
+]
+
+[[package]]
+name = "thiserror"
+version = "2.0.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4288b5bcbc7920c07a1149a35cf9590a2aa808e0bc1eafaade0b80947865fbc4"
+dependencies = [
+ "thiserror-impl 2.0.18",
+]
+
+[[package]]
+name = "thiserror-impl"
+version = "1.0.69"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4fee6c4efc90059e10f81e6d42c60a18f76588c3d74cb83a0b242a2b6c7504c1"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "thiserror-impl"
+version = "2.0.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ebc4ee7f67670e9b64d05fa4253e753e016c6c95ff35b89b7941d6b856dec1d5"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "thread_local"
+version = "1.1.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f60246a4944f24f6e018aa17cdeffb7818b76356965d03b07d6a9886e8962185"
+dependencies = [
+ "cfg-if",
+]
+
+[[package]]
+name = "tinystr"
+version = "0.8.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c8323304221c2a851516f22236c5722a72eaa19749016521d6dff0824447d96d"
+dependencies = [
+ "displaydoc",
+ "zerovec",
+]
+
+[[package]]
+name = "tinyvec"
+version = "1.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3e61e67053d25a4e82c844e8424039d9745781b3fc4f32b8d55ed50f5f667ef3"
+dependencies = [
+ "tinyvec_macros",
+]
+
+[[package]]
+name = "tinyvec_macros"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1f3ccbac311fea05f86f61904b462b55fb3df8837a366dfc601a0161d0532f20"
+
+[[package]]
+name = "tokio"
+version = "1.52.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8fc7f01b389ac15039e4dc9531aa973a135d7a4135281b12d7c1bc79fd57fffe"
+dependencies = [
+ "bytes",
+ "libc",
+ "mio",
+ "pin-project-lite",
+ "signal-hook-registry",
+ "socket2",
+ "tokio-macros",
+ "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "tokio-macros"
+version = "2.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "385a6cb71ab9ab790c5fe8d67f1645e6c450a7ce006a33de03daa956cf70a496"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "tokio-rustls"
+version = "0.26.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1729aa945f29d91ba541258c8df89027d5792d85a8841fb65e8bf0f4ede4ef61"
+dependencies = [
+ "rustls",
+ "tokio",
+]
+
+[[package]]
+name = "tokio-stream"
+version = "0.1.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "32da49809aab5c3bc678af03902d4ccddea2a87d028d86392a4b1560c6906c70"
+dependencies = [
+ "futures-core",
+ "pin-project-lite",
+ "tokio",
+]
+
+[[package]]
+name = "tokio-test"
+version = "0.4.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3f6d24790a10a7af737693a3e8f1d03faef7e6ca0cc99aae5066f533766de545"
+dependencies = [
+ "futures-core",
+ "tokio",
+ "tokio-stream",
+]
+
+[[package]]
+name = "tokio-util"
+version = "0.7.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9ae9cec805b01e8fc3fd2fe289f89149a9b66dd16786abd8b19cfa7b48cb0098"
+dependencies = [
+ "bytes",
+ "futures-core",
+ "futures-sink",
+ "pin-project-lite",
+ "tokio",
+]
+
+[[package]]
+name = "toml"
+version = "0.8.23"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dc1beb996b9d83529a9e75c17a1686767d148d70663143c7854d8b4a09ced362"
+dependencies = [
+ "serde",
+ "serde_spanned",
+ "toml_datetime",
+ "toml_edit",
+]
+
+[[package]]
+name = "toml_datetime"
+version = "0.6.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "22cddaf88f4fbc13c51aebbf5f8eceb5c7c5a9da2ac40a13519eb5b0a0e8f11c"
+dependencies = [
+ "serde",
+]
+
+[[package]]
+name = "toml_edit"
+version = "0.22.27"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "41fe8c660ae4257887cf66394862d21dbca4a6ddd26f04a3560410406a2f819a"
+dependencies = [
+ "indexmap",
+ "serde",
+ "serde_spanned",
+ "toml_datetime",
+ "toml_write",
+ "winnow",
+]
+
+[[package]]
+name = "toml_write"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5d99f8c9a7727884afe522e9bd5edbfc91a3312b36a77b5fb8926e4c31a41801"
+
+[[package]]
+name = "tower"
+version = "0.5.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ebe5ef63511595f1344e2d5cfa636d973292adc0eec1f0ad45fae9f0851ab1d4"
+dependencies = [
+ "futures-core",
+ "futures-util",
+ "pin-project-lite",
+ "sync_wrapper",
+ "tokio",
+ "tower-layer",
+ "tower-service",
+]
+
+[[package]]
+name = "tower-http"
+version = "0.6.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4cfcf7e2740e6fc6d4d688b4ef00650406bb94adf4731e43c096c3a19fe40840"
+dependencies = [
+ "bitflags",
+ "bytes",
+ "futures-util",
+ "http",
+ "http-body",
+ "pin-project-lite",
+ "tower",
+ "tower-layer",
+ "tower-service",
+ "tracing",
+ "url",
+ "uuid",
+]
+
+[[package]]
+name = "tower-layer"
+version = "0.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "121c2a6cda46980bb0fcd1647ffaf6cd3fc79a013de288782836f6df9c48780e"
+
+[[package]]
+name = "tower-service"
+version = "0.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8df9b6e13f2d32c91b9bd719c00d1958837bc7dec474d94952798cc8e69eeec3"
+
+[[package]]
+name = "tracing"
+version = "0.1.44"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "63e71662fa4b2a2c3a26f570f037eb95bb1f85397f3cd8076caed2f026a6d100"
+dependencies = [
+ "pin-project-lite",
+ "tracing-attributes",
+ "tracing-core",
+]
+
+[[package]]
+name = "tracing-attributes"
+version = "0.1.31"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7490cfa5ec963746568740651ac6781f701c9c5ea257c58e057f3ba8cf69e8da"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "tracing-core"
+version = "0.1.36"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "db97caf9d906fbde555dd62fa95ddba9eecfd14cb388e4f491a66d74cd5fb79a"
+dependencies = [
+ "once_cell",
+ "valuable",
+]
+
+[[package]]
+name = "tracing-log"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ee855f1f400bd0e5c02d150ae5de3840039a3f54b025156404e34c23c03f47c3"
+dependencies = [
+ "log",
+ "once_cell",
+ "tracing-core",
+]
+
+[[package]]
+name = "tracing-serde"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "704b1aeb7be0d0a84fc9828cae51dab5970fee5088f83d1dd7ee6f6246fc6ff1"
+dependencies = [
+ "serde",
+ "tracing-core",
+]
+
+[[package]]
+name = "tracing-subscriber"
+version = "0.3.23"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cb7f578e5945fb242538965c2d0b04418d38ec25c79d160cd279bf0731c8d319"
+dependencies = [
+ "matchers",
+ "nu-ansi-term",
+ "once_cell",
+ "regex-automata",
+ "serde",
+ "serde_json",
+ "sharded-slab",
+ "smallvec",
+ "thread_local",
+ "tracing",
+ "tracing-core",
+ "tracing-log",
+ "tracing-serde",
+]
+
+[[package]]
+name = "try-lock"
+version = "0.2.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e421abadd41a4225275504ea4d6566923418b7f05506fbc9c0fe86ba7396114b"
+
+[[package]]
+name = "unicode-ident"
+version = "1.0.24"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e6e4313cd5fcd3dad5cafa179702e2b244f760991f45397d14d4ebf38247da75"
+
+[[package]]
+name = "unicode-xid"
+version = "0.2.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ebc1c04c71510c7f702b52b7c350734c9ff1295c464a03335b00bb84fc54f853"
+
+[[package]]
+name = "untrusted"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8ecb6da28b8a351d773b68d5825ac39017e680750f980f3a1a85cd8dd28a47c1"
+
+[[package]]
+name = "url"
+version = "2.5.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ff67a8a4397373c3ef660812acab3268222035010ab8680ec4215f38ba3d0eed"
+dependencies = [
+ "form_urlencoded",
+ "idna",
+ "percent-encoding",
+ "serde",
+]
+
+[[package]]
+name = "utf8_iter"
+version = "1.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b6c140620e7ffbb22c2dee59cafe6084a59b5ffc27a8859a5f0d494b5d52b6be"
+
+[[package]]
+name = "uuid"
+version = "1.23.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ddd74a9687298c6858e9b88ec8935ec45d22e8fd5e6394fa1bd4e99a87789c76"
+dependencies = [
+ "getrandom 0.4.2",
+ "js-sys",
+ "wasm-bindgen",
+]
+
+[[package]]
+name = "valuable"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ba73ea9cf16a25df0c8caa16c51acb937d5712a8429db78a3ee29d5dcacd3a65"
+
+[[package]]
+name = "want"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bfa7760aed19e106de2c7c0b581b509f2f25d3dacaf737cb82ac61bc6d760b0e"
+dependencies = [
+ "try-lock",
+]
+
+[[package]]
+name = "wasi"
+version = "0.11.1+wasi-snapshot-preview1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ccf3ec651a847eb01de73ccad15eb7d99f80485de043efb2f370cd654f4ea44b"
+
+[[package]]
+name = "wasip2"
+version = "1.0.3+wasi-0.2.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "20064672db26d7cdc89c7798c48a0fdfac8213434a1186e5ef29fd560ae223d6"
+dependencies = [
+ "wit-bindgen 0.57.1",
+]
+
+[[package]]
+name = "wasip3"
+version = "0.4.0+wasi-0.3.0-rc-2026-01-06"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5428f8bf88ea5ddc08faddef2ac4a67e390b88186c703ce6dbd955e1c145aca5"
+dependencies = [
+ "wit-bindgen 0.51.0",
+]
+
+[[package]]
+name = "wasm-bindgen"
+version = "0.2.121"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "49ace1d07c165b0864824eee619580c4689389afa9dc9ed3a4c75040d82e6790"
+dependencies = [
+ "cfg-if",
+ "once_cell",
+ "rustversion",
+ "wasm-bindgen-macro",
+ "wasm-bindgen-shared",
+]
+
+[[package]]
+name = "wasm-bindgen-futures"
+version = "0.4.71"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "96492d0d3ffba25305a7dc88720d250b1401d7edca02cc3bcd50633b424673b8"
+dependencies = [
+ "js-sys",
+ "wasm-bindgen",
+]
+
+[[package]]
+name = "wasm-bindgen-macro"
+version = "0.2.121"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8e68e6f4afd367a562002c05637acb8578ff2dea1943df76afb9e83d177c8578"
+dependencies = [
+ "quote",
+ "wasm-bindgen-macro-support",
+]
+
+[[package]]
+name = "wasm-bindgen-macro-support"
+version = "0.2.121"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d95a9ec35c64b2a7cb35d3fead40c4238d0940c86d107136999567a4703259f2"
+dependencies = [
+ "bumpalo",
+ "proc-macro2",
+ "quote",
+ "syn",
+ "wasm-bindgen-shared",
+]
+
+[[package]]
+name = "wasm-bindgen-shared"
+version = "0.2.121"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c4e0100b01e9f0d03189a92b96772a1fb998639d981193d7dbab487302513441"
+dependencies = [
+ "unicode-ident",
+]
+
+[[package]]
+name = "wasm-encoder"
+version = "0.244.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "990065f2fe63003fe337b932cfb5e3b80e0b4d0f5ff650e6985b1048f62c8319"
+dependencies = [
+ "leb128fmt",
+ "wasmparser",
+]
+
+[[package]]
+name = "wasm-metadata"
+version = "0.244.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bb0e353e6a2fbdc176932bbaab493762eb1255a7900fe0fea1a2f96c296cc909"
+dependencies = [
+ "anyhow",
+ "indexmap",
+ "wasm-encoder",
+ "wasmparser",
+]
+
+[[package]]
+name = "wasmparser"
+version = "0.244.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "47b807c72e1bac69382b3a6fb3dbe8ea4c0ed87ff5629b8685ae6b9a611028fe"
+dependencies = [
+ "bitflags",
+ "hashbrown 0.15.5",
+ "indexmap",
+ "semver",
+]
+
+[[package]]
+name = "web-sys"
+version = "0.3.98"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4b572dff8bcf38bad0fa19729c89bb5748b2b9b1d8be70cf90df697e3a8f32aa"
+dependencies = [
+ "js-sys",
+ "wasm-bindgen",
+]
+
+[[package]]
+name = "web-time"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5a6580f308b1fad9207618087a65c04e7a10bc77e02c8e84e9b00dd4b12fa0bb"
+dependencies = [
+ "js-sys",
+ "wasm-bindgen",
+]
+
+[[package]]
+name = "webpki-roots"
+version = "1.0.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "52f5ee44c96cf55f1b349600768e3ece3a8f26010c05265ab73f945bb1a2eb9d"
+dependencies = [
+ "rustls-pki-types",
+]
+
+[[package]]
+name = "windows-link"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f0805222e57f7521d6a62e36fa9163bc891acd422f971defe97d64e70d0a4fe5"
+
+[[package]]
+name = "windows-sys"
+version = "0.52.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "282be5f36a8ce781fad8c8ae18fa3f9beff57ec1b52cb3de0789201425d9a33d"
+dependencies = [
+ "windows-targets 0.52.6",
+]
+
+[[package]]
+name = "windows-sys"
+version = "0.60.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f2f500e4d28234f72040990ec9d39e3a6b950f9f22d3dba18416c35882612bcb"
+dependencies = [
+ "windows-targets 0.53.5",
+]
+
+[[package]]
+name = "windows-sys"
+version = "0.61.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ae137229bcbd6cdf0f7b80a31df61766145077ddf49416a728b02cb3921ff3fc"
+dependencies = [
+ "windows-link",
+]
+
+[[package]]
+name = "windows-targets"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9b724f72796e036ab90c1021d4780d4d3d648aca59e491e6b98e725b84e99973"
+dependencies = [
+ "windows_aarch64_gnullvm 0.52.6",
+ "windows_aarch64_msvc 0.52.6",
+ "windows_i686_gnu 0.52.6",
+ "windows_i686_gnullvm 0.52.6",
+ "windows_i686_msvc 0.52.6",
+ "windows_x86_64_gnu 0.52.6",
+ "windows_x86_64_gnullvm 0.52.6",
+ "windows_x86_64_msvc 0.52.6",
+]
+
+[[package]]
+name = "windows-targets"
+version = "0.53.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4945f9f551b88e0d65f3db0bc25c33b8acea4d9e41163edf90dcd0b19f9069f3"
+dependencies = [
+ "windows-link",
+ "windows_aarch64_gnullvm 0.53.1",
+ "windows_aarch64_msvc 0.53.1",
+ "windows_i686_gnu 0.53.1",
+ "windows_i686_gnullvm 0.53.1",
+ "windows_i686_msvc 0.53.1",
+ "windows_x86_64_gnu 0.53.1",
+ "windows_x86_64_gnullvm 0.53.1",
+ "windows_x86_64_msvc 0.53.1",
+]
+
+[[package]]
+name = "windows_aarch64_gnullvm"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "32a4622180e7a0ec044bb555404c800bc9fd9ec262ec147edd5989ccd0c02cd3"
+
+[[package]]
+name = "windows_aarch64_gnullvm"
+version = "0.53.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a9d8416fa8b42f5c947f8482c43e7d89e73a173cead56d044f6a56104a6d1b53"
+
+[[package]]
+name = "windows_aarch64_msvc"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "09ec2a7bb152e2252b53fa7803150007879548bc709c039df7627cabbd05d469"
+
+[[package]]
+name = "windows_aarch64_msvc"
+version = "0.53.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b9d782e804c2f632e395708e99a94275910eb9100b2114651e04744e9b125006"
+
+[[package]]
+name = "windows_i686_gnu"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8e9b5ad5ab802e97eb8e295ac6720e509ee4c243f69d781394014ebfe8bbfa0b"
+
+[[package]]
+name = "windows_i686_gnu"
+version = "0.53.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "960e6da069d81e09becb0ca57a65220ddff016ff2d6af6a223cf372a506593a3"
+
+[[package]]
+name = "windows_i686_gnullvm"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0eee52d38c090b3caa76c563b86c3a4bd71ef1a819287c19d586d7334ae8ed66"
+
+[[package]]
+name = "windows_i686_gnullvm"
+version = "0.53.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fa7359d10048f68ab8b09fa71c3daccfb0e9b559aed648a8f95469c27057180c"
+
+[[package]]
+name = "windows_i686_msvc"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "240948bc05c5e7c6dabba28bf89d89ffce3e303022809e73deaefe4f6ec56c66"
+
+[[package]]
+name = "windows_i686_msvc"
+version = "0.53.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1e7ac75179f18232fe9c285163565a57ef8d3c89254a30685b57d83a38d326c2"
+
+[[package]]
+name = "windows_x86_64_gnu"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "147a5c80aabfbf0c7d901cb5895d1de30ef2907eb21fbbab29ca94c5b08b1a78"
+
+[[package]]
+name = "windows_x86_64_gnu"
+version = "0.53.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9c3842cdd74a865a8066ab39c8a7a473c0778a3f29370b5fd6b4b9aa7df4a499"
+
+[[package]]
+name = "windows_x86_64_gnullvm"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "24d5b23dc417412679681396f2b49f3de8c1473deb516bd34410872eff51ed0d"
+
+[[package]]
+name = "windows_x86_64_gnullvm"
+version = "0.53.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0ffa179e2d07eee8ad8f57493436566c7cc30ac536a3379fdf008f47f6bb7ae1"
+
+[[package]]
+name = "windows_x86_64_msvc"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "589f6da84c646204747d1270a2a5661ea66ed1cced2631d546fdfb155959f9ec"
+
+[[package]]
+name = "windows_x86_64_msvc"
+version = "0.53.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d6bbff5f0aada427a1e5a6da5f1f98158182f26556f345ac9e04d36d0ebed650"
+
+[[package]]
+name = "winnow"
+version = "0.7.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "df79d97927682d2fd8adb29682d1140b343be4ac0f08fd68b7765d9c059d3945"
+dependencies = [
+ "memchr",
+]
+
+[[package]]
+name = "wit-bindgen"
+version = "0.51.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d7249219f66ced02969388cf2bb044a09756a083d0fab1e566056b04d9fbcaa5"
+dependencies = [
+ "wit-bindgen-rust-macro",
+]
+
+[[package]]
+name = "wit-bindgen"
+version = "0.57.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1ebf944e87a7c253233ad6766e082e3cd714b5d03812acc24c318f549614536e"
+
+[[package]]
+name = "wit-bindgen-core"
+version = "0.51.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ea61de684c3ea68cb082b7a88508a8b27fcc8b797d738bfc99a82facf1d752dc"
+dependencies = [
+ "anyhow",
+ "heck",
+ "wit-parser",
+]
+
+[[package]]
+name = "wit-bindgen-rust"
+version = "0.51.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b7c566e0f4b284dd6561c786d9cb0142da491f46a9fbed79ea69cdad5db17f21"
+dependencies = [
+ "anyhow",
+ "heck",
+ "indexmap",
+ "prettyplease",
+ "syn",
+ "wasm-metadata",
+ "wit-bindgen-core",
+ "wit-component",
+]
+
+[[package]]
+name = "wit-bindgen-rust-macro"
+version = "0.51.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0c0f9bfd77e6a48eccf51359e3ae77140a7f50b1e2ebfe62422d8afdaffab17a"
+dependencies = [
+ "anyhow",
+ "prettyplease",
+ "proc-macro2",
+ "quote",
+ "syn",
+ "wit-bindgen-core",
+ "wit-bindgen-rust",
+]
+
+[[package]]
+name = "wit-component"
+version = "0.244.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9d66ea20e9553b30172b5e831994e35fbde2d165325bec84fc43dbf6f4eb9cb2"
+dependencies = [
+ "anyhow",
+ "bitflags",
+ "indexmap",
+ "log",
+ "serde",
+ "serde_derive",
+ "serde_json",
+ "wasm-encoder",
+ "wasm-metadata",
+ "wasmparser",
+ "wit-parser",
+]
+
+[[package]]
+name = "wit-parser"
+version = "0.244.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ecc8ac4bc1dc3381b7f59c34f00b67e18f910c2c0f50015669dde7def656a736"
+dependencies = [
+ "anyhow",
+ "id-arena",
+ "indexmap",
+ "log",
+ "semver",
+ "serde",
+ "serde_derive",
+ "serde_json",
+ "unicode-xid",
+ "wasmparser",
+]
+
+[[package]]
+name = "writeable"
+version = "0.6.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1ffae5123b2d3fc086436f8834ae3ab053a283cfac8fe0a0b8eaae044768a4c4"
+
+[[package]]
+name = "yoke"
+version = "0.8.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "abe8c5fda708d9ca3df187cae8bfb9ceda00dd96231bed36e445a1a48e66f9ca"
+dependencies = [
+ "stable_deref_trait",
+ "yoke-derive",
+ "zerofrom",
+]
+
+[[package]]
+name = "yoke-derive"
+version = "0.8.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "de844c262c8848816172cef550288e7dc6c7b7814b4ee56b3e1553f275f1858e"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+ "synstructure",
+]
+
+[[package]]
+name = "zerocopy"
+version = "0.8.48"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "eed437bf9d6692032087e337407a86f04cd8d6a16a37199ed57949d415bd68e9"
+dependencies = [
+ "zerocopy-derive",
+]
+
+[[package]]
+name = "zerocopy-derive"
+version = "0.8.48"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "70e3cd084b1788766f53af483dd21f93881ff30d7320490ec3ef7526d203bad4"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "zerofrom"
+version = "0.1.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0ec05a11813ea801ff6d75110ad09cd0824ddba17dfe17128ea0d5f68e6c5272"
+dependencies = [
+ "zerofrom-derive",
+]
+
+[[package]]
+name = "zerofrom-derive"
+version = "0.1.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "11532158c46691caf0f2593ea8358fed6bbf68a0315e80aae9bd41fbade684a1"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+ "synstructure",
+]
+
+[[package]]
+name = "zeroize"
+version = "1.8.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b97154e67e32c85465826e8bcc1c59429aaaf107c1e4a9e53c8d8ccd5eff88d0"
+
+[[package]]
+name = "zerotrie"
+version = "0.2.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0f9152d31db0792fa83f70fb2f83148effb5c1f5b8c7686c3459e361d9bc20bf"
+dependencies = [
+ "displaydoc",
+ "yoke",
+ "zerofrom",
+]
+
+[[package]]
+name = "zerovec"
+version = "0.11.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "90f911cbc359ab6af17377d242225f4d75119aec87ea711a880987b18cd7b239"
+dependencies = [
+ "yoke",
+ "zerofrom",
+ "zerovec-derive",
+]
+
+[[package]]
+name = "zerovec-derive"
+version = "0.11.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "625dc425cab0dca6dc3c3319506e6593dcb08a9f387ea3b284dbd52a92c40555"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "zmij"
+version = "1.0.21"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b8848ee67ecc8aedbaf3e4122217aff892639231befc6a1b58d29fff4c2cabaa"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -32,6 +32,32 @@ keywords = ["framework", "rust", "backend", "anti-gravital"]
 categories = ["web-programming", "asynchronous"]
 publish = false
 
+# Dependencias compartidas del workspace.
+# Cada nueva dependencia exige RFC; el set inicial corresponde a RFC-0002
+# (diseno del Shield MVP). Los crates internos las referencian con
+# `dep = { workspace = true }`.
+[workspace.dependencies]
+axum = { version = "0.7", default-features = false, features = ["http1", "http2", "tokio", "json", "matched-path"] }
+bytes = "1"
+http = "1"
+http-body-util = "0.1"
+hyper = { version = "1.4", features = ["http1", "http2"] }
+hyper-util = { version = "0.1", features = ["tokio", "server", "server-graceful", "http1", "http2"] }
+pin-project-lite = "0.2"
+serde = { version = "1", features = ["derive"] }
+serde_json = "1"
+thiserror = "1"
+tokio = { version = "1.40", features = ["rt-multi-thread", "macros", "net", "signal", "time", "sync"] }
+toml = "0.8"
+tower = { version = "0.5", features = ["util"] }
+tower-http = { version = "0.6", features = ["trace", "request-id", "util"] }
+tracing = "0.1"
+tracing-subscriber = { version = "0.3", features = ["env-filter", "fmt", "json"] }
+
+# Dev-dependencies compartidas.
+reqwest = { version = "0.12", default-features = false, features = ["rustls-tls", "json"] }
+tokio-test = "0.4"
+
 [workspace.lints.rust]
 # Cada bloque `unsafe` exige justificacion via RFC; por defecto se rechaza.
 # Para sobreescribir en un crate concreto, anada un `#[allow(unsafe_code)]`

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -23,21 +23,21 @@ matriz de soporte por release.
 
 Reporte privado y coordinado. NO abra un issue publico.
 
-Mientras los canales oficiales de la organizacion estan en proceso de
-habilitacion, los reportes se envian al mantenedor inicial a traves
-del mecanismo de divulgacion privada de GitHub Security Advisories del
-repositorio:
+Reporte por orden de preferencia:
 
 1. Abra una nueva advisory privada en la pestana Security del
    repositorio.
-2. Describa: version o commit afectado, plataforma, pasos de
+2. Si no puede usar GitHub Security Advisories, envie el reporte por
+   correo:
+   - Primario: `anti@gravitalcloud.com`.
+   - Respaldo (BDFL inicial): `angelnereira@gravitalcloud.com`.
+3. Describa: version o commit afectado, plataforma, pasos de
    reproduccion, impacto observado o estimado.
-3. Si dispone de un parche, adjuntelo.
+4. Si dispone de un parche, adjuntelo.
 
-Direccion de correo de respaldo: `security@gravital.io`. Esta
-direccion aparece como pendiente de habilitacion en
-`docs/governance/external-deliverables.md`. Mientras no este activa,
-la divulgacion privada de GitHub es la via primaria.
+No abra issues publicos para vulnerabilidades. Vease tambien
+`docs/governance/external-deliverables.md` para el estado de los
+canales operativos.
 
 ## SLA inicial
 

--- a/crates/ag-core/Cargo.toml
+++ b/crates/ag-core/Cargo.toml
@@ -16,3 +16,40 @@ publish = false
 
 [lints]
 workspace = true
+
+# Features de Fase 1.
+# Cada feature aisla una capa Shield. Vease RFC-0002 seccion 4.3.
+# Las capas TLS, JWT y rate-limit llegan en PRs posteriores y por ahora
+# las features simplemente reservan los nombres y compilan vacias.
+[features]
+default = ["validation", "cors", "csrf", "logging", "rate-limit"]
+tls = []
+auth-jwt = []
+rate-limit = []
+validation = []
+cors = []
+csrf = []
+logging = []
+
+[dependencies]
+axum = { workspace = true }
+bytes = { workspace = true }
+http = { workspace = true }
+http-body-util = { workspace = true }
+hyper = { workspace = true }
+hyper-util = { workspace = true }
+pin-project-lite = { workspace = true }
+serde = { workspace = true }
+serde_json = { workspace = true }
+thiserror = { workspace = true }
+tokio = { workspace = true }
+toml = { workspace = true }
+tower = { workspace = true }
+tower-http = { workspace = true }
+tracing = { workspace = true }
+tracing-subscriber = { workspace = true }
+
+[dev-dependencies]
+reqwest = { workspace = true }
+tokio = { workspace = true, features = ["test-util"] }
+tokio-test = { workspace = true }

--- a/crates/ag-core/README.md
+++ b/crates/ag-core/README.md
@@ -1,24 +1,59 @@
 # ag-core
 
-> Estado: Fase 0 - Vacio. La implementacion comienza en Fase 1 (Shield MVP) y Fase 2 (Core MVP).
+> Estado: Fase 1 en curso. Bootstrap del Shield publicado.
 > Criticidad: Nucleo.
 > Capitulo de arquitectura: docs/architecture/06-nucleo-shield-y-core.md
+> RFC vigente: docs/rfc/RFC-0002-diseno-shield-mvp.md
 
 ## Dominio
 
-Runtime HTTP de alto rendimiento. Combina la capa Shield (Tower middleware con TLS 1.3, autenticacion JWT Ed25519, rate limiting, validacion, CORS, CSRF, RBAC) y la capa Core (router Axum con extractores tipados, sistema de errores y estado compartido). Es la unica dependencia obligatoria del ecosistema.
+Runtime HTTP de alto rendimiento. Combina la capa Shield (pipeline
+Tower de middleware) con la capa Core (router Axum con extractores
+tipados, sistema de errores y estado compartido). Es la unica
+dependencia obligatoria del ecosistema Anti-Gravital.
+
+## Estado del bootstrap
+
+Lo que ya esta:
+
+- Crate compilando con dependencias declaradas (axum, tokio, tower,
+  tower-http, tracing, serde, thiserror).
+- Modulos `error`, `config`, `runtime`, `shield`, `core` con esqueleto
+  estable.
+- Capa Shield con logging estructurado (primera capa de la pipeline).
+- Soporte HTTP/1.1 y HTTP/2 via Axum + Tokio (sin TLS).
+- Tipos `AgError` y `AgResult` con mapeo automatico a respuestas HTTP.
+- `ShieldConfig` deserializable desde TOML.
+- Tests unitarios por modulo y tests E2E con servidor real.
+
+Lo que falta de Fase 1 (en PRs posteriores):
+
+- Capa de validacion de payload.
+- Capa CORS.
+- Capa CSRF.
+- Capa de rate limiting con governor.
+- Capa de autenticacion JWT Ed25519.
+- Capa TLS 1.3 con rustls.
+- Configuracion TOML completa.
+- Benchmark Hello World con criterion.
+- Documentacion publicada en docs.rs.
+
+Lo que llega en Fase 2:
+
+- Router Core con extractores tipados.
+- Sistema de respuestas JSON, plaintext, streams.
+- Integracion con `ag-data`.
 
 ## Referencias
 
-- Documento maestro de arquitectura: `docs/master/ANTI-GRAVITAL-Arquitectura-Tecnica.md`.
-- Capitulo navegable: `docs/architecture/06-nucleo-shield-y-core.md`.
-- Hoja de ruta del crate: `docs/modules/ag-core/README.md`.
-- Constitucion tecnica: `CLAUDE.md`.
+- `docs/master/ANTI-GRAVITAL-Arquitectura-Tecnica.md` seccion 6.
+- `docs/architecture/06-nucleo-shield-y-core.md`.
+- `docs/roadmap/fase-01-shield-mvp.md`.
+- `docs/rfc/RFC-0002-diseno-shield-mvp.md`.
 
 ## Reglas aplicables
 
-- Este crate cumple las reglas 14 y 15 de `CLAUDE.md` sobre crates y
-  dependencias.
-- Versionado semantico independiente del resto del workspace una vez
-  publicado.
-- Sin `unsafe` salvo justificacion via RFC bajo `docs/rfc/`.
+- Cumple reglas 14 y 15 de `CLAUDE.md` (crates y dependencias).
+- `ag-core` no depende de ningun crate Anti-Gravital.
+- Versionado semantico independiente del resto del workspace.
+- Sin `unsafe`. Vease `unsafe_code = "deny"` en `Cargo.toml` raiz.

--- a/crates/ag-core/src/config/mod.rs
+++ b/crates/ag-core/src/config/mod.rs
@@ -1,0 +1,105 @@
+//! Configuracion publica del Shield.
+//!
+//! La configuracion se deserializa desde un archivo TOML descrito en
+//! `docs/rfc/RFC-0002-diseno-shield-mvp.md` seccion 4.5. Esta version
+//! cubre los campos minimos del bootstrap; el resto de campos llegan
+//! con sus respectivas capas.
+
+use std::net::SocketAddr;
+
+use serde::{Deserialize, Serialize};
+
+use crate::error::{AgError, AgResult};
+
+/// Configuracion completa del Shield.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct ShieldConfig {
+    /// Direccion de escucha.
+    #[serde(default = "default_bind_addr")]
+    pub bind: SocketAddr,
+
+    /// Configuracion del runtime Tokio.
+    #[serde(default)]
+    pub runtime: RuntimeConfig,
+}
+
+impl Default for ShieldConfig {
+    fn default() -> Self {
+        Self {
+            bind: default_bind_addr(),
+            runtime: RuntimeConfig::default(),
+        }
+    }
+}
+
+impl ShieldConfig {
+    /// Carga la configuracion desde una cadena TOML.
+    ///
+    /// # Errores
+    ///
+    /// Devuelve `AgError::Config` si el TOML no parsea o contiene claves
+    /// desconocidas.
+    pub fn from_toml_str(toml_text: &str) -> AgResult<Self> {
+        toml::from_str(toml_text).map_err(|e| AgError::Config(e.to_string()))
+    }
+}
+
+/// Configuracion del runtime Tokio.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct RuntimeConfig {
+    /// Numero de workers. `None` significa uno por CPU disponible.
+    #[serde(default)]
+    pub workers: Option<usize>,
+
+    /// Maximo de threads bloqueantes.
+    #[serde(default = "default_blocking_threads")]
+    pub blocking_threads: usize,
+}
+
+impl Default for RuntimeConfig {
+    fn default() -> Self {
+        Self {
+            workers: None,
+            blocking_threads: default_blocking_threads(),
+        }
+    }
+}
+
+fn default_bind_addr() -> SocketAddr {
+    SocketAddr::from(([0, 0, 0, 0], 8080))
+}
+
+const fn default_blocking_threads() -> usize {
+    512
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn default_bind_is_0_0_0_0_8080() {
+        let config = ShieldConfig::default();
+        assert_eq!(config.bind.port(), 8080);
+        assert!(config.bind.ip().is_unspecified());
+    }
+
+    #[test]
+    fn from_toml_parses_minimal() {
+        let cfg = ShieldConfig::from_toml_str(r#"bind = "127.0.0.1:9090""#).unwrap();
+        assert_eq!(cfg.bind.port(), 9090);
+    }
+
+    #[test]
+    fn from_toml_rejects_invalid() {
+        let err = ShieldConfig::from_toml_str("not valid toml [").unwrap_err();
+        assert_eq!(err.code(), "config_error");
+    }
+
+    #[test]
+    fn runtime_default_blocking_threads() {
+        let rt = RuntimeConfig::default();
+        assert_eq!(rt.blocking_threads, 512);
+        assert!(rt.workers.is_none());
+    }
+}

--- a/crates/ag-core/src/core/mod.rs
+++ b/crates/ag-core/src/core/mod.rs
@@ -1,0 +1,25 @@
+//! Capa Core: router, extractores tipados y estado compartido.
+//!
+//! Fase 1 deja este modulo como placeholder estable: solo expone el
+//! tipo `AppState` minimo. La implementacion completa (router con
+//! extractores `State<T>`, `ValidatedBody<T>`, `Claims<T>`, `Path<T>`,
+//! `Query<T>`, sistema de respuestas JSON/plaintext/streams) llega en
+//! Fase 2 segun la Hoja de Ruta.
+//!
+//! La separacion logica Shield/Core descrita en el capitulo 6 del
+//! maestro de arquitectura se respeta desde el bootstrap.
+
+/// Estado compartido por defecto. Los proyectos lo extienden con sus
+/// clientes a base de datos, caches y servicios externos.
+#[derive(Debug, Default, Clone)]
+pub struct AppState;
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn app_state_default_is_constructible() {
+        let _state = AppState;
+    }
+}

--- a/crates/ag-core/src/error.rs
+++ b/crates/ag-core/src/error.rs
@@ -1,0 +1,127 @@
+//! Sistema de errores del nucleo.
+//!
+//! `AgError` enumera las clases de error que la pipeline Shield puede
+//! producir. Cada variante mapea a una respuesta HTTP estable con un
+//! codigo `snake_case` en el cuerpo JSON. La conversion a
+//! `axum::response::Response` es automatica via `IntoResponse`.
+
+use axum::http::StatusCode;
+use axum::response::{IntoResponse, Response};
+use axum::Json;
+use serde::Serialize;
+use thiserror::Error;
+
+/// Resultado estandar del nucleo.
+pub type AgResult<T> = Result<T, AgError>;
+
+/// Errores producidos por el nucleo y por la pipeline Shield.
+#[derive(Debug, Error)]
+pub enum AgError {
+    /// Error de carga o validacion de la configuracion.
+    #[error("config error: {0}")]
+    Config(String),
+
+    /// Error de capa TLS.
+    #[error("tls error: {0}")]
+    Tls(String),
+
+    /// Error de autenticacion.
+    #[error("auth error: {0}")]
+    Auth(String),
+
+    /// Limite de tasa excedido.
+    #[error("rate limit exceeded")]
+    RateLimit,
+
+    /// Error de validacion de payload.
+    #[error("validation error: {0}")]
+    Validation(String),
+
+    /// Error de CORS.
+    #[error("cors error: {0}")]
+    Cors(String),
+
+    /// Error de CSRF.
+    #[error("csrf error: {0}")]
+    Csrf(String),
+
+    /// Error de I/O.
+    #[error("io error: {0}")]
+    Io(#[from] std::io::Error),
+
+    /// Cualquier otro error no clasificado.
+    #[error("internal error: {0}")]
+    Other(String),
+}
+
+impl AgError {
+    /// Codigo estable `snake_case` para serializacion publica.
+    #[must_use]
+    pub fn code(&self) -> &'static str {
+        match self {
+            Self::Config(_) => "config_error",
+            Self::Tls(_) => "tls_error",
+            Self::Auth(_) => "auth_error",
+            Self::RateLimit => "rate_limit_exceeded",
+            Self::Validation(_) => "validation_error",
+            Self::Cors(_) => "cors_error",
+            Self::Csrf(_) => "csrf_error",
+            Self::Io(_) => "io_error",
+            Self::Other(_) => "internal_error",
+        }
+    }
+
+    /// Codigo HTTP correspondiente a la variante.
+    #[must_use]
+    pub fn status(&self) -> StatusCode {
+        match self {
+            Self::Config(_) | Self::Tls(_) => StatusCode::INTERNAL_SERVER_ERROR,
+            Self::Auth(_) => StatusCode::UNAUTHORIZED,
+            Self::RateLimit => StatusCode::TOO_MANY_REQUESTS,
+            Self::Validation(_) => StatusCode::UNPROCESSABLE_ENTITY,
+            Self::Cors(_) | Self::Csrf(_) => StatusCode::FORBIDDEN,
+            Self::Io(_) | Self::Other(_) => StatusCode::INTERNAL_SERVER_ERROR,
+        }
+    }
+}
+
+#[derive(Serialize)]
+struct ErrorBody<'a> {
+    code: &'a str,
+    message: String,
+}
+
+impl IntoResponse for AgError {
+    fn into_response(self) -> Response {
+        let body = ErrorBody {
+            code: self.code(),
+            message: self.to_string(),
+        };
+        (self.status(), Json(body)).into_response()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn rate_limit_maps_to_429() {
+        let err = AgError::RateLimit;
+        assert_eq!(err.status(), StatusCode::TOO_MANY_REQUESTS);
+        assert_eq!(err.code(), "rate_limit_exceeded");
+    }
+
+    #[test]
+    fn validation_maps_to_422() {
+        let err = AgError::Validation("bad field".into());
+        assert_eq!(err.status(), StatusCode::UNPROCESSABLE_ENTITY);
+        assert_eq!(err.code(), "validation_error");
+    }
+
+    #[test]
+    fn auth_maps_to_401() {
+        let err = AgError::Auth("missing token".into());
+        assert_eq!(err.status(), StatusCode::UNAUTHORIZED);
+    }
+}

--- a/crates/ag-core/src/lib.rs
+++ b/crates/ag-core/src/lib.rs
@@ -1,5 +1,37 @@
 //! Nucleo de Anti-Gravital: Shield, Core, runtime Tokio y extractores tipados.
 //!
-//! Estado: Fase 0 (Fundaciones y Gobernanza). Este crate aun no contiene
-//! codigo funcional. La implementacion se entrega en la fase declarada
-//! en el README del crate y en la Hoja de Ruta del proyecto.
+//! Fase 1 (en curso): bootstrap del Shield. La pipeline Tower del Shield
+//! se construye capa por capa en PRs incrementales descritos en
+//! `docs/rfc/RFC-0002-diseno-shield-mvp.md`. Este crate ya compila y
+//! expone una API publica minima que sirve HTTP/1.1 y HTTP/2 sobre
+//! Axum + Tokio sin TLS, suficiente para el ejemplo Hello World.
+//!
+//! # Ejemplo
+//!
+//! ```no_run
+//! use ag_core::{Shield, ShieldConfig};
+//!
+//! # async fn run() -> Result<(), ag_core::AgError> {
+//! let config = ShieldConfig::default();
+//! let shield = Shield::new(config);
+//! let app = axum::Router::new()
+//!     .route("/", axum::routing::get(|| async { "hello, shield" }))
+//!     .layer(shield.layer());
+//!
+//! let listener = tokio::net::TcpListener::bind("127.0.0.1:0").await?;
+//! axum::serve(listener, app).await?;
+//! # Ok(())
+//! # }
+//! ```
+
+#![deny(missing_docs)]
+
+pub mod config;
+pub mod core;
+pub mod error;
+pub mod runtime;
+pub mod shield;
+
+pub use crate::config::ShieldConfig;
+pub use crate::error::{AgError, AgResult};
+pub use crate::shield::Shield;

--- a/crates/ag-core/src/runtime/mod.rs
+++ b/crates/ag-core/src/runtime/mod.rs
@@ -1,0 +1,49 @@
+//! Construccion del runtime Tokio para Anti-Gravital.
+//!
+//! Lee la configuracion declarativa de `crate::config::RuntimeConfig`
+//! y construye un `tokio::runtime::Runtime` multi-thread con los
+//! parametros indicados. Los valores por defecto vienen del maestro
+//! de arquitectura seccion 6.5.
+
+use crate::config::RuntimeConfig;
+use crate::error::{AgError, AgResult};
+
+/// Construye un runtime Tokio multi-thread segun la configuracion.
+///
+/// # Errores
+///
+/// Devuelve `AgError::Other` si la construccion del runtime falla.
+pub fn build(config: &RuntimeConfig) -> AgResult<tokio::runtime::Runtime> {
+    let mut builder = tokio::runtime::Builder::new_multi_thread();
+    builder.enable_all();
+    if let Some(workers) = config.workers {
+        builder.worker_threads(workers);
+    }
+    builder.max_blocking_threads(config.blocking_threads);
+    builder
+        .build()
+        .map_err(|e| AgError::Other(format!("failed to build tokio runtime: {e}")))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn builds_runtime_with_defaults() {
+        let rt = build(&RuntimeConfig::default()).unwrap();
+        let result = rt.block_on(async { 1 + 1 });
+        assert_eq!(result, 2);
+    }
+
+    #[test]
+    fn builds_runtime_with_two_workers() {
+        let cfg = RuntimeConfig {
+            workers: Some(2),
+            blocking_threads: 16,
+        };
+        let rt = build(&cfg).unwrap();
+        let result = rt.block_on(async { "ok" });
+        assert_eq!(result, "ok");
+    }
+}

--- a/crates/ag-core/src/shield/logging.rs
+++ b/crates/ag-core/src/shield/logging.rs
@@ -1,0 +1,105 @@
+//! Capa de logging estructurado para la pipeline Shield.
+//!
+//! Emite un evento `tracing` por cada request entrante con metodo,
+//! path y latencia total. Esta es la primera capa de la pipeline en
+//! orden de adicion porque otras capas se beneficiarian del
+//! contexto de tracing aunque fallen.
+
+use std::future::Future;
+use std::pin::Pin;
+use std::task::{Context, Poll};
+use std::time::Instant;
+
+use axum::extract::Request;
+use axum::response::Response;
+use pin_project_lite::pin_project;
+use tower::{Layer, Service};
+
+/// Layer Tower que envuelve un servicio con logging estructurado.
+#[derive(Debug, Clone, Copy, Default)]
+pub struct LoggingLayer;
+
+impl<S> Layer<S> for LoggingLayer {
+    type Service = LoggingService<S>;
+
+    fn layer(&self, inner: S) -> Self::Service {
+        LoggingService { inner }
+    }
+}
+
+/// Servicio que registra cada request con `tracing`.
+#[derive(Debug, Clone)]
+pub struct LoggingService<S> {
+    inner: S,
+}
+
+impl<S> Service<Request> for LoggingService<S>
+where
+    S: Service<Request, Response = Response> + Clone + Send + 'static,
+    S::Future: Send + 'static,
+{
+    type Response = S::Response;
+    type Error = S::Error;
+    type Future = LoggingFuture<S::Future>;
+
+    fn poll_ready(&mut self, cx: &mut Context<'_>) -> Poll<Result<(), Self::Error>> {
+        self.inner.poll_ready(cx)
+    }
+
+    fn call(&mut self, req: Request) -> Self::Future {
+        let method = req.method().clone();
+        let uri = req.uri().clone();
+        let start = Instant::now();
+        LoggingFuture {
+            inner: self.inner.call(req),
+            method,
+            uri,
+            start,
+        }
+    }
+}
+
+pin_project! {
+    /// Future del servicio de logging.
+    #[derive(Debug)]
+    pub struct LoggingFuture<F> {
+        #[pin]
+        inner: F,
+        method: axum::http::Method,
+        uri: axum::http::Uri,
+        start: Instant,
+    }
+}
+
+impl<F, E> Future for LoggingFuture<F>
+where
+    F: Future<Output = Result<Response, E>>,
+{
+    type Output = Result<Response, E>;
+
+    fn poll(self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Self::Output> {
+        let this = self.project();
+        match this.inner.poll(cx) {
+            Poll::Pending => Poll::Pending,
+            Poll::Ready(result) => {
+                let elapsed_ms = this.start.elapsed().as_secs_f64() * 1000.0;
+                match &result {
+                    Ok(resp) => tracing::info!(
+                        method = %this.method,
+                        path = %this.uri.path(),
+                        status = resp.status().as_u16(),
+                        latency_ms = elapsed_ms,
+                        "request completed"
+                    ),
+                    Err(_) => tracing::error!(
+                        method = %this.method,
+                        path = %this.uri.path(),
+                        latency_ms = elapsed_ms,
+                        "request errored"
+                    ),
+                }
+                Poll::Ready(result)
+            }
+        }
+    }
+}

--- a/crates/ag-core/src/shield/mod.rs
+++ b/crates/ag-core/src/shield/mod.rs
@@ -1,0 +1,67 @@
+//! Capa Shield: pipeline Tower de middleware que protege el Core.
+//!
+//! En el bootstrap de Fase 1 (este PR) la pipeline solo aplica la
+//! capa de logging estructurado. Las capas restantes (TLS, JWT, rate
+//! limiting, validacion, CORS, CSRF) se anaden capa por capa en PRs
+//! posteriores. Vease `docs/rfc/RFC-0002-diseno-shield-mvp.md`.
+
+use tower::layer::util::{Identity, Stack};
+use tower::ServiceBuilder;
+
+use crate::config::ShieldConfig;
+
+mod logging;
+
+/// Pipeline Shield configurable.
+#[derive(Debug, Clone)]
+pub struct Shield {
+    config: ShieldConfig,
+}
+
+impl Shield {
+    /// Construye un Shield desde la configuracion declarativa.
+    #[must_use]
+    pub fn new(config: ShieldConfig) -> Self {
+        Self { config }
+    }
+
+    /// Construye un Shield con la configuracion por defecto.
+    #[must_use]
+    pub fn with_defaults() -> Self {
+        Self::new(ShieldConfig::default())
+    }
+
+    /// Devuelve la configuracion en uso.
+    #[must_use]
+    pub fn config(&self) -> &ShieldConfig {
+        &self.config
+    }
+
+    /// Devuelve la capa Tower que se compone con un router Axum.
+    ///
+    /// La capa actual incluye unicamente logging estructurado. Las
+    /// siguientes capas se agregaran en orden definido por RFC-0002.
+    #[must_use]
+    pub fn layer(&self) -> Stack<logging::LoggingLayer, Identity> {
+        ServiceBuilder::new()
+            .layer(logging::LoggingLayer)
+            .into_inner()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn shield_defaults_uses_default_config() {
+        let shield = Shield::with_defaults();
+        assert_eq!(shield.config().bind.port(), 8080);
+    }
+
+    #[test]
+    fn shield_layer_is_constructible() {
+        let shield = Shield::with_defaults();
+        let _layer = shield.layer();
+    }
+}

--- a/crates/ag-core/tests/shield_e2e.rs
+++ b/crates/ag-core/tests/shield_e2e.rs
@@ -1,0 +1,52 @@
+//! Tests end-to-end del bootstrap del Shield.
+//!
+//! Arrancan un servidor real sobre `127.0.0.1:0` (puerto efimero) y
+//! validan que la pipeline acepta peticiones HTTP/1.1 y produce
+//! respuestas esperadas.
+
+use ag_core::{Shield, ShieldConfig};
+use axum::routing::get;
+use axum::Router;
+use std::net::SocketAddr;
+
+async fn start_server() -> (SocketAddr, tokio::task::JoinHandle<()>) {
+    let shield = Shield::new(ShieldConfig::default());
+    let app = Router::new()
+        .route("/hello", get(|| async { "hello, shield" }))
+        .layer(shield.layer());
+
+    let listener = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
+    let addr = listener.local_addr().unwrap();
+    let handle = tokio::spawn(async move {
+        axum::serve(listener, app.into_make_service())
+            .await
+            .unwrap();
+    });
+    (addr, handle)
+}
+
+#[tokio::test]
+async fn hello_endpoint_responds_200_with_body() {
+    let (addr, handle) = start_server().await;
+    let url = format!("http://{addr}/hello");
+
+    let client = reqwest::Client::builder().build().unwrap();
+    let resp = client.get(&url).send().await.unwrap();
+    assert_eq!(resp.status(), reqwest::StatusCode::OK);
+    let body = resp.text().await.unwrap();
+    assert_eq!(body, "hello, shield");
+
+    handle.abort();
+}
+
+#[tokio::test]
+async fn missing_route_responds_404() {
+    let (addr, handle) = start_server().await;
+    let url = format!("http://{addr}/no-such-route");
+
+    let client = reqwest::Client::builder().build().unwrap();
+    let resp = client.get(&url).send().await.unwrap();
+    assert_eq!(resp.status(), reqwest::StatusCode::NOT_FOUND);
+
+    handle.abort();
+}

--- a/docs/adr/0005-contact-identities.md
+++ b/docs/adr/0005-contact-identities.md
@@ -1,0 +1,87 @@
+# ADR-0005 - Identidades de contacto oficiales del proyecto
+
+- Estado: aceptado
+- Fecha: 2026-05-19
+- RFC origen: ninguna; autorizacion verbal del BDFL inicial registrada
+  en la conversacion de setup de Fase 0. Esta ADR sirve como registro
+  formal del cambio.
+
+## Contexto
+
+Los maestros instalados en `docs/master/` usaban placeholders para los
+correos institucionales del proyecto: `security@gravital.io` y
+`hello@antigravital.dev`. Estos correos no existen ni estaban
+asignados. La regla del repositorio dice que los maestros no se editan
+sin RFC, pero tambien dice que los placeholders se reconcilian contra
+la realidad cuando la realidad esta disponible.
+
+Durante el setup de Fase 0, el BDFL inicial (Angel Nereira) declaro
+los correos oficiales y autorizo el reemplazo de los placeholders en
+los maestros y en los archivos operativos.
+
+## Decision
+
+Las identidades de contacto oficiales del proyecto Anti-Gravital son:
+
+- Correo raiz del proyecto: `anti@gravitalcloud.com`.
+- Mantenedor inicial (BDFL): Angel Nereira, primario
+  `angelnereira@gravitalcloud.com`, alternativo
+  `contact@angelnereira.com`.
+
+Aplicacion concreta:
+
+1. Contacto general del proyecto y reportes de conducta:
+   `anti@gravitalcloud.com`.
+2. Reportes de seguridad: GitHub Security Advisories primero;
+   `anti@gravitalcloud.com` como primario por correo;
+   `angelnereira@gravitalcloud.com` como respaldo.
+3. Escalado al BDFL: `angelnereira@gravitalcloud.com`.
+
+Se actualizan:
+
+- `docs/master/ANTI-GRAVITAL-Arquitectura-Tecnica.md` seccion 15.3.
+- `docs/master/ANTI-GRAVITAL-Hoja-de-Ruta.md` entregables de Fase 0.
+- `docs/master/VERSION.md` con nuevos hashes SHA-256 y entrada de
+  historial.
+- `SECURITY.md`, `CODE_OF_CONDUCT.md`, `docs/governance/external-deliverables.md`,
+  `docs/roadmap/STATUS.md`.
+- Workflow `.github/workflows/docs.yml` con los nuevos hashes
+  esperados.
+- Derivados verbatim regenerados via `tools/split-masters.sh` y
+  `tools/scaffold-docs.sh`.
+
+## Consecuencias
+
+Positivas:
+
+- Los canales de contacto del proyecto pasan de aspiracionales a
+  reales. Cualquier persona puede reportar seguridad o conducta de
+  inmediato.
+- Las casillas correspondientes de `docs/roadmap/STATUS.md` se
+  marcan como completadas.
+- Reduce ambiguedad sobre quien recibe los reportes.
+
+Negativas:
+
+- Los dominios `gravital.io` y `antigravital.dev` que aparecian en los
+  placeholders quedan sin uso. Se mantiene la opcion de registrarlos
+  como redirecciones a `gravitalcloud.com` si el proyecto los
+  considera estrategicos en el futuro.
+- El historial git refleja el cambio sobre los maestros; eso es
+  deseable para auditabilidad.
+
+## Alternativas consideradas
+
+- Mantener los placeholders en los maestros y reflejar la realidad
+  solo en los archivos operativos: rechazado porque crearia
+  divergencia entre la fuente de verdad y la operacion real.
+- Abrir RFC formal completa: rechazado por desproporcion; se trata de
+  un reemplazo factual de placeholders por valores concretos, sin
+  cambio arquitectonico.
+
+## Notas
+
+- Cualquier futuro cambio en estas identidades debera repetir el
+  procedimiento: actualizar maestros, recomputar hashes en
+  `docs/master/VERSION.md`, regenerar derivados y dejar registro en un
+  nuevo ADR.

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -28,3 +28,4 @@ Consecuencias, Alternativas, Estado.
 | 0002 | Documentacion bilingue espanol e ingles | aceptado | `0002-bilingual-documentation.md` |
 | 0003 | Modelo de gobernanza BDFL inicial con transicion a comite | aceptado | `0003-bdfl-governance.md` |
 | 0004 | Descomposicion verbatim de los documentos maestros | aceptado | `0004-descomposicion-de-maestros.md` |
+| 0005 | Identidades de contacto oficiales del proyecto | aceptado | `0005-contact-identities.md` |

--- a/docs/architecture/15-seguridad.md
+++ b/docs/architecture/15-seguridad.md
@@ -21,7 +21,7 @@ Las primitivas criptográficas se importan del crate `ring`, mantenido por miemb
 
 ### 15.3 Política de divulgación responsable
 
-El repositorio mantiene un archivo `SECURITY.md` con una dirección de contacto (`security@gravital.io`) y una política clara: las vulnerabilidades se reportan privadamente, el equipo confirma recepción en 48 horas, publica un parche en 30 días para vulnerabilidades críticas, y un CVE con crédito al reportero.
+El repositorio mantiene un archivo `SECURITY.md` con direcciones de contacto (primario `anti@gravitalcloud.com`, respaldo `angelnereira@gravitalcloud.com`) y una política clara: las vulnerabilidades se reportan privadamente, el equipo confirma recepción en 48 horas, publica un parche en 30 días para vulnerabilidades críticas, y un CVE con crédito al reportero.
 
 ### 15.4 Auditorías
 

--- a/docs/governance/external-deliverables.md
+++ b/docs/governance/external-deliverables.md
@@ -1,11 +1,21 @@
 # Entregables externos pendientes de Fase 0
 
-> Estado a 2026-05-19.
+> Ultima actualizacion: 2026-05-19.
 
 La Fase 0 de la Hoja de Ruta incluye varios entregables que no viven
 en el repositorio sino en servicios externos. Esta tabla los enumera,
 indica su estado actual y senala que puerta de criterio de salida
 desbloquean. Cada item se mantiene aqui hasta que se completa.
+
+## Identidades de contacto oficiales
+
+- Correo raiz del proyecto: `anti@gravitalcloud.com`.
+- Mantenedor inicial (BDFL): Angel Nereira, `angelnereira@gravitalcloud.com`,
+  con alternativo `contact@angelnereira.com`.
+
+Estos correos figuran como contactos primario y de respaldo en
+`SECURITY.md`, `CODE_OF_CONDUCT.md` y en el maestro de Arquitectura
+Tecnica (seccion 15.3).
 
 ## Tabla de entregables
 
@@ -16,9 +26,9 @@ desbloquean. Cada item se mantiene aqui hasta que se completa.
 | Cuenta en X o Bluesky para anuncios | Pendiente | BDFL inicial | Acompana anuncios de releases. |
 | Dominio `antigravital.dev` registrado | Pendiente | Gravital Labs - Operaciones | Apunta a landing page. |
 | Landing page minima en `antigravital.dev` | Pendiente | Gravital Labs - Diseno | Criterio 0.3: describe que es y donde esta en el roadmap. |
-| Email institucional `hello@antigravital.dev` | Pendiente | Gravital Labs - Operaciones | Canal de contacto general. |
-| Email de seguridad `security@gravital.io` | Pendiente | BDFL inicial | Canal en SECURITY.md y CODE_OF_CONDUCT.md. |
-| Email de conducta `conduct@gravital.io` | Pendiente | BDFL inicial | Canal alternativo en CODE_OF_CONDUCT.md. |
+| Email institucional `anti@gravitalcloud.com` (correo raiz del proyecto) | Completado 2026-05-19 | Gravital Labs | Canal de contacto general y de seguridad primario. |
+| Email de respaldo del BDFL `angelnereira@gravitalcloud.com` | Completado 2026-05-19 | Angel Nereira | Canal de seguridad de respaldo y escalado de conducta. |
+| Email del desarrollador (alternativo) `contact@angelnereira.com` | Completado 2026-05-19 | Angel Nereira | Canal personal de contacto del BDFL. |
 | Calendario publico de releases publicado en el sitio | Pendiente | BDFL inicial | Mirror externo del `docs/roadmap/calendar.md`. |
 
 ## Procedimiento de cierre

--- a/docs/master/ANTI-GRAVITAL-Arquitectura-Tecnica.md
+++ b/docs/master/ANTI-GRAVITAL-Arquitectura-Tecnica.md
@@ -928,7 +928,7 @@ Las primitivas criptográficas se importan del crate `ring`, mantenido por miemb
 
 ### 15.3 Política de divulgación responsable
 
-El repositorio mantiene un archivo `SECURITY.md` con una dirección de contacto (`security@gravital.io`) y una política clara: las vulnerabilidades se reportan privadamente, el equipo confirma recepción en 48 horas, publica un parche en 30 días para vulnerabilidades críticas, y un CVE con crédito al reportero.
+El repositorio mantiene un archivo `SECURITY.md` con direcciones de contacto (primario `anti@gravitalcloud.com`, respaldo `angelnereira@gravitalcloud.com`) y una política clara: las vulnerabilidades se reportan privadamente, el equipo confirma recepción en 48 horas, publica un parche en 30 días para vulnerabilidades críticas, y un CVE con crédito al reportero.
 
 ### 15.4 Auditorías
 

--- a/docs/master/ANTI-GRAVITAL-Hoja-de-Ruta.md
+++ b/docs/master/ANTI-GRAVITAL-Hoja-de-Ruta.md
@@ -63,7 +63,7 @@ La regla principal es: **una fase no se da por concluida hasta que todas sus cas
 - [ ] Archivo `README.md` bilingüe (español + inglés) con propuesta de valor.
 - [ ] Archivo `CONTRIBUTING.md` con guía de contribución, convenciones de código, proceso de pull request.
 - [ ] Archivo `CODE_OF_CONDUCT.md` adoptando Contributor Covenant 2.1.
-- [ ] Archivo `SECURITY.md` con política de divulgación responsable y dirección `security@gravital.io`.
+- [ ] Archivo `SECURITY.md` con política de divulgación responsable y dirección `anti@gravitalcloud.com` (respaldo: `angelnereira@gravitalcloud.com`).
 - [ ] Archivo `GOVERNANCE.md` describiendo modelo BDFL inicial y plan de transición.
 - [ ] Configuración de CI con GitHub Actions: build en Linux x86-64, Linux ARM64, macOS ARM64, Windows x64.
 - [ ] Plantillas de issue (bug report, feature request, RFC) y plantilla de pull request.
@@ -71,7 +71,7 @@ La regla principal es: **una fase no se da por concluida hasta que todas sus cas
 - [ ] Discord oficial del proyecto con canales `#español`, `#english`, `#announcements`, `#help`.
 - [ ] Cuenta del proyecto en X/Bluesky para anuncios.
 - [ ] Dominio `antigravital.dev` registrado y apuntando a una landing page mínima.
-- [ ] Email institucional `hello@antigravital.dev` operativo.
+- [ ] Email institucional `anti@gravitalcloud.com` operativo (correo raíz del proyecto).
 - [ ] Calendario público de releases publicado.
 
 ### 0.3 Criterios de salida (puerta antes de Fase 1)

--- a/docs/master/VERSION.md
+++ b/docs/master/VERSION.md
@@ -23,8 +23,15 @@ desde el origen autorizado antes de continuar.
 | Archivo | Tamano (bytes) | SHA-256 |
 | --- | --- | --- |
 | `ANTI-GRAVITAL-Blueprint-v4.0.pdf` | 511945 | `59a1df26bd24e96067c58c142709e3cb55fc33efbb1c8f3739d9473598dfb660` |
-| `ANTI-GRAVITAL-Arquitectura-Tecnica.md` | 88015 | `2b0847522af804df7feeccb3fd64341f1ecf7b34ca6f915db7d775932919304c` |
-| `ANTI-GRAVITAL-Hoja-de-Ruta.md` | 28358 | `d1cb15bc943be6c4e87c33bd59aa6056bb8e580a52a03b1a4306aa636f2ee31e` |
+| `ANTI-GRAVITAL-Arquitectura-Tecnica.md` | 88066 | `c6f16879cd8c4d7772dbe2911043e31cce9196a31f75a235fdd8bcf72afd67ae` |
+| `ANTI-GRAVITAL-Hoja-de-Ruta.md` | 28433 | `534f15ac103cdd45fdca7e91f1c5bd0e3a81527d72c59b0a25eb0425a02a80d4` |
+
+## Historial de revisiones de maestros
+
+| Fecha | Cambio | Origen |
+| --- | --- | --- |
+| 2026-05-19 | Instalacion inicial de los tres maestros v4.0. | Aporte directo de Gravital Labs. |
+| 2026-05-19 | Reemplazo de placeholders de email: `security@gravital.io` y `hello@antigravital.dev` por `anti@gravitalcloud.com` (raiz) con `angelnereira@gravitalcloud.com` como respaldo de seguridad. Registrado en `docs/adr/0005-contact-identities.md`. | Decision del BDFL inicial. |
 
 ## Verificación local
 

--- a/docs/rfc/README.md
+++ b/docs/rfc/README.md
@@ -63,6 +63,7 @@ como `superseded`.
 
 ## Lista de RFC
 
-| Numero | Titulo | Estado |
-| --- | --- | --- |
-| - | (sin RFC activas en Fase 0) | - |
+| Numero | Titulo | Estado | Archivo |
+| --- | --- | --- | --- |
+| 0001 | Paralelizar puertas externas de Fase 0 con implementacion de Fase 1 | aceptado | `RFC-0001-paralelizar-fase-0-externa-y-fase-1.md` |
+| 0002 | Diseno del Shield MVP (Fase 1) | aceptado | `RFC-0002-diseno-shield-mvp.md` |

--- a/docs/rfc/RFC-0001-paralelizar-fase-0-externa-y-fase-1.md
+++ b/docs/rfc/RFC-0001-paralelizar-fase-0-externa-y-fase-1.md
@@ -1,0 +1,137 @@
+# RFC-0001 - Paralelizar puertas externas de Fase 0 con implementacion de Fase 1
+
+- Estado: aceptado
+- Autor: Angel Nereira (BDFL inicial)
+- Fecha de borrador: 2026-05-19
+- Fecha de aceptacion: 2026-05-19
+- Fase objetivo: Fase 0 mas Fase 1
+- Modulos o crates afectados: gobernanza del proceso (sin codigo)
+- RFC predecesora: ninguna
+- Periodo de comentarios: omitido por decision del BDFL en modo solo
+
+## 1. Motivacion
+
+La Hoja de Ruta v4.0 fija dos reglas que se cruzan en este momento:
+
+1. Una fase no se considera concluida hasta que todas sus casillas de
+   criterio de salida estan marcadas (Regla 1 de las Reglas de Oro).
+2. Los criterios de entrada de Fase 1 exigen "Fase 0 completada" y
+   "al menos un contribuidor adicional al mantenedor principal
+   activo".
+
+Estas reglas, aplicadas literalmente, bloquean el proyecto hasta que
+ocurran tres eventos externos (primer star externo, cinco miembros
+externos en Discord, landing page operativa) y aparezca un segundo
+contribuidor. Esos eventos no se pueden forzar desde el repositorio.
+
+La cuestion es si el proyecto detiene toda actividad tecnica hasta que
+esos eventos ocurran, o si paraleliza la espera con trabajo de Fase 1
+asumiendo que las casillas externas se cierran cuando se cierren.
+
+## 2. Problema
+
+Dos riesgos compiten:
+
+- Riesgo de saltarse el proceso: relajar la Regla 1 abre la puerta a
+  futuras justificaciones de saltos arbitrarios. Es el riesgo que las
+  reglas existen para prevenir.
+- Riesgo de paralisis: si el repositorio queda inactivo durante meses
+  esperando un primer star y un segundo contribuidor, el proyecto
+  pierde momentum y los entregables de Fase 1 se acumulan sin avance.
+  La calidad del trabajo cae cuando se hace bajo presion al final.
+
+## 3. Alternativas consideradas
+
+### 3.1 Cumplir literalmente Regla 1
+
+Detener toda actividad tecnica hasta que las tres puertas externas
+cierren y aparezca un segundo contribuidor. Pros: respeta la regla al
+pie de la letra. Contras: bloquea el avance tecnico durante semanas o
+meses por eventos que no controlamos.
+
+### 3.2 Modificar Regla 1 en CLAUDE.md
+
+Reescribir la regla para permitir paralelizacion. Pros: elimina la
+contradiccion. Contras: debilita el contrato general del proyecto;
+abre puerta a futuras laxitudes; es una solucion mayor para un caso
+particular.
+
+### 3.3 Paralelizar como excepcion documentada (esta RFC)
+
+Mantener la Regla 1 vigente. Documentar formalmente que para esta
+ventana especifica del proyecto, la implementacion de Fase 1 avanza en
+paralelo con el cierre de las puertas externas de Fase 0 y sin
+segundo contribuidor. Pros: respeta la regla general; resuelve el
+caso particular sin debilitarla; queda auditado. Contras: requiere
+disciplina para no normalizar la excepcion.
+
+## 4. Diseno propuesto
+
+Se acepta la alternativa 3.3 con los siguientes acuerdos:
+
+1. La implementacion de Fase 1 comienza inmediatamente, dirigida por
+   RFC-0002 (diseno de Shield MVP) que se aprueba conjuntamente con
+   esta RFC.
+2. Las casillas externas de Fase 0 (primer star, cinco miembros en
+   Discord, landing page) permanecen como `[ ]` en
+   `docs/roadmap/STATUS.md` y se completan en paralelo.
+3. La promocion publica del proyecto a "Fase 1 iniciada" no se anuncia
+   hasta que las casillas externas de Fase 0 esten cerradas. Es decir:
+   el trabajo tecnico avanza, pero el hito publico se reserva.
+4. El requisito de "segundo contribuidor activo" se da por satisfecho
+   con la incorporacion futura del primer colaborador externo. Hasta
+   entonces el BDFL trabaja en solitario, con revision diferida
+   asincronamente cuando aparezcan contribuidores.
+5. Esta RFC no se reutiliza como precedente para saltos similares en
+   el futuro. Cualquier otra excepcion futura requerira su propia RFC
+   independiente.
+
+## 5. Plan de implementacion
+
+- Aceptacion de esta RFC y de RFC-0002 (Shield) en el mismo commit.
+- Pull requests subsiguientes implementan Shield capa por capa
+  (HTTP/Tokio base, TLS, JWT, rate limiting, validacion, CORS/CSRF,
+  logging, configuracion TOML, tests, benchmarks).
+
+## 6. Riesgos
+
+- Normalizar excepciones: alto. Mitigacion: prohibir reutilizar esta
+  RFC como precedente; exigir RFC propia para cada salto futuro.
+- Calidad baja por falta de revisores: alto. Mitigacion: cuando el
+  primer contribuidor aparezca, todas las PRs aceptadas en este
+  periodo se someten a revision retrospectiva; cualquier cambio
+  necesario se hace en nueva PR.
+- Acumulacion de deuda tecnica: medio. Mitigacion: cada incremento se
+  cubre con tests, fmt y clippy estrictos.
+- Anuncio publico prematuro: bajo. Mitigacion: punto 3 del diseno.
+
+## 7. Impacto
+
+- Sobre el alcance: ninguno.
+- Sobre el cronograma: positivo; no se pierden semanas en espera.
+- Sobre las APIs publicas: ninguno aun.
+- Sobre la documentacion: requiere actualizar STATUS.md con una nota
+  que aclare la excepcion de paralelizacion.
+
+## 8. Rollback
+
+Si la excepcion produce deuda detectable o calidad insuficiente, se
+pausa la implementacion de Fase 1, se cumple la Regla 1 literalmente,
+y se revierten al ultimo commit estable con cobertura completa. La
+revision retrospectiva del primer contribuidor externo es el momento
+formal para evaluar si la excepcion funciono.
+
+## 9. Decision
+
+Aceptada por el BDFL inicial en modo solo, autorizacion verbal
+registrada en la conversacion de continuidad de Fase 0. Esta RFC
+queda como registro formal.
+
+## 10. Referencias
+
+- `docs/roadmap/reglas-de-oro.md` (Regla 1).
+- `docs/roadmap/fase-00-fundaciones-y-gobernanza.md` (criterios 0.3).
+- `docs/roadmap/fase-01-shield-mvp.md` (criterios 1.1).
+- `docs/governance/external-deliverables.md`.
+- `docs/adr/0003-bdfl-governance.md`.
+- RFC-0002 (Shield MVP).

--- a/docs/rfc/RFC-0002-diseno-shield-mvp.md
+++ b/docs/rfc/RFC-0002-diseno-shield-mvp.md
@@ -1,0 +1,278 @@
+# RFC-0002 - Diseno del Shield MVP (Fase 1)
+
+- Estado: aceptado
+- Autor: Angel Nereira (BDFL inicial)
+- Fecha de borrador: 2026-05-19
+- Fecha de aceptacion: 2026-05-19
+- Fase objetivo: Fase 1
+- Modulos o crates afectados: `ag-core`
+- RFC predecesora: RFC-0001 (paralelizacion)
+- Periodo de comentarios: omitido por decision del BDFL en modo solo
+
+## 1. Motivacion
+
+La Fase 1 entrega la capa Shield del nucleo: una pipeline de
+middleware Tower que valida, autentica basicamente, aplica rate
+limiting y entrega requests a un handler placeholder. El maestro de
+arquitectura define el alcance (seccion 6) y la Hoja de Ruta define
+los entregables y los criterios de salida medibles (Fase 1).
+
+Esta RFC fija las decisiones tecnicas concretas necesarias para
+iniciar la implementacion: stack, organizacion del codigo,
+dependencias permitidas y politicas de evolucion.
+
+## 2. Problema
+
+El maestro y la hoja de ruta describen el que. Falta el como, en
+detalle suficiente para que la implementacion no improvise
+arquitectura. Concretamente, falta decidir:
+
+- Que crates externos se usan y en que version.
+- Como se organiza el codigo dentro de `ag-core`.
+- Que tipo de configuracion publica expone el Shield.
+- Como se mide el cumplimiento de los criterios de salida.
+
+## 3. Alternativas consideradas
+
+### 3.1 Stack basado en Axum + Tower
+
+Axum sobre Hyper, middleware via Tower, runtime Tokio. Es la opcion
+descrita en el maestro. Es el estandar de facto del ecosistema Rust
+para servicios HTTP y es lo que cualquier contribuidor con experiencia
+Rust espera.
+
+### 3.2 Stack basado en Actix-Web
+
+Actor model, performance excepcional historicamente. Pros: muy
+rapido. Contras: contradice la decision arquitectonica del maestro;
+modelo de actores es mas complejo de razonar para middleware
+compositional; menor familiaridad cross-team.
+
+### 3.3 Implementar el servidor HTTP desde cero
+
+Solo Hyper y traits propios. Maxima libertad. Contras: reinventa
+ruedas; pierde la composibilidad de Tower que necesitamos para los
+modulos posteriores; viola la Regla 12 (interoperabilidad: integrar,
+no reemplazar).
+
+Se elige 3.1 por alineacion con el maestro, ecosistema y filosofia
+del proyecto.
+
+## 4. Diseno propuesto
+
+### 4.1 Stack y dependencias
+
+Dependencias del crate `ag-core` en Fase 1:
+
+| Crate externo | Version minima | Proposito |
+| --- | --- | --- |
+| `tokio` | 1.40 | Runtime async multi-thread con feature `full`. |
+| `axum` | 0.7 | Router HTTP/1.1 y HTTP/2 sobre Hyper. |
+| `tower` | 0.5 | Modelo de middleware compositional. |
+| `tower-http` | 0.6 | Capas estandar: trace, cors, timeout, request-id. |
+| `hyper` | 1.4 | HTTP base; expuesto a traves de Axum. |
+| `hyper-util` | 0.1 | Helpers de servidor para Axum. |
+| `rustls` | 0.23 | TLS 1.3 sin OpenSSL. Activado en capa de TLS. |
+| `tokio-rustls` | 0.26 | Integracion de rustls con Tokio. |
+| `rustls-pemfile` | 2 | Carga de certificados PEM. |
+| `governor` | 0.7 | Token bucket para rate limiting. |
+| `jsonwebtoken` | 9 | Verificacion JWT (Ed25519 via feature). |
+| `ring` | 0.17 | Primitivas criptograficas Ed25519. |
+| `serde` | 1 | Serializacion. |
+| `serde_json` | 1 | JSON. |
+| `toml` | 0.8 | Configuracion. |
+| `tracing` | 0.1 | Logging estructurado. |
+| `tracing-subscriber` | 0.3 | Suscriptor por defecto con formato. |
+| `thiserror` | 1 | Tipos de error derivados. |
+| `bytes` | 1 | Buffers eficientes. |
+| `http` | 1 | Tipos HTTP estandar. |
+| `pin-project-lite` | 0.2 | Pin projection sin dep de proc-macro. |
+
+Dependencias de desarrollo:
+
+| Crate | Proposito |
+| --- | --- |
+| `criterion` | Benchmarks. |
+| `tokio-test` | Utilidades async para tests. |
+| `reqwest` | Cliente HTTP para tests E2E. |
+| `tower-test` | Mock services para Tower. |
+
+Cada dependencia debe estar listada en `[workspace.dependencies]` del
+`Cargo.toml` raiz, con su feature set explicito, para garantizar
+versionado coherente cross-crate.
+
+### 4.2 Organizacion del codigo
+
+```
+crates/ag-core/
+  src/
+    lib.rs            // Re-exports publicos y modulos
+    error.rs          // AgError, AgResult, IntoResponse impl
+    runtime/
+      mod.rs          // Configuracion Tokio
+    config/
+      mod.rs          // Tipos de configuracion deserializados desde TOML
+    shield/
+      mod.rs          // Pipeline Tower; Shield::builder()
+      tls.rs          // Capa TLS 1.3 (rustls). Feature `tls`.
+      auth.rs         // Capa JWT Ed25519. Feature `auth-jwt`.
+      rate_limit.rs   // Token bucket por IP. Feature `rate-limit`.
+      validation.rs   // Validacion de payload.
+      cors.rs         // CORS con defaults seguros.
+      csrf.rs         // CSRF con defaults seguros.
+      logging.rs      // Tracing layer.
+    core/             // Placeholder; implementacion completa en Fase 2.
+      mod.rs
+  benches/
+    shield_hello_world.rs
+  tests/
+    shield_e2e.rs
+```
+
+### 4.3 Features Cargo
+
+- `default = ["rate-limit", "validation", "cors", "csrf", "logging"]`.
+- `tls`: activa TLS y dependencias `rustls`, `tokio-rustls`, `rustls-pemfile`.
+- `auth-jwt`: activa JWT y dependencias `jsonwebtoken`, `ring`.
+- `rate-limit`: activa `governor`.
+- `validation`: activa restricciones declarativas basicas en `serde`.
+- `cors`: activa `tower-http` cors.
+- `csrf`: activa proteccion CSRF.
+- `logging`: activa `tracing` y `tracing-subscriber`.
+
+Esto cumple la Regla 15 (features bien aisladas).
+
+### 4.4 API publica minima de Fase 1
+
+```rust
+use ag_core::{Shield, ShieldConfig};
+
+let config = ShieldConfig::from_path("ag.toml")?;
+let shield = Shield::builder(config).build();
+let app = axum::Router::new()
+    .route("/", get(|| async { "hello, shield" }))
+    .layer(shield.into_layer());
+
+let listener = tokio::net::TcpListener::bind(config.bind_addr).await?;
+axum::serve(listener, app).await?;
+```
+
+Esto es el contrato que la Fase 1 debe sostener. Los modulos
+posteriores (Core en Fase 2) componen sobre esta misma firma.
+
+### 4.5 Configuracion TOML
+
+```toml
+[bind]
+addr = "0.0.0.0:8080"
+
+[runtime]
+workers = "auto"
+blocking_threads = 512
+shutdown_timeout = "30s"
+
+[shield.rate_limit]
+enabled = true
+per_ip_rps = 100
+burst = 200
+
+[shield.cors]
+enabled = true
+allow_origins = ["https://example.com"]
+allow_methods = ["GET", "POST"]
+allow_headers = ["content-type", "authorization"]
+allow_credentials = false
+
+[shield.csrf]
+enabled = true
+token_header = "X-CSRF-Token"
+
+[shield.tls]
+enabled = false
+cert_path = "/etc/ag/cert.pem"
+key_path = "/etc/ag/key.pem"
+
+[shield.auth.jwt]
+enabled = false
+public_key_path = "/etc/ag/jwt-ed25519.pub"
+```
+
+Todos los campos opcionales tienen defaults seguros. La carga falla
+con error preciso si el TOML contiene claves desconocidas.
+
+### 4.6 Sistema de errores
+
+`AgError` es un enum con variantes por dominio (`Config`, `Tls`,
+`Auth`, `RateLimit`, `Validation`, `Cors`, `Csrf`, `Io`, `Other`).
+Implementa `axum::response::IntoResponse` para mapeo automatico a
+respuesta HTTP. Cada variante lleva un codigo de error estable
+(string snake_case) que se serializa en el body JSON. Un `correlation_id`
+generado por el middleware de logging aparece en todas las respuestas
+de error.
+
+### 4.7 Configuracion Tokio
+
+Runtime multi-thread por defecto: un worker por CPU. Stack size de
+2MB por thread. Blocking pool de 512. Shutdown graceful con timeout
+configurable. Estos parametros vienen de la seccion 6.5 del maestro.
+
+## 5. Plan de implementacion
+
+PRs incrementales, cada uno con tests, fmt y clippy estrictos:
+
+1. Bootstrap `ag-core`: dependencias, modulos vacios, error.rs basico,
+   runtime.rs basico, ejemplo Hello World HTTP/1.1+HTTP/2 sin TLS.
+2. Capa de logging con tracing y request-id.
+3. Capa de validacion de payload.
+4. Capa CORS.
+5. Capa CSRF.
+6. Capa de rate limiting con governor.
+7. Capa de autenticacion JWT Ed25519.
+8. Capa TLS 1.3 con rustls.
+9. Configuracion TOML completa.
+10. Benchmark Hello World con criterion.
+11. Tests E2E con reqwest cubriendo el pipeline completo.
+
+## 6. Riesgos
+
+- Versiones de dependencias rapidas en evolucion (axum, hyper).
+  Mitigacion: pin estricto y actualizaciones semanales monitorizadas.
+- Targets de rendimiento ambiciosos (300K req/s). Mitigacion: medir
+  desde el primer PR, publicar cifras honestas; si no se alcanzan,
+  documentar la brecha en STATUS.md y abrir RFC de optimizacion.
+- Curva de aprendizaje de rustls 0.23. Mitigacion: capa de TLS llega
+  en PR 8, con tiempo de estudio previo.
+- Compatibilidad CI ARM64. Mitigacion: ya configurado en
+  `.github/workflows/ci.yml`.
+
+## 7. Impacto
+
+- Sobre el alcance: ninguno; estrictamente dentro de Fase 1.
+- Sobre el cronograma: 11 PRs estimados a 1-2 semanas cada uno = 3
+  meses, consistente con el rango de Hoja de Ruta (2-3 meses).
+- Sobre la API publica: define la primera API publica del proyecto.
+- Sobre la documentacion: cada PR actualiza el capitulo
+  correspondiente bajo `docs/architecture/06-nucleo-shield-y-core.md`
+  (siempre via regeneracion desde el maestro si la decision afecta al
+  maestro).
+
+## 8. Rollback
+
+Si el stack elegido demuestra ser inviable durante la implementacion
+(por ejemplo, axum no escala a los targets), se abre RFC sucesora que
+proponga el cambio. Mientras tanto, los PRs ya merged se revierten en
+orden inverso. El crate `ag-core` se restaura al estado Fase 0
+(esqueleto vacio).
+
+## 9. Decision
+
+Aceptada por el BDFL inicial junto con RFC-0001.
+
+## 10. Referencias
+
+- `docs/architecture/06-nucleo-shield-y-core.md`.
+- `docs/roadmap/fase-01-shield-mvp.md`.
+- `docs/architecture/15-seguridad.md`.
+- `docs/architecture/16-rendimiento-y-validacion.md`.
+- RFC-0001 (paralelizacion).
+- ADR-0001 (monorepo workspace).

--- a/docs/roadmap/STATUS.md
+++ b/docs/roadmap/STATUS.md
@@ -66,8 +66,49 @@ Detalle y owner sugerido en `docs/governance/external-deliverables.md`.
 
 ## Fase 1 - The Shield MVP
 
-Estado: Pendiente. Todos los criterios de entrada y entregables en
-`docs/roadmap/fase-01-shield-mvp.md` permanecen sin marcar.
+Estado: En curso bajo excepcion documentada en
+`docs/rfc/RFC-0001-paralelizar-fase-0-externa-y-fase-1.md`. La
+implementacion avanza en paralelo con el cierre de las puertas
+externas de Fase 0. El diseno de Shield esta fijado en
+`docs/rfc/RFC-0002-diseno-shield-mvp.md`.
+
+### Criterios de entrada (1.1)
+
+- [/] Fase 0 completada con todos sus criterios de salida marcados.
+  (Excepcion: tres casillas externas siguen pendientes; vease RFC-0001.)
+- [ ] Al menos un contribuidor adicional al mantenedor principal esta
+  activo en el repositorio. (Excepcion: BDFL en modo solo; vease
+  RFC-0001.)
+
+### Entregables (1.2)
+
+- [/] Crate `ag-core` con modulo `shield` operativo. (En bootstrap.)
+- [ ] Soporte de HTTP/1.1 y HTTP/2 via Axum + Tokio.
+- [ ] Terminacion TLS 1.3 con rustls.
+- [ ] Middleware de validacion de payload basico.
+- [ ] Middleware de autenticacion JWT con verificacion Ed25519.
+- [ ] Middleware de rate limiting con governor.
+- [ ] Middleware CORS y CSRF con defaults seguros.
+- [ ] Middleware de logging estructurado con `tracing`.
+- [ ] Configuracion minima desde archivo TOML.
+- [ ] Tests unitarios con cobertura >= 80% del crate.
+- [ ] Tests de integracion end-to-end del pipeline Shield.
+- [ ] Benchmark Hello World ejecutable.
+- [ ] Documentacion API generada con `cargo doc`.
+- [ ] Capitulo del manual de usuario sobre uso de Shield como libreria.
+
+### Criterios de salida (1.3)
+
+- [ ] Benchmark Hello World >= 300K req/s en hardware de referencia.
+- [ ] Latencia p99 del pipeline Shield <= 1 ms a 100K req/s.
+- [ ] Memoria del proceso idle <= 15 MB.
+- [ ] Tiempo de arranque <= 100 ms.
+- [ ] CI pasa en las cuatro plataformas objetivo.
+- [ ] Clippy sin warnings.
+- [ ] `cargo audit` sin vulnerabilidades conocidas.
+- [ ] Cero bloques `unsafe` no documentados.
+- [ ] Al menos un blog post tecnico sobre la arquitectura de Shield.
+- [ ] Al menos diez stars en el repositorio.
 
 ## Fase 2 - The Core MVP
 

--- a/docs/roadmap/STATUS.md
+++ b/docs/roadmap/STATUS.md
@@ -48,7 +48,7 @@ Estado: En curso.
 - [ ] Discord oficial del proyecto con canales requeridos.
 - [ ] Cuenta del proyecto en X o Bluesky para anuncios.
 - [ ] Dominio `antigravital.dev` registrado y apuntando a landing page.
-- [ ] Email institucional `hello@antigravital.dev` operativo.
+- [x] Email institucional `anti@gravitalcloud.com` operativo (correo raiz). Respaldo del BDFL: `angelnereira@gravitalcloud.com`.
 - [ ] Calendario publico de releases publicado en el sitio.
 
 Detalle y owner sugerido en `docs/governance/external-deliverables.md`.

--- a/docs/roadmap/fase-00-fundaciones-y-gobernanza.md
+++ b/docs/roadmap/fase-00-fundaciones-y-gobernanza.md
@@ -22,7 +22,7 @@
 - [ ] Archivo `README.md` bilingüe (español + inglés) con propuesta de valor.
 - [ ] Archivo `CONTRIBUTING.md` con guía de contribución, convenciones de código, proceso de pull request.
 - [ ] Archivo `CODE_OF_CONDUCT.md` adoptando Contributor Covenant 2.1.
-- [ ] Archivo `SECURITY.md` con política de divulgación responsable y dirección `security@gravital.io`.
+- [ ] Archivo `SECURITY.md` con política de divulgación responsable y dirección `anti@gravitalcloud.com` (respaldo: `angelnereira@gravitalcloud.com`).
 - [ ] Archivo `GOVERNANCE.md` describiendo modelo BDFL inicial y plan de transición.
 - [ ] Configuración de CI con GitHub Actions: build en Linux x86-64, Linux ARM64, macOS ARM64, Windows x64.
 - [ ] Plantillas de issue (bug report, feature request, RFC) y plantilla de pull request.
@@ -30,7 +30,7 @@
 - [ ] Discord oficial del proyecto con canales `#español`, `#english`, `#announcements`, `#help`.
 - [ ] Cuenta del proyecto en X/Bluesky para anuncios.
 - [ ] Dominio `antigravital.dev` registrado y apuntando a una landing page mínima.
-- [ ] Email institucional `hello@antigravital.dev` operativo.
+- [ ] Email institucional `anti@gravitalcloud.com` operativo (correo raíz del proyecto).
 - [ ] Calendario público de releases publicado.
 
 ### 0.3 Criterios de salida (puerta antes de Fase 1)

--- a/docs/security/README.md
+++ b/docs/security/README.md
@@ -18,7 +18,7 @@ Las primitivas criptográficas se importan del crate `ring`, mantenido por miemb
 
 ### 15.3 Política de divulgación responsable
 
-El repositorio mantiene un archivo `SECURITY.md` con una dirección de contacto (`security@gravital.io`) y una política clara: las vulnerabilidades se reportan privadamente, el equipo confirma recepción en 48 horas, publica un parche en 30 días para vulnerabilidades críticas, y un CVE con crédito al reportero.
+El repositorio mantiene un archivo `SECURITY.md` con direcciones de contacto (primario `anti@gravitalcloud.com`, respaldo `angelnereira@gravitalcloud.com`) y una política clara: las vulnerabilidades se reportan privadamente, el equipo confirma recepción en 48 horas, publica un parche en 30 días para vulnerabilidades críticas, y un CVE con crédito al reportero.
 
 ### 15.4 Auditorías
 


### PR DESCRIPTION
## Resumen

<!-- Una linea, maximo 256 caracteres. Misma frase puede usarse como
     titulo de la PR. Sin emojis ni atribuciones a herramientas IA. -->

## Fase afectada

<!-- Fase 0, 1, ... 10. Vease docs/roadmap/. -->

## Tipo de cambio

- [ ] Documentacion
- [ ] Codigo
- [ ] Infraestructura o CI
- [ ] RFC nueva o actualizacion de RFC
- [ ] ADR nuevo
- [ ] Seguridad

## Documentos relacionados

- RFC: <!-- docs/rfc/RFC-XXXX-...md o N/A -->
- ADR: <!-- docs/adr/XXXX-...md o N/A -->
- Maestro afectado: <!-- docs/master/... o N/A -->

## Plan de prueba

<!-- Pasos concretos para verificar el cambio. Si aplica:
- cargo fmt --all -- --check
- cargo clippy --workspace --all-targets -- -D warnings
- cargo test --workspace
- cargo audit
- cargo deny check
-->

## Criterios de salida que avanza

<!-- Casillas concretas de docs/roadmap/STATUS.md que esta PR marca. -->

## Checklist

- [ ] Titulo de PR de 256 caracteres o menos.
- [ ] Sin emojis en ningun archivo modificado.
- [ ] Sin atribuciones de herramientas IA.
- [ ] Documentacion actualizada en el mismo PR.
- [ ] CHANGELOG.md actualizado bajo [Unreleased].
- [ ] CLAUDE.md respetado (alcance, fase, dependencias, seguridad).
