### PR TITLE
ag-core: capa rate-limit token bucket por IP con governor

Feature 'rate-limit'. RateLimitLayer con governor dashmap keyed por IpAddr. Sin ConnectInfo pasa transparente. 6 unit + 3 E2E. RFC-0002 PR 5 de 11.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -100,6 +100,15 @@ Anadido:
   `CsrfConfig` con header por defecto `x-csrf-token` y cookie
   `ag_csrf`. CSRF deshabilitado por defecto. 7 unit tests sobre
   parsing de cookies y validacion y 6 tests E2E sobre flujo completo.
+- Capa rate-limit (`shield::rate_limit`) detras de la feature
+  `rate-limit` activa por defecto. Token bucket por IP con `governor`
+  (dashmap storage). Cuando una IP excede `per_ip_rps`/`burst`, las
+  peticiones rebotan con `AgError::RateLimit` (status 429, codigo
+  `rate_limit_exceeded`). Sin `ConnectInfo` la capa pasa transparente
+  (compatibilidad con tests sin transporte). `RateLimitConfig`
+  deshabilitada por defecto, configuracion validada al construir
+  Shield. Dependencia opcional `governor = 0.7`. 6 unit tests y 3
+  tests E2E.
 
 Cambiado:
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -85,5 +85,25 @@ Anadido:
   `ValidatedJson<T>` que mapea fallos a `AgError::Validation` con
   detalle estructurado por campo (status 422). 4 unit tests
   adicionales y 3 tests E2E sobre `/projects`.
+- Capa CORS (`shield::cors`) detras de la feature `cors` activa por
+  defecto. Wraps `tower_http::cors::CorsLayer` con configuracion
+  declarativa via `CorsConfig` en `ShieldConfig`. Defaults seguros:
+  CORS deshabilitado salvo declaracion explicita. Errores de
+  configuracion mapeados a `AgError::Cors` con codigo `cors_error`
+  (status 403). 4 unit tests sobre construccion y 4 tests E2E sobre
+  preflight, origenes listados y rechazados.
+- Tower-http feature `cors` activada en el workspace.
+
+Cambiado:
+
+- API publica de `Shield`: `Shield::layer()` reemplazado por
+  `Shield::apply(router)`. La nueva firma oculta la complejidad de
+  tipos de la pipeline y permite agregar capas sin romper la
+  superficie publica en cada PR.
+- `Shield::try_new(config)` valida la configuracion en construccion
+  (origenes, metodos y headers de CORS); `Shield::new(config)` mantiene
+  semantica de panic para casos de prototipado.
+- Workflow `quality.yml`: `cargo deny` ya pasa tras anadir
+  `Unicode-3.0` a `deny.toml` (commit anterior).
 
 [Unreleased]: https://github.com/anti-gravital/anti-gravital/compare/HEAD..HEAD

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -93,6 +93,13 @@ Anadido:
   (status 403). 4 unit tests sobre construccion y 4 tests E2E sobre
   preflight, origenes listados y rechazados.
 - Tower-http feature `cors` activada en el workspace.
+- Capa CSRF (`shield::csrf`) detras de la feature `csrf` activa por
+  defecto. Patron double-submit cookie apatrida: en peticiones que
+  mutan estado (POST, PUT, PATCH, DELETE) se exige que el header y la
+  cookie configurados lleven el mismo valor opaco. Configuracion via
+  `CsrfConfig` con header por defecto `x-csrf-token` y cookie
+  `ag_csrf`. CSRF deshabilitado por defecto. 7 unit tests sobre
+  parsing de cookies y validacion y 6 tests E2E sobre flujo completo.
 
 Cambiado:
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -28,6 +28,7 @@ version = "0.0.0"
 dependencies = [
  "axum",
  "bytes",
+ "governor",
  "http",
  "http-body-util",
  "hyper",
@@ -213,6 +214,26 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "613afe47fcd5fac7ccf1db93babcb082c5994d996f20b8b159f2ad1658eb5724"
 
 [[package]]
+name = "crossbeam-utils"
+version = "0.8.21"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d0a5c400df2834b80a4c3327b3aad3a4c4cd4de0629063962b03235697506a28"
+
+[[package]]
+name = "dashmap"
+version = "6.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e6361d5c062261c78a176addb82d4c821ae42bed6089de0e12603cd25de2059c"
+dependencies = [
+ "cfg-if",
+ "crossbeam-utils",
+ "hashbrown 0.14.5",
+ "lock_api",
+ "once_cell",
+ "parking_lot_core",
+]
+
+[[package]]
 name = "displaydoc"
 version = "0.2.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -294,12 +315,19 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "037711b3d59c33004d3856fbdc83b99d4ff37a24768fa1be9ce3538a1cde4393"
 
 [[package]]
+name = "futures-timer"
+version = "3.0.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f288b0a4f20f9a56b5d1da57e2227c661b7b16168e2f72365f57b63326e29b24"
+
+[[package]]
 name = "futures-util"
 version = "0.3.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "389ca41296e6190b48053de0321d02a77f32f8a5d2461dd38762c0593805c6d6"
 dependencies = [
  "futures-core",
+ "futures-sink",
  "futures-task",
  "pin-project-lite",
  "slab",
@@ -346,6 +374,27 @@ dependencies = [
 ]
 
 [[package]]
+name = "governor"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0746aa765db78b521451ef74221663b57ba595bf83f75d0ce23cc09447c8139f"
+dependencies = [
+ "cfg-if",
+ "dashmap",
+ "futures-sink",
+ "futures-timer",
+ "futures-util",
+ "no-std-compat",
+ "nonzero_ext",
+ "parking_lot",
+ "portable-atomic",
+ "quanta",
+ "rand 0.8.6",
+ "smallvec",
+ "spinning_top",
+]
+
+[[package]]
 name = "h2"
 version = "0.4.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -363,6 +412,12 @@ dependencies = [
  "tokio-util",
  "tracing",
 ]
+
+[[package]]
+name = "hashbrown"
+version = "0.14.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e5274423e17b7c9fc20b6e7e208532f9b19825d82dfd615708b70edd83df41f1"
 
 [[package]]
 name = "hashbrown"
@@ -661,6 +716,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "92daf443525c4cce67b150400bc2316076100ce0b3686209eb8cf3c31612e6f0"
 
 [[package]]
+name = "lock_api"
+version = "0.4.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "224399e74b87b5f3557511d98dff8b14089b3dadafcab6bb93eab67d3aace965"
+dependencies = [
+ "scopeguard",
+]
+
+[[package]]
 name = "log"
 version = "0.4.29"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -711,6 +775,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "no-std-compat"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b93853da6d84c2e3c7d730d6473e8817692dd89be387eb01b94d7f108ecb5b8c"
+
+[[package]]
+name = "nonzero_ext"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "38bf9645c8b145698bb0b18a4637dcacbc421ea49bef2317e4fd8065a387cf21"
+
+[[package]]
 name = "nu-ansi-term"
 version = "0.50.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -726,6 +802,29 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9f7c3e4beb33f85d45ae3e3a1792185706c8e16d043238c593331cc7cd313b50"
 
 [[package]]
+name = "parking_lot"
+version = "0.12.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "93857453250e3077bd71ff98b6a65ea6621a19bb0f559a85248955ac12c45a1a"
+dependencies = [
+ "lock_api",
+ "parking_lot_core",
+]
+
+[[package]]
+name = "parking_lot_core"
+version = "0.9.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2621685985a2ebf1c516881c026032ac7deafcda1a2c9b7850dc81e3dfcb64c1"
+dependencies = [
+ "cfg-if",
+ "libc",
+ "redox_syscall",
+ "smallvec",
+ "windows-link",
+]
+
+[[package]]
 name = "percent-encoding"
 version = "2.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -736,6 +835,12 @@ name = "pin-project-lite"
 version = "0.2.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a89322df9ebe1c1578d689c92318e070967d1042b512afbe49518723f4e6d5cd"
+
+[[package]]
+name = "portable-atomic"
+version = "1.13.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c33a9471896f1c69cecef8d20cbe2f7accd12527ce60845ff44c153bb2a21b49"
 
 [[package]]
 name = "potential_utf"
@@ -775,6 +880,21 @@ dependencies = [
 ]
 
 [[package]]
+name = "quanta"
+version = "0.12.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f3ab5a9d756f0d97bdc89019bd2e4ea098cf9cde50ee7564dde6b81ccc8f06c7"
+dependencies = [
+ "crossbeam-utils",
+ "libc",
+ "once_cell",
+ "raw-cpuid",
+ "wasi",
+ "web-sys",
+ "winapi",
+]
+
+[[package]]
 name = "quinn"
 version = "0.11.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -803,7 +923,7 @@ dependencies = [
  "bytes",
  "getrandom 0.3.4",
  "lru-slab",
- "rand",
+ "rand 0.9.4",
  "ring",
  "rustc-hash",
  "rustls",
@@ -852,12 +972,33 @@ checksum = "f8dcc9c7d52a811697d2151c701e0d08956f92b0e24136cf4cf27b57a6a0d9bf"
 
 [[package]]
 name = "rand"
+version = "0.8.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5ca0ecfa931c29007047d1bc58e623ab12e5590e8c7cc53200d5202b69266d8a"
+dependencies = [
+ "libc",
+ "rand_chacha 0.3.1",
+ "rand_core 0.6.4",
+]
+
+[[package]]
+name = "rand"
 version = "0.9.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "44c5af06bb1b7d3216d91932aed5265164bf384dc89cd6ba05cf59a35f5f76ea"
 dependencies = [
- "rand_chacha",
- "rand_core",
+ "rand_chacha 0.9.0",
+ "rand_core 0.9.5",
+]
+
+[[package]]
+name = "rand_chacha"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e6c10a63a0fa32252be49d21e7709d4d4baf8d231c2dbce1eaa8141b9b127d88"
+dependencies = [
+ "ppv-lite86",
+ "rand_core 0.6.4",
 ]
 
 [[package]]
@@ -867,7 +1008,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d3022b5f1df60f26e1ffddd6c66e8aa15de382ae63b3a0c1bfc0e4d3e3f325cb"
 dependencies = [
  "ppv-lite86",
- "rand_core",
+ "rand_core 0.9.5",
+]
+
+[[package]]
+name = "rand_core"
+version = "0.6.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ec0be4795e2f6a28069bec0b5ff3e2ac9bafc99e6a9a7dc3547996c5c816922c"
+dependencies = [
+ "getrandom 0.2.17",
 ]
 
 [[package]]
@@ -877,6 +1027,24 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "76afc826de14238e6e8c374ddcc1fa19e374fd8dd986b0d2af0d02377261d83c"
 dependencies = [
  "getrandom 0.3.4",
+]
+
+[[package]]
+name = "raw-cpuid"
+version = "11.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "498cd0dc59d73224351ee52a95fee0f1a617a2eae0e7d9d720cc622c73a54186"
+dependencies = [
+ "bitflags",
+]
+
+[[package]]
+name = "redox_syscall"
+version = "0.5.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ed2bf2547551a7053d6fdfafda3f938979645c44812fbfcda098faae3f1a362d"
+dependencies = [
+ "bitflags",
 ]
 
 [[package]]
@@ -1000,6 +1168,12 @@ name = "ryu"
 version = "1.0.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9774ba4a74de5f7b1c1451ed6cd5285a32eddb5cccb8cc655a4e50009e06477f"
+
+[[package]]
+name = "scopeguard"
+version = "1.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "94143f37725109f92c262ed2cf5e59bce7498c01bcc1502d7b9afe439a4e9f49"
 
 [[package]]
 name = "semver"
@@ -1127,6 +1301,15 @@ checksum = "3a766e1110788c36f4fa1c2b71b387a7815aa65f88ce0229841826633d93723e"
 dependencies = [
  "libc",
  "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "spinning_top"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d96d2d1d716fb500937168cc09353ffdc7a012be8475ac7308e1bdf0e3923300"
+dependencies = [
+ "lock_api",
 ]
 
 [[package]]
@@ -1689,6 +1872,28 @@ checksum = "52f5ee44c96cf55f1b349600768e3ece3a8f26010c05265ab73f945bb1a2eb9d"
 dependencies = [
  "rustls-pki-types",
 ]
+
+[[package]]
+name = "winapi"
+version = "0.3.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5c839a674fcd7a98952e593242ea400abe93992746761e38641405d28b00f419"
+dependencies = [
+ "winapi-i686-pc-windows-gnu",
+ "winapi-x86_64-pc-windows-gnu",
+]
+
+[[package]]
+name = "winapi-i686-pc-windows-gnu"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ac3b87c63620426dd9b991e5ce0329eff545bccbbb34f3be09ff6fb6ab51b7b6"
+
+[[package]]
+name = "winapi-x86_64-pc-windows-gnu"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"
 
 [[package]]
 name = "windows-link"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -39,6 +39,7 @@ publish = false
 [workspace.dependencies]
 axum = { version = "0.7", default-features = false, features = ["http1", "http2", "tokio", "json", "matched-path"] }
 bytes = "1"
+governor = "0.7"
 http = "1"
 http-body-util = "0.1"
 hyper = { version = "1.4", features = ["http1", "http2"] }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -50,7 +50,7 @@ thiserror = "1"
 tokio = { version = "1.40", features = ["rt-multi-thread", "macros", "net", "signal", "time", "sync"] }
 toml = "0.8"
 tower = { version = "0.5", features = ["util"] }
-tower-http = { version = "0.6", features = ["trace", "request-id", "util"] }
+tower-http = { version = "0.6", features = ["trace", "request-id", "util", "cors"] }
 tracing = "0.1"
 tracing-subscriber = { version = "0.3", features = ["env-filter", "fmt", "json"] }
 

--- a/crates/ag-core/Cargo.toml
+++ b/crates/ag-core/Cargo.toml
@@ -25,7 +25,7 @@ workspace = true
 default = ["validation", "cors", "csrf", "logging", "rate-limit"]
 tls = []
 auth-jwt = []
-rate-limit = []
+rate-limit = ["dep:governor"]
 validation = []
 cors = []
 csrf = []
@@ -34,6 +34,7 @@ logging = []
 [dependencies]
 axum = { workspace = true }
 bytes = { workspace = true }
+governor = { workspace = true, optional = true }
 http = { workspace = true }
 http-body-util = { workspace = true }
 hyper = { workspace = true }

--- a/crates/ag-core/src/config/mod.rs
+++ b/crates/ag-core/src/config/mod.rs
@@ -25,6 +25,10 @@ pub struct ShieldConfig {
     /// Configuracion CORS.
     #[serde(default)]
     pub cors: CorsConfig,
+
+    /// Configuracion CSRF.
+    #[serde(default)]
+    pub csrf: CsrfConfig,
 }
 
 impl Default for ShieldConfig {
@@ -33,6 +37,7 @@ impl Default for ShieldConfig {
             bind: default_bind_addr(),
             runtime: RuntimeConfig::default(),
             cors: CorsConfig::default(),
+            csrf: CsrfConfig::default(),
         }
     }
 }
@@ -63,6 +68,46 @@ pub struct CorsConfig {
     /// Si se permiten credenciales en peticiones cross-origin.
     #[serde(default)]
     pub allow_credentials: bool,
+}
+
+/// Configuracion CSRF.
+///
+/// Por defecto deshabilitada. Cuando se activa, las peticiones que mutan
+/// estado deben presentar el header y la cookie configurados con
+/// valores identicos (patron double-submit cookie).
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct CsrfConfig {
+    /// Activa la capa CSRF.
+    #[serde(default)]
+    pub enabled: bool,
+
+    /// Nombre del header que transporta el token. Por defecto
+    /// `X-CSRF-Token`. Se compara en minusculas.
+    #[serde(default = "default_csrf_header")]
+    pub token_header: String,
+
+    /// Nombre de la cookie que transporta el token. Por defecto
+    /// `ag_csrf`.
+    #[serde(default = "default_csrf_cookie")]
+    pub token_cookie: String,
+}
+
+impl Default for CsrfConfig {
+    fn default() -> Self {
+        Self {
+            enabled: false,
+            token_header: default_csrf_header(),
+            token_cookie: default_csrf_cookie(),
+        }
+    }
+}
+
+fn default_csrf_header() -> String {
+    "x-csrf-token".to_owned()
+}
+
+fn default_csrf_cookie() -> String {
+    "ag_csrf".to_owned()
 }
 
 impl ShieldConfig {

--- a/crates/ag-core/src/config/mod.rs
+++ b/crates/ag-core/src/config/mod.rs
@@ -21,6 +21,10 @@ pub struct ShieldConfig {
     /// Configuracion del runtime Tokio.
     #[serde(default)]
     pub runtime: RuntimeConfig,
+
+    /// Configuracion CORS.
+    #[serde(default)]
+    pub cors: CorsConfig,
 }
 
 impl Default for ShieldConfig {
@@ -28,8 +32,37 @@ impl Default for ShieldConfig {
         Self {
             bind: default_bind_addr(),
             runtime: RuntimeConfig::default(),
+            cors: CorsConfig::default(),
         }
     }
+}
+
+/// Configuracion CORS.
+///
+/// Por defecto la capa esta deshabilitada para no permitir cross-origin
+/// implicito. Para habilitarla declare `enabled = true` y al menos un
+/// origen.
+#[derive(Debug, Clone, Default, Serialize, Deserialize)]
+pub struct CorsConfig {
+    /// Activa la capa CORS.
+    #[serde(default)]
+    pub enabled: bool,
+
+    /// Origenes permitidos. Ej: `["https://app.example.com"]`.
+    #[serde(default)]
+    pub allow_origins: Vec<String>,
+
+    /// Metodos HTTP permitidos. Ej: `["GET", "POST"]`.
+    #[serde(default)]
+    pub allow_methods: Vec<String>,
+
+    /// Headers permitidos. Ej: `["content-type", "authorization"]`.
+    #[serde(default)]
+    pub allow_headers: Vec<String>,
+
+    /// Si se permiten credenciales en peticiones cross-origin.
+    #[serde(default)]
+    pub allow_credentials: bool,
 }
 
 impl ShieldConfig {

--- a/crates/ag-core/src/config/mod.rs
+++ b/crates/ag-core/src/config/mod.rs
@@ -29,6 +29,10 @@ pub struct ShieldConfig {
     /// Configuracion CSRF.
     #[serde(default)]
     pub csrf: CsrfConfig,
+
+    /// Configuracion de rate limiting por IP.
+    #[serde(default)]
+    pub rate_limit: RateLimitConfig,
 }
 
 impl Default for ShieldConfig {
@@ -38,6 +42,7 @@ impl Default for ShieldConfig {
             runtime: RuntimeConfig::default(),
             cors: CorsConfig::default(),
             csrf: CsrfConfig::default(),
+            rate_limit: RateLimitConfig::default(),
         }
     }
 }
@@ -108,6 +113,44 @@ fn default_csrf_header() -> String {
 
 fn default_csrf_cookie() -> String {
     "ag_csrf".to_owned()
+}
+
+/// Configuracion de rate limiting por IP.
+///
+/// Por defecto deshabilitada. Cuando se activa aplica un token bucket
+/// por direccion IP de origen con `per_ip_rps` peticiones por segundo
+/// como tasa sostenida y `burst` peticiones como pico instantaneo.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct RateLimitConfig {
+    /// Activa la capa de rate limiting.
+    #[serde(default)]
+    pub enabled: bool,
+
+    /// Peticiones por segundo permitidas por IP en regimen sostenido.
+    #[serde(default = "default_per_ip_rps")]
+    pub per_ip_rps: u32,
+
+    /// Capacidad maxima del token bucket por IP.
+    #[serde(default = "default_burst")]
+    pub burst: u32,
+}
+
+impl Default for RateLimitConfig {
+    fn default() -> Self {
+        Self {
+            enabled: false,
+            per_ip_rps: default_per_ip_rps(),
+            burst: default_burst(),
+        }
+    }
+}
+
+const fn default_per_ip_rps() -> u32 {
+    100
+}
+
+const fn default_burst() -> u32 {
+    200
 }
 
 impl ShieldConfig {

--- a/crates/ag-core/src/lib.rs
+++ b/crates/ag-core/src/lib.rs
@@ -13,10 +13,10 @@
 //!
 //! # async fn run() -> Result<(), ag_core::AgError> {
 //! let config = ShieldConfig::default();
-//! let shield = Shield::new(config);
+//! let shield = Shield::try_new(config)?;
 //! let app = axum::Router::new()
-//!     .route("/", axum::routing::get(|| async { "hello, shield" }))
-//!     .layer(shield.layer());
+//!     .route("/", axum::routing::get(|| async { "hello, shield" }));
+//! let app = shield.apply(app);
 //!
 //! let listener = tokio::net::TcpListener::bind("127.0.0.1:0").await?;
 //! axum::serve(listener, app).await?;

--- a/crates/ag-core/src/shield/cors.rs
+++ b/crates/ag-core/src/shield/cors.rs
@@ -1,0 +1,106 @@
+//! Capa CORS de Anti-Gravital.
+//!
+//! Envuelve `tower_http::cors::CorsLayer` con defaults seguros y una
+//! configuracion declarativa desde `ShieldConfig`. Por defecto la capa
+//! se construye en modo restrictivo: sin origenes permitidos. Para
+//! habilitar CORS hay que declarar `[shield.cors]` con `enabled = true`
+//! y al menos un origen.
+
+use axum::http::header::{HeaderName, HeaderValue};
+use axum::http::Method;
+use tower_http::cors::{AllowOrigin, CorsLayer};
+
+use crate::config::CorsConfig;
+use crate::error::AgError;
+
+/// Construye una `CorsLayer` desde la configuracion.
+///
+/// # Errores
+///
+/// Devuelve `AgError::Cors` si la configuracion contiene origenes,
+/// metodos o headers invalidos.
+pub fn build_layer(config: &CorsConfig) -> Result<CorsLayer, AgError> {
+    let mut layer = CorsLayer::new();
+
+    if !config.enabled {
+        return Ok(layer);
+    }
+
+    let origins = config
+        .allow_origins
+        .iter()
+        .map(|origin| HeaderValue::from_str(origin).map_err(|e| AgError::Cors(e.to_string())))
+        .collect::<Result<Vec<_>, _>>()?;
+    layer = layer.allow_origin(AllowOrigin::list(origins));
+
+    let methods = config
+        .allow_methods
+        .iter()
+        .map(|m| {
+            m.parse::<Method>()
+                .map_err(|e| AgError::Cors(e.to_string()))
+        })
+        .collect::<Result<Vec<_>, _>>()?;
+    layer = layer.allow_methods(methods);
+
+    let headers = config
+        .allow_headers
+        .iter()
+        .map(|h| HeaderName::from_bytes(h.as_bytes()).map_err(|e| AgError::Cors(e.to_string())))
+        .collect::<Result<Vec<_>, _>>()?;
+    layer = layer.allow_headers(headers);
+
+    layer = layer.allow_credentials(config.allow_credentials);
+
+    Ok(layer)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn disabled_cors_builds_empty_layer() {
+        let cfg = CorsConfig::default();
+        let layer = build_layer(&cfg);
+        assert!(layer.is_ok());
+    }
+
+    #[test]
+    fn enabled_cors_with_valid_origins_builds() {
+        let cfg = CorsConfig {
+            enabled: true,
+            allow_origins: vec!["https://example.com".into()],
+            allow_methods: vec!["GET".into(), "POST".into()],
+            allow_headers: vec!["content-type".into()],
+            allow_credentials: false,
+        };
+        assert!(build_layer(&cfg).is_ok());
+    }
+
+    #[test]
+    fn enabled_cors_with_invalid_method_errors() {
+        let cfg = CorsConfig {
+            enabled: true,
+            allow_origins: vec!["https://example.com".into()],
+            allow_methods: vec!["NOT A METHOD".into()],
+            allow_headers: vec![],
+            allow_credentials: false,
+        };
+        let err = build_layer(&cfg).unwrap_err();
+        assert_eq!(err.code(), "cors_error");
+    }
+
+    #[test]
+    fn enabled_cors_with_invalid_header_errors() {
+        let cfg = CorsConfig {
+            enabled: true,
+            allow_origins: vec!["https://example.com".into()],
+            allow_methods: vec!["GET".into()],
+            allow_headers: vec!["invalid header name with spaces".into()],
+            allow_credentials: false,
+        };
+        let err = build_layer(&cfg).unwrap_err();
+        assert_eq!(err.code(), "cors_error");
+    }
+}

--- a/crates/ag-core/src/shield/csrf.rs
+++ b/crates/ag-core/src/shield/csrf.rs
@@ -1,0 +1,277 @@
+//! Capa CSRF de Anti-Gravital.
+//!
+//! Implementa proteccion CSRF apatrida via patron double-submit cookie:
+//! en peticiones que mutan estado (POST, PUT, PATCH, DELETE), el
+//! servidor exige que la cookie configurada y el header configurado
+//! contengan exactamente el mismo valor opaco. Si faltan o no
+//! coinciden, la peticion se rechaza con `AgError::Csrf` (status 403).
+//!
+//! Las peticiones seguras (GET, HEAD, OPTIONS, TRACE) pasan sin
+//! verificacion porque por definicion no mutan estado del servidor.
+//!
+//! El emisor del token (cookie) es responsabilidad del proyecto: la
+//! Shield no asume sesion ni storage. Una implementacion tipica usa
+//! un endpoint dedicado (por ejemplo, GET `/csrf-token`) que setea
+//! la cookie en la respuesta.
+
+use std::future::Future;
+use std::pin::Pin;
+use std::task::{Context, Poll};
+
+use axum::extract::Request;
+use axum::http::Method;
+use axum::response::{IntoResponse, Response};
+use pin_project_lite::pin_project;
+use tower::{Layer, Service};
+
+use crate::config::CsrfConfig;
+use crate::error::AgError;
+
+/// Tower layer que aplica double-submit cookie CSRF.
+#[derive(Debug, Clone)]
+pub struct CsrfLayer {
+    config: CsrfConfig,
+}
+
+impl CsrfLayer {
+    /// Construye una `CsrfLayer` con la configuracion dada.
+    #[must_use]
+    pub fn new(config: CsrfConfig) -> Self {
+        Self { config }
+    }
+}
+
+impl<S> Layer<S> for CsrfLayer {
+    type Service = CsrfService<S>;
+
+    fn layer(&self, inner: S) -> Self::Service {
+        CsrfService {
+            inner,
+            config: self.config.clone(),
+        }
+    }
+}
+
+/// Servicio que valida CSRF antes de delegar al inner.
+#[derive(Debug, Clone)]
+pub struct CsrfService<S> {
+    inner: S,
+    config: CsrfConfig,
+}
+
+fn is_safe_method(method: &Method) -> bool {
+    matches!(
+        *method,
+        Method::GET | Method::HEAD | Method::OPTIONS | Method::TRACE
+    )
+}
+
+fn extract_cookie_value<'a>(cookie_header: &'a str, name: &str) -> Option<&'a str> {
+    cookie_header.split(';').find_map(|kv| {
+        let kv = kv.trim();
+        let (k, v) = kv.split_once('=')?;
+        if k.trim() == name {
+            Some(v.trim())
+        } else {
+            None
+        }
+    })
+}
+
+fn validate(req: &Request, config: &CsrfConfig) -> Result<(), AgError> {
+    if is_safe_method(req.method()) {
+        return Ok(());
+    }
+
+    let headers = req.headers();
+    let header_value = headers
+        .get(config.token_header.as_str())
+        .ok_or_else(|| AgError::Csrf("missing CSRF header".to_owned()))?
+        .to_str()
+        .map_err(|_| AgError::Csrf("CSRF header is not valid UTF-8".to_owned()))?;
+
+    let cookie_header = headers
+        .get(axum::http::header::COOKIE)
+        .ok_or_else(|| AgError::Csrf("missing cookie".to_owned()))?
+        .to_str()
+        .map_err(|_| AgError::Csrf("cookie header is not valid UTF-8".to_owned()))?;
+
+    let cookie_value = extract_cookie_value(cookie_header, &config.token_cookie)
+        .ok_or_else(|| AgError::Csrf("missing CSRF cookie".to_owned()))?;
+
+    if header_value == cookie_value && !header_value.is_empty() {
+        Ok(())
+    } else {
+        Err(AgError::Csrf("CSRF token mismatch".to_owned()))
+    }
+}
+
+impl<S> Service<Request> for CsrfService<S>
+where
+    S: Service<Request, Response = Response> + Clone + Send + 'static,
+    S::Future: Send + 'static,
+{
+    type Response = Response;
+    type Error = S::Error;
+    type Future = CsrfFuture<S::Future>;
+
+    fn poll_ready(&mut self, cx: &mut Context<'_>) -> Poll<Result<(), Self::Error>> {
+        self.inner.poll_ready(cx)
+    }
+
+    fn call(&mut self, req: Request) -> Self::Future {
+        match validate(&req, &self.config) {
+            Ok(()) => CsrfFuture {
+                state: CsrfState::Inner {
+                    future: self.inner.call(req),
+                },
+            },
+            Err(err) => CsrfFuture {
+                state: CsrfState::Reject {
+                    response: Some(err.into_response()),
+                },
+            },
+        }
+    }
+}
+
+pin_project! {
+    /// Future del servicio CSRF.
+    #[derive(Debug)]
+    pub struct CsrfFuture<F> {
+        #[pin]
+        state: CsrfState<F>,
+    }
+}
+
+pin_project! {
+    #[project = CsrfStateProj]
+    #[derive(Debug)]
+    enum CsrfState<F> {
+        Inner { #[pin] future: F },
+        Reject { response: Option<Response> },
+    }
+}
+
+impl<F, E> Future for CsrfFuture<F>
+where
+    F: Future<Output = Result<Response, E>>,
+{
+    type Output = Result<Response, E>;
+
+    fn poll(self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Self::Output> {
+        let this = self.project();
+        match this.state.project() {
+            CsrfStateProj::Inner { future } => future.poll(cx),
+            CsrfStateProj::Reject { response } => {
+                let resp = response.take().expect("polled CsrfFuture after completion");
+                Poll::Ready(Ok(resp))
+            }
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use axum::http::HeaderValue;
+
+    fn config() -> CsrfConfig {
+        CsrfConfig {
+            enabled: true,
+            token_header: "x-csrf-token".to_owned(),
+            token_cookie: "ag_csrf".to_owned(),
+        }
+    }
+
+    #[test]
+    fn safe_methods_skip_validation() {
+        for method in [Method::GET, Method::HEAD, Method::OPTIONS, Method::TRACE] {
+            assert!(is_safe_method(&method), "method {method:?} should be safe");
+        }
+    }
+
+    #[test]
+    fn unsafe_methods_require_validation() {
+        for method in [Method::POST, Method::PUT, Method::PATCH, Method::DELETE] {
+            assert!(
+                !is_safe_method(&method),
+                "method {method:?} should not be safe"
+            );
+        }
+    }
+
+    #[test]
+    fn extract_cookie_value_finds_named_cookie() {
+        let header = "session=abc; ag_csrf=xyz; theme=dark";
+        assert_eq!(extract_cookie_value(header, "ag_csrf"), Some("xyz"));
+        assert_eq!(extract_cookie_value(header, "session"), Some("abc"));
+        assert_eq!(extract_cookie_value(header, "missing"), None);
+    }
+
+    #[test]
+    fn validate_passes_when_header_matches_cookie() {
+        let cfg = config();
+        let req = Request::builder()
+            .method(Method::POST)
+            .uri("/x")
+            .header("x-csrf-token", HeaderValue::from_static("token-123"))
+            .header(
+                axum::http::header::COOKIE,
+                HeaderValue::from_static("ag_csrf=token-123"),
+            )
+            .body(axum::body::Body::empty())
+            .unwrap();
+        assert!(validate(&req, &cfg).is_ok());
+    }
+
+    #[test]
+    fn validate_rejects_when_header_missing() {
+        let cfg = config();
+        let req = Request::builder()
+            .method(Method::POST)
+            .uri("/x")
+            .header(
+                axum::http::header::COOKIE,
+                HeaderValue::from_static("ag_csrf=token-123"),
+            )
+            .body(axum::body::Body::empty())
+            .unwrap();
+        let err = validate(&req, &cfg).unwrap_err();
+        assert_eq!(err.code(), "csrf_error");
+    }
+
+    #[test]
+    fn validate_rejects_when_values_differ() {
+        let cfg = config();
+        let req = Request::builder()
+            .method(Method::POST)
+            .uri("/x")
+            .header("x-csrf-token", HeaderValue::from_static("aaa"))
+            .header(
+                axum::http::header::COOKIE,
+                HeaderValue::from_static("ag_csrf=bbb"),
+            )
+            .body(axum::body::Body::empty())
+            .unwrap();
+        let err = validate(&req, &cfg).unwrap_err();
+        assert_eq!(err.code(), "csrf_error");
+    }
+
+    #[test]
+    fn validate_rejects_empty_token() {
+        let cfg = config();
+        let req = Request::builder()
+            .method(Method::POST)
+            .uri("/x")
+            .header("x-csrf-token", HeaderValue::from_static(""))
+            .header(
+                axum::http::header::COOKIE,
+                HeaderValue::from_static("ag_csrf="),
+            )
+            .body(axum::body::Body::empty())
+            .unwrap();
+        let err = validate(&req, &cfg).unwrap_err();
+        assert_eq!(err.code(), "csrf_error");
+    }
+}

--- a/crates/ag-core/src/shield/mod.rs
+++ b/crates/ag-core/src/shield/mod.rs
@@ -15,6 +15,8 @@ mod cors;
 #[cfg(feature = "csrf")]
 mod csrf;
 mod logging;
+#[cfg(feature = "rate-limit")]
+mod rate_limit;
 #[cfg(feature = "validation")]
 pub mod validation;
 
@@ -32,6 +34,8 @@ pub struct Shield {
     config: ShieldConfig,
     #[cfg(feature = "cors")]
     cors_layer: Option<tower_http::cors::CorsLayer>,
+    #[cfg(feature = "rate-limit")]
+    rate_limit_layer: Option<rate_limit::RateLimitLayer>,
 }
 
 impl Shield {
@@ -49,10 +53,19 @@ impl Shield {
             None
         };
 
+        #[cfg(feature = "rate-limit")]
+        let rate_limit_layer = if config.rate_limit.enabled {
+            Some(rate_limit::RateLimitLayer::new(&config.rate_limit)?)
+        } else {
+            None
+        };
+
         Ok(Self {
             config,
             #[cfg(feature = "cors")]
             cors_layer,
+            #[cfg(feature = "rate-limit")]
+            rate_limit_layer,
         })
     }
 
@@ -97,6 +110,11 @@ impl Shield {
         #[cfg(feature = "cors")]
         if let Some(cors) = self.cors_layer.clone() {
             router = router.layer(cors);
+        }
+
+        #[cfg(feature = "rate-limit")]
+        if let Some(rl) = self.rate_limit_layer.clone() {
+            router = router.layer(rl);
         }
 
         router = router.layer(logging::LoggingLayer);

--- a/crates/ag-core/src/shield/mod.rs
+++ b/crates/ag-core/src/shield/mod.rs
@@ -1,15 +1,17 @@
 //! Capa Shield: pipeline Tower de middleware que protege el Core.
 //!
-//! En el bootstrap de Fase 1 (este PR) la pipeline solo aplica la
-//! capa de logging estructurado. Las capas restantes (TLS, JWT, rate
-//! limiting, validacion, CORS, CSRF) se anaden capa por capa en PRs
-//! posteriores. Vease `docs/rfc/RFC-0002-diseno-shield-mvp.md`.
+//! En Fase 1 la pipeline crece capa por capa segun el orden de
+//! `docs/rfc/RFC-0002-diseno-shield-mvp.md`. La API publica es
+//! `Shield::apply(router)` que recibe un `axum::Router` y devuelve el
+//! mismo router con todas las capas configuradas activas.
 
-use tower::layer::util::{Identity, Stack};
-use tower::ServiceBuilder;
+use axum::Router;
 
 use crate::config::ShieldConfig;
+use crate::error::AgResult;
 
+#[cfg(feature = "cors")]
+mod cors;
 mod logging;
 #[cfg(feature = "validation")]
 pub mod validation;
@@ -18,16 +20,49 @@ pub mod validation;
 pub use validation::{FieldError, Validate, ValidatedJson, ValidationErrors};
 
 /// Pipeline Shield configurable.
+///
+/// La construccion valida la configuracion (por ejemplo, formato de
+/// origenes CORS). Si la configuracion es invalida, `try_new` devuelve
+/// el error correspondiente y `new` entra en panic. Por convencion el
+/// arranque del proceso usa `try_new` para fallar rapido y limpio.
 #[derive(Debug, Clone)]
 pub struct Shield {
     config: ShieldConfig,
+    #[cfg(feature = "cors")]
+    cors_layer: Option<tower_http::cors::CorsLayer>,
 }
 
 impl Shield {
-    /// Construye un Shield desde la configuracion declarativa.
+    /// Construye un Shield validando la configuracion declarativa.
+    ///
+    /// # Errores
+    ///
+    /// Devuelve `AgError` si alguna seccion de la configuracion es
+    /// invalida en el momento del arranque.
+    pub fn try_new(config: ShieldConfig) -> AgResult<Self> {
+        #[cfg(feature = "cors")]
+        let cors_layer = if config.cors.enabled {
+            Some(cors::build_layer(&config.cors)?)
+        } else {
+            None
+        };
+
+        Ok(Self {
+            config,
+            #[cfg(feature = "cors")]
+            cors_layer,
+        })
+    }
+
+    /// Construye un Shield sin verificar la configuracion.
+    ///
+    /// # Panicos
+    ///
+    /// Entra en panic si la configuracion es invalida. Use `try_new`
+    /// si necesita manejar el error de forma estructurada.
     #[must_use]
     pub fn new(config: ShieldConfig) -> Self {
-        Self { config }
+        Self::try_new(config).expect("invalid shield configuration")
     }
 
     /// Construye un Shield con la configuracion por defecto.
@@ -42,15 +77,23 @@ impl Shield {
         &self.config
     }
 
-    /// Devuelve la capa Tower que se compone con un router Axum.
+    /// Aplica todas las capas configuradas al router.
     ///
-    /// La capa actual incluye unicamente logging estructurado. Las
-    /// siguientes capas se agregaran en orden definido por RFC-0002.
-    #[must_use]
-    pub fn layer(&self) -> Stack<logging::LoggingLayer, Identity> {
-        ServiceBuilder::new()
-            .layer(logging::LoggingLayer)
-            .into_inner()
+    /// El orden de aplicacion es relevante: la primera capa en
+    /// agregarse es la mas interna; la ultima es la mas externa, es
+    /// decir la primera en ver el request entrante. La capa de
+    /// logging es la mas externa para que todo request quede
+    /// trazado, incluso si es rechazado por otra capa.
+    pub fn apply(&self, router: Router) -> Router {
+        let mut router = router;
+
+        #[cfg(feature = "cors")]
+        if let Some(cors) = self.cors_layer.clone() {
+            router = router.layer(cors);
+        }
+
+        router = router.layer(logging::LoggingLayer);
+        router
     }
 }
 
@@ -65,8 +108,34 @@ mod tests {
     }
 
     #[test]
-    fn shield_layer_is_constructible() {
+    fn shield_apply_is_callable() {
         let shield = Shield::with_defaults();
-        let _layer = shield.layer();
+        let router = Router::<()>::new();
+        let _routed = shield.apply(router);
+    }
+
+    #[cfg(feature = "cors")]
+    #[test]
+    fn try_new_with_invalid_cors_fails() {
+        use crate::config::CorsConfig;
+        let cfg = ShieldConfig {
+            cors: CorsConfig {
+                enabled: true,
+                allow_origins: vec!["https://example.com".into()],
+                allow_methods: vec!["NOT A METHOD".into()],
+                allow_headers: vec![],
+                allow_credentials: false,
+            },
+            ..ShieldConfig::default()
+        };
+        let err = Shield::try_new(cfg).unwrap_err();
+        assert_eq!(err.code(), "cors_error");
+    }
+
+    #[cfg(feature = "cors")]
+    #[test]
+    fn try_new_with_disabled_cors_succeeds() {
+        let shield = Shield::try_new(ShieldConfig::default()).unwrap();
+        assert!(!shield.config().cors.enabled);
     }
 }

--- a/crates/ag-core/src/shield/mod.rs
+++ b/crates/ag-core/src/shield/mod.rs
@@ -12,6 +12,8 @@ use crate::error::AgResult;
 
 #[cfg(feature = "cors")]
 mod cors;
+#[cfg(feature = "csrf")]
+mod csrf;
 mod logging;
 #[cfg(feature = "validation")]
 pub mod validation;
@@ -86,6 +88,11 @@ impl Shield {
     /// trazado, incluso si es rechazado por otra capa.
     pub fn apply(&self, router: Router) -> Router {
         let mut router = router;
+
+        #[cfg(feature = "csrf")]
+        if self.config.csrf.enabled {
+            router = router.layer(csrf::CsrfLayer::new(self.config.csrf.clone()));
+        }
 
         #[cfg(feature = "cors")]
         if let Some(cors) = self.cors_layer.clone() {

--- a/crates/ag-core/src/shield/rate_limit.rs
+++ b/crates/ag-core/src/shield/rate_limit.rs
@@ -1,0 +1,248 @@
+//! Capa de rate limiting por IP con governor (token bucket).
+//!
+//! Mantiene un keyed rate limiter en memoria con clave `IpAddr` del
+//! cliente. Cuando un cliente excede `per_ip_rps` peticiones por
+//! segundo (con permiso de pico hasta `burst`), las peticiones
+//! adicionales se rechazan con `AgError::RateLimit` (status 429).
+//!
+//! La IP de origen se determina por el `SocketAddr` reportado por
+//! Axum a traves del extractor `ConnectInfo`. Cuando el server vive
+//! detras de un proxy de confianza que setea cabeceras como
+//! `X-Forwarded-For`, la resolucion correcta de la IP real se entrega
+//! por configuracion en una PR posterior.
+
+use std::future::Future;
+use std::net::{IpAddr, SocketAddr};
+use std::num::NonZeroU32;
+use std::pin::Pin;
+use std::sync::Arc;
+use std::task::{Context, Poll};
+
+use axum::extract::connect_info::ConnectInfo;
+use axum::extract::Request;
+use axum::response::{IntoResponse, Response};
+use governor::clock::DefaultClock;
+#[cfg(test)]
+use governor::state::{InMemoryState, NotKeyed};
+use governor::{Quota, RateLimiter};
+use pin_project_lite::pin_project;
+use tower::{Layer, Service};
+
+use crate::config::RateLimitConfig;
+use crate::error::AgError;
+
+type IpLimiter =
+    RateLimiter<IpAddr, governor::state::keyed::DashMapStateStore<IpAddr>, DefaultClock>;
+
+#[cfg(test)]
+type DirectLimiter = RateLimiter<NotKeyed, InMemoryState, DefaultClock>;
+
+/// Tower layer de rate limiting por IP.
+#[derive(Clone)]
+pub struct RateLimitLayer {
+    limiter: Arc<IpLimiter>,
+}
+
+impl std::fmt::Debug for RateLimitLayer {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("RateLimitLayer").finish_non_exhaustive()
+    }
+}
+
+impl RateLimitLayer {
+    /// Construye una capa con los parametros indicados.
+    ///
+    /// # Errores
+    ///
+    /// Devuelve `AgError::Config` si `per_ip_rps` o `burst` son 0.
+    pub fn new(config: &RateLimitConfig) -> Result<Self, AgError> {
+        let rps = NonZeroU32::new(config.per_ip_rps)
+            .ok_or_else(|| AgError::Config("rate_limit.per_ip_rps must be > 0".to_owned()))?;
+        let burst = NonZeroU32::new(config.burst)
+            .ok_or_else(|| AgError::Config("rate_limit.burst must be > 0".to_owned()))?;
+
+        let quota = Quota::per_second(rps).allow_burst(burst);
+        let limiter = RateLimiter::dashmap(quota);
+        Ok(Self {
+            limiter: Arc::new(limiter),
+        })
+    }
+
+    /// Acceso al limiter interno (uso interno y tests).
+    #[cfg(test)]
+    fn limiter(&self) -> Arc<IpLimiter> {
+        Arc::clone(&self.limiter)
+    }
+}
+
+impl<S> Layer<S> for RateLimitLayer {
+    type Service = RateLimitService<S>;
+
+    fn layer(&self, inner: S) -> Self::Service {
+        RateLimitService {
+            inner,
+            limiter: Arc::clone(&self.limiter),
+        }
+    }
+}
+
+/// Servicio Tower que aplica el rate limit.
+#[derive(Clone)]
+pub struct RateLimitService<S> {
+    inner: S,
+    limiter: Arc<IpLimiter>,
+}
+
+impl<S> std::fmt::Debug for RateLimitService<S> {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("RateLimitService").finish_non_exhaustive()
+    }
+}
+
+fn client_ip(req: &Request) -> Option<IpAddr> {
+    req.extensions()
+        .get::<ConnectInfo<SocketAddr>>()
+        .map(|ConnectInfo(addr)| addr.ip())
+}
+
+impl<S> Service<Request> for RateLimitService<S>
+where
+    S: Service<Request, Response = Response> + Clone + Send + 'static,
+    S::Future: Send + 'static,
+{
+    type Response = Response;
+    type Error = S::Error;
+    type Future = RateLimitFuture<S::Future>;
+
+    fn poll_ready(&mut self, cx: &mut Context<'_>) -> Poll<Result<(), Self::Error>> {
+        self.inner.poll_ready(cx)
+    }
+
+    fn call(&mut self, req: Request) -> Self::Future {
+        let Some(ip) = client_ip(&req) else {
+            // Sin informacion de IP no aplicamos rate limit: en este caso
+            // la pipeline va detras de un transporte que no expone IP
+            // (tests con TcpListener sin ConnectInfo, por ejemplo).
+            return RateLimitFuture {
+                state: RateLimitState::Inner {
+                    future: self.inner.call(req),
+                },
+            };
+        };
+
+        match self.limiter.check_key(&ip) {
+            Ok(()) => RateLimitFuture {
+                state: RateLimitState::Inner {
+                    future: self.inner.call(req),
+                },
+            },
+            Err(_) => RateLimitFuture {
+                state: RateLimitState::Reject {
+                    response: Some(AgError::RateLimit.into_response()),
+                },
+            },
+        }
+    }
+}
+
+pin_project! {
+    /// Future del servicio rate limit.
+    #[derive(Debug)]
+    pub struct RateLimitFuture<F> {
+        #[pin]
+        state: RateLimitState<F>,
+    }
+}
+
+pin_project! {
+    #[project = RateLimitStateProj]
+    #[derive(Debug)]
+    enum RateLimitState<F> {
+        Inner { #[pin] future: F },
+        Reject { response: Option<Response> },
+    }
+}
+
+impl<F, E> Future for RateLimitFuture<F>
+where
+    F: Future<Output = Result<Response, E>>,
+{
+    type Output = Result<Response, E>;
+
+    fn poll(self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Self::Output> {
+        let this = self.project();
+        match this.state.project() {
+            RateLimitStateProj::Inner { future } => future.poll(cx),
+            RateLimitStateProj::Reject { response } => {
+                let resp = response
+                    .take()
+                    .expect("polled RateLimitFuture after completion");
+                Poll::Ready(Ok(resp))
+            }
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::net::{IpAddr, Ipv4Addr};
+
+    fn cfg(rps: u32, burst: u32) -> RateLimitConfig {
+        RateLimitConfig {
+            enabled: true,
+            per_ip_rps: rps,
+            burst,
+        }
+    }
+
+    #[test]
+    fn zero_rps_returns_config_error() {
+        let err = RateLimitLayer::new(&cfg(0, 10)).unwrap_err();
+        assert_eq!(err.code(), "config_error");
+    }
+
+    #[test]
+    fn zero_burst_returns_config_error() {
+        let err = RateLimitLayer::new(&cfg(10, 0)).unwrap_err();
+        assert_eq!(err.code(), "config_error");
+    }
+
+    #[test]
+    fn valid_config_builds_layer() {
+        assert!(RateLimitLayer::new(&cfg(100, 200)).is_ok());
+    }
+
+    #[test]
+    fn limiter_allows_then_blocks_per_key() {
+        let layer = RateLimitLayer::new(&cfg(1, 2)).unwrap();
+        let limiter = layer.limiter();
+        let ip: IpAddr = IpAddr::V4(Ipv4Addr::new(10, 0, 0, 1));
+        // Burst de 2: las dos primeras pasan, la tercera rebota.
+        assert!(limiter.check_key(&ip).is_ok());
+        assert!(limiter.check_key(&ip).is_ok());
+        assert!(limiter.check_key(&ip).is_err());
+    }
+
+    #[test]
+    fn limiter_isolates_ips() {
+        let layer = RateLimitLayer::new(&cfg(1, 1)).unwrap();
+        let limiter = layer.limiter();
+        let ip_a: IpAddr = IpAddr::V4(Ipv4Addr::new(10, 0, 0, 1));
+        let ip_b: IpAddr = IpAddr::V4(Ipv4Addr::new(10, 0, 0, 2));
+        assert!(limiter.check_key(&ip_a).is_ok());
+        // ip_a agotada, ip_b sigue con cupo.
+        assert!(limiter.check_key(&ip_a).is_err());
+        assert!(limiter.check_key(&ip_b).is_ok());
+    }
+
+    #[test]
+    fn rejects_a_well_known_direct_limiter_too() {
+        // Sanity: comportamiento basico de governor sin nuestro wrapper.
+        let quota =
+            Quota::per_second(NonZeroU32::new(1).unwrap()).allow_burst(NonZeroU32::new(1).unwrap());
+        let limiter: DirectLimiter = RateLimiter::direct(quota);
+        assert!(limiter.check().is_ok());
+        assert!(limiter.check().is_err());
+    }
+}

--- a/crates/ag-core/tests/shield_cors.rs
+++ b/crates/ag-core/tests/shield_cors.rs
@@ -1,0 +1,116 @@
+//! Tests E2E de la capa CORS.
+
+#![cfg(feature = "cors")]
+
+use ag_core::config::CorsConfig;
+use ag_core::{Shield, ShieldConfig};
+use axum::routing::get;
+use axum::Router;
+use std::net::SocketAddr;
+
+async fn start_server(cors: CorsConfig) -> (SocketAddr, tokio::task::JoinHandle<()>) {
+    let config = ShieldConfig {
+        cors,
+        ..ShieldConfig::default()
+    };
+    let shield = Shield::try_new(config).unwrap();
+    let app = shield.apply(Router::new().route("/ping", get(|| async { "pong" })));
+
+    let listener = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
+    let addr = listener.local_addr().unwrap();
+    let handle = tokio::spawn(async move {
+        axum::serve(listener, app.into_make_service())
+            .await
+            .unwrap();
+    });
+    (addr, handle)
+}
+
+#[tokio::test]
+async fn cors_disabled_omits_headers() {
+    let cors = CorsConfig::default();
+    let (addr, handle) = start_server(cors).await;
+    let client = reqwest::Client::new();
+    let resp = client
+        .get(format!("http://{addr}/ping"))
+        .header("origin", "https://other.example")
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(resp.status(), reqwest::StatusCode::OK);
+    assert!(resp.headers().get("access-control-allow-origin").is_none());
+    handle.abort();
+}
+
+#[tokio::test]
+async fn cors_enabled_allows_listed_origin() {
+    let cors = CorsConfig {
+        enabled: true,
+        allow_origins: vec!["https://app.example.com".into()],
+        allow_methods: vec!["GET".into()],
+        allow_headers: vec!["content-type".into()],
+        allow_credentials: false,
+    };
+    let (addr, handle) = start_server(cors).await;
+    let client = reqwest::Client::new();
+    let resp = client
+        .get(format!("http://{addr}/ping"))
+        .header("origin", "https://app.example.com")
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(resp.status(), reqwest::StatusCode::OK);
+    let allow_origin = resp.headers().get("access-control-allow-origin").unwrap();
+    assert_eq!(allow_origin, "https://app.example.com");
+    handle.abort();
+}
+
+#[tokio::test]
+async fn cors_enabled_rejects_unlisted_origin() {
+    let cors = CorsConfig {
+        enabled: true,
+        allow_origins: vec!["https://app.example.com".into()],
+        allow_methods: vec!["GET".into()],
+        allow_headers: vec!["content-type".into()],
+        allow_credentials: false,
+    };
+    let (addr, handle) = start_server(cors).await;
+    let client = reqwest::Client::new();
+    let resp = client
+        .get(format!("http://{addr}/ping"))
+        .header("origin", "https://attacker.example")
+        .send()
+        .await
+        .unwrap();
+    // El request pasa (200 OK); pero el navegador rechaza por ausencia
+    // del header `access-control-allow-origin` para este origen.
+    assert_eq!(resp.status(), reqwest::StatusCode::OK);
+    assert!(resp.headers().get("access-control-allow-origin").is_none());
+    handle.abort();
+}
+
+#[tokio::test]
+async fn cors_preflight_options_returns_204_with_allow_methods() {
+    let cors = CorsConfig {
+        enabled: true,
+        allow_origins: vec!["https://app.example.com".into()],
+        allow_methods: vec!["GET".into(), "POST".into()],
+        allow_headers: vec!["content-type".into()],
+        allow_credentials: false,
+    };
+    let (addr, handle) = start_server(cors).await;
+    let client = reqwest::Client::new();
+    let resp = client
+        .request(reqwest::Method::OPTIONS, format!("http://{addr}/ping"))
+        .header("origin", "https://app.example.com")
+        .header("access-control-request-method", "POST")
+        .header("access-control-request-headers", "content-type")
+        .send()
+        .await
+        .unwrap();
+    assert!(resp.status().is_success());
+    let allow_methods = resp.headers().get("access-control-allow-methods").unwrap();
+    let methods_str = allow_methods.to_str().unwrap();
+    assert!(methods_str.contains("POST"));
+    handle.abort();
+}

--- a/crates/ag-core/tests/shield_csrf.rs
+++ b/crates/ag-core/tests/shield_csrf.rs
@@ -1,0 +1,129 @@
+//! Tests E2E de la capa CSRF (double-submit cookie).
+
+#![cfg(feature = "csrf")]
+
+use ag_core::config::CsrfConfig;
+use ag_core::{Shield, ShieldConfig};
+use axum::routing::{get, post};
+use axum::Router;
+use std::net::SocketAddr;
+
+async fn start_server(csrf: CsrfConfig) -> (SocketAddr, tokio::task::JoinHandle<()>) {
+    let config = ShieldConfig {
+        csrf,
+        ..ShieldConfig::default()
+    };
+    let shield = Shield::try_new(config).unwrap();
+    let app = shield.apply(
+        Router::new()
+            .route("/get", get(|| async { "ok-get" }))
+            .route("/post", post(|| async { "ok-post" })),
+    );
+
+    let listener = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
+    let addr = listener.local_addr().unwrap();
+    let handle = tokio::spawn(async move {
+        axum::serve(listener, app.into_make_service())
+            .await
+            .unwrap();
+    });
+    (addr, handle)
+}
+
+fn enabled_config() -> CsrfConfig {
+    CsrfConfig {
+        enabled: true,
+        ..CsrfConfig::default()
+    }
+}
+
+#[tokio::test]
+async fn get_request_skips_csrf_check() {
+    let (addr, handle) = start_server(enabled_config()).await;
+    let client = reqwest::Client::new();
+    let resp = client
+        .get(format!("http://{addr}/get"))
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(resp.status(), reqwest::StatusCode::OK);
+    assert_eq!(resp.text().await.unwrap(), "ok-get");
+    handle.abort();
+}
+
+#[tokio::test]
+async fn post_without_token_returns_403() {
+    let (addr, handle) = start_server(enabled_config()).await;
+    let client = reqwest::Client::new();
+    let resp = client
+        .post(format!("http://{addr}/post"))
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(resp.status(), reqwest::StatusCode::FORBIDDEN);
+    let body: serde_json::Value = resp.json().await.unwrap();
+    assert_eq!(body["code"], "csrf_error");
+    handle.abort();
+}
+
+#[tokio::test]
+async fn post_with_matching_header_and_cookie_passes() {
+    let (addr, handle) = start_server(enabled_config()).await;
+    let client = reqwest::Client::new();
+    let resp = client
+        .post(format!("http://{addr}/post"))
+        .header("x-csrf-token", "abc123")
+        .header("cookie", "ag_csrf=abc123")
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(resp.status(), reqwest::StatusCode::OK);
+    assert_eq!(resp.text().await.unwrap(), "ok-post");
+    handle.abort();
+}
+
+#[tokio::test]
+async fn post_with_mismatched_token_returns_403() {
+    let (addr, handle) = start_server(enabled_config()).await;
+    let client = reqwest::Client::new();
+    let resp = client
+        .post(format!("http://{addr}/post"))
+        .header("x-csrf-token", "header-value")
+        .header("cookie", "ag_csrf=cookie-value")
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(resp.status(), reqwest::StatusCode::FORBIDDEN);
+    handle.abort();
+}
+
+#[tokio::test]
+async fn post_with_only_header_returns_403() {
+    let (addr, handle) = start_server(enabled_config()).await;
+    let client = reqwest::Client::new();
+    let resp = client
+        .post(format!("http://{addr}/post"))
+        .header("x-csrf-token", "abc")
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(resp.status(), reqwest::StatusCode::FORBIDDEN);
+    handle.abort();
+}
+
+#[tokio::test]
+async fn csrf_disabled_lets_post_through() {
+    let cfg = CsrfConfig {
+        enabled: false,
+        ..CsrfConfig::default()
+    };
+    let (addr, handle) = start_server(cfg).await;
+    let client = reqwest::Client::new();
+    let resp = client
+        .post(format!("http://{addr}/post"))
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(resp.status(), reqwest::StatusCode::OK);
+    handle.abort();
+}

--- a/crates/ag-core/tests/shield_e2e.rs
+++ b/crates/ag-core/tests/shield_e2e.rs
@@ -10,10 +10,8 @@ use axum::Router;
 use std::net::SocketAddr;
 
 async fn start_server() -> (SocketAddr, tokio::task::JoinHandle<()>) {
-    let shield = Shield::new(ShieldConfig::default());
-    let app = Router::new()
-        .route("/hello", get(|| async { "hello, shield" }))
-        .layer(shield.layer());
+    let shield = Shield::try_new(ShieldConfig::default()).unwrap();
+    let app = shield.apply(Router::new().route("/hello", get(|| async { "hello, shield" })));
 
     let listener = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
     let addr = listener.local_addr().unwrap();

--- a/crates/ag-core/tests/shield_rate_limit.rs
+++ b/crates/ag-core/tests/shield_rate_limit.rs
@@ -1,0 +1,93 @@
+//! Tests E2E de la capa rate-limit (token bucket por IP).
+
+#![cfg(feature = "rate-limit")]
+
+use ag_core::config::RateLimitConfig;
+use ag_core::{Shield, ShieldConfig};
+use axum::routing::get;
+use axum::Router;
+use std::net::SocketAddr;
+
+async fn start_server(rl: RateLimitConfig) -> (SocketAddr, tokio::task::JoinHandle<()>) {
+    let config = ShieldConfig {
+        rate_limit: rl,
+        ..ShieldConfig::default()
+    };
+    let shield = Shield::try_new(config).unwrap();
+    let app = shield.apply(Router::new().route("/ping", get(|| async { "pong" })));
+
+    let listener = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
+    let addr = listener.local_addr().unwrap();
+    let handle = tokio::spawn(async move {
+        axum::serve(
+            listener,
+            app.into_make_service_with_connect_info::<SocketAddr>(),
+        )
+        .await
+        .unwrap();
+    });
+    (addr, handle)
+}
+
+#[tokio::test]
+async fn rate_limit_disabled_lets_all_requests_through() {
+    let rl = RateLimitConfig::default();
+    let (addr, handle) = start_server(rl).await;
+    let client = reqwest::Client::new();
+    for _ in 0..10 {
+        let resp = client
+            .get(format!("http://{addr}/ping"))
+            .send()
+            .await
+            .unwrap();
+        assert_eq!(resp.status(), reqwest::StatusCode::OK);
+    }
+    handle.abort();
+}
+
+#[tokio::test]
+async fn rate_limit_enabled_blocks_after_burst() {
+    let rl = RateLimitConfig {
+        enabled: true,
+        per_ip_rps: 1,
+        burst: 2,
+    };
+    let (addr, handle) = start_server(rl).await;
+    let client = reqwest::Client::builder().build().unwrap();
+
+    // Burst de 2: las primeras dos pasan inmediatamente.
+    for _ in 0..2 {
+        let resp = client
+            .get(format!("http://{addr}/ping"))
+            .send()
+            .await
+            .unwrap();
+        assert_eq!(resp.status(), reqwest::StatusCode::OK);
+    }
+
+    // La siguiente, sin esperar reposicion del bucket, debe rebotar.
+    let resp = client
+        .get(format!("http://{addr}/ping"))
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(resp.status(), reqwest::StatusCode::TOO_MANY_REQUESTS);
+    let body: serde_json::Value = resp.json().await.unwrap();
+    assert_eq!(body["code"], "rate_limit_exceeded");
+
+    handle.abort();
+}
+
+#[tokio::test]
+async fn invalid_rate_limit_config_fails_construction() {
+    let config = ShieldConfig {
+        rate_limit: RateLimitConfig {
+            enabled: true,
+            per_ip_rps: 0,
+            burst: 10,
+        },
+        ..ShieldConfig::default()
+    };
+    let err = Shield::try_new(config).unwrap_err();
+    assert_eq!(err.code(), "config_error");
+}

--- a/crates/ag-core/tests/shield_validation.rs
+++ b/crates/ag-core/tests/shield_validation.rs
@@ -38,10 +38,8 @@ async fn handler(ValidatedJson(project): ValidatedJson<NewProject>) -> String {
 }
 
 async fn start_server() -> (SocketAddr, tokio::task::JoinHandle<()>) {
-    let shield = Shield::new(ShieldConfig::default());
-    let app = Router::new()
-        .route("/projects", post(handler))
-        .layer(shield.layer());
+    let shield = Shield::try_new(ShieldConfig::default()).unwrap();
+    let app = shield.apply(Router::new().route("/projects", post(handler)));
 
     let listener = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
     let addr = listener.local_addr().unwrap();

--- a/docs/roadmap/STATUS.md
+++ b/docs/roadmap/STATUS.md
@@ -88,7 +88,7 @@ externas de Fase 0. El diseno de Shield esta fijado en
 - [x] Middleware de validacion de payload basico. Trait `Validate` y extractor `ValidatedJson<T>` bajo `shield::validation`.
 - [ ] Middleware de autenticacion JWT con verificacion Ed25519.
 - [ ] Middleware de rate limiting con governor.
-- [/] Middleware CORS y CSRF con defaults seguros. CORS implementado en `shield::cors`; CSRF pendiente.
+- [x] Middleware CORS y CSRF con defaults seguros. CORS en `shield::cors` y CSRF en `shield::csrf` (double-submit cookie apatrida).
 - [ ] Middleware de logging estructurado con `tracing`.
 - [ ] Configuracion minima desde archivo TOML.
 - [ ] Tests unitarios con cobertura >= 80% del crate.

--- a/docs/roadmap/STATUS.md
+++ b/docs/roadmap/STATUS.md
@@ -87,7 +87,7 @@ externas de Fase 0. El diseno de Shield esta fijado en
 - [ ] Terminacion TLS 1.3 con rustls.
 - [x] Middleware de validacion de payload basico. Trait `Validate` y extractor `ValidatedJson<T>` bajo `shield::validation`.
 - [ ] Middleware de autenticacion JWT con verificacion Ed25519.
-- [ ] Middleware de rate limiting con governor.
+- [x] Middleware de rate limiting con governor. Token bucket por IP en `shield::rate_limit`.
 - [x] Middleware CORS y CSRF con defaults seguros. CORS en `shield::cors` y CSRF en `shield::csrf` (double-submit cookie apatrida).
 - [ ] Middleware de logging estructurado con `tracing`.
 - [ ] Configuracion minima desde archivo TOML.

--- a/docs/roadmap/STATUS.md
+++ b/docs/roadmap/STATUS.md
@@ -88,7 +88,7 @@ externas de Fase 0. El diseno de Shield esta fijado en
 - [x] Middleware de validacion de payload basico. Trait `Validate` y extractor `ValidatedJson<T>` bajo `shield::validation`.
 - [ ] Middleware de autenticacion JWT con verificacion Ed25519.
 - [ ] Middleware de rate limiting con governor.
-- [ ] Middleware CORS y CSRF con defaults seguros.
+- [/] Middleware CORS y CSRF con defaults seguros. CORS implementado en `shield::cors`; CSRF pendiente.
 - [ ] Middleware de logging estructurado con `tracing`.
 - [ ] Configuracion minima desde archivo TOML.
 - [ ] Tests unitarios con cobertura >= 80% del crate.


### PR DESCRIPTION
## Resumen

<!-- Una linea, maximo 256 caracteres. Misma frase puede usarse como
     titulo de la PR. Sin emojis ni atribuciones a herramientas IA. -->

## Fase afectada

<!-- Fase 0, 1, ... 10. Vease docs/roadmap/. -->

## Tipo de cambio

- [ ] Documentacion
- [ ] Codigo
- [ ] Infraestructura o CI
- [ ] RFC nueva o actualizacion de RFC
- [ ] ADR nuevo
- [ ] Seguridad

## Documentos relacionados

- RFC: <!-- docs/rfc/RFC-XXXX-...md o N/A -->
- ADR: <!-- docs/adr/XXXX-...md o N/A -->
- Maestro afectado: <!-- docs/master/... o N/A -->

## Plan de prueba

<!-- Pasos concretos para verificar el cambio. Si aplica:
- cargo fmt --all -- --check
- cargo clippy --workspace --all-targets -- -D warnings
- cargo test --workspace
- cargo audit
- cargo deny check
-->

## Criterios de salida que avanza

<!-- Casillas concretas de docs/roadmap/STATUS.md que esta PR marca. -->

## Checklist

- [ ] Titulo de PR de 256 caracteres o menos.
- [ ] Sin emojis en ningun archivo modificado.
- [ ] Sin atribuciones de herramientas IA.
- [ ] Documentacion actualizada en el mismo PR.
- [ ] CHANGELOG.md actualizado bajo [Unreleased].
- [ ] CLAUDE.md respetado (alcance, fase, dependencias, seguridad).
