### PR TITLE
docs: descriptor PR pre-rellenado por rama y regla incorporada a CLAUDE.md

docs/pr-drafts/ alberga el descriptor por rama. Plantilla GitHub queda como fallback. Descriptor de phase-0/foundations-and-governance publicado y listo para copiar al cuerpo del PR.

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,11 +1,25 @@
+<!--
+  Esta plantilla es solo un fallback. Cada pull request del proyecto
+  trae su descriptor pre-rellenado en `docs/pr-drafts/<rama>.md`.
+  Antes de abrir el PR:
+    1. Localice `docs/pr-drafts/<nombre-de-rama>.md` en la rama.
+    2. Copie su contenido completo y peguelo aqui, reemplazando este
+       comentario y todas las secciones que siguen.
+    3. Verifique que el titulo del PR (campo de arriba en GitHub) no
+       excede 256 caracteres y coincide con el "Resumen" del
+       descriptor.
+  Si el descriptor no existe, hay que crearlo en el mismo commit que
+  abre la rama. Vease `docs/pr-drafts/README.md` para la convencion.
+-->
+
 ## Resumen
 
-<!-- Una linea, maximo 256 caracteres. Misma frase puede usarse como
-     titulo de la PR. Sin emojis ni atribuciones a herramientas IA. -->
+Una linea, maximo 256 caracteres. Misma frase usable como titulo del
+PR. Sin emojis ni atribuciones a herramientas IA.
 
 ## Fase afectada
 
-<!-- Fase 0, 1, ... 10. Vease docs/roadmap/. -->
+Fase N. Vease `docs/roadmap/`.
 
 ## Tipo de cambio
 
@@ -18,23 +32,22 @@
 
 ## Documentos relacionados
 
-- RFC: <!-- docs/rfc/RFC-XXXX-...md o N/A -->
-- ADR: <!-- docs/adr/XXXX-...md o N/A -->
-- Maestro afectado: <!-- docs/master/... o N/A -->
+- RFC: `docs/rfc/RFC-XXXX-...md` o N/A.
+- ADR: `docs/adr/XXXX-...md` o N/A.
+- Maestro afectado: `docs/master/...` o N/A.
 
 ## Plan de prueba
 
-<!-- Pasos concretos para verificar el cambio. Si aplica:
-- cargo fmt --all -- --check
-- cargo clippy --workspace --all-targets -- -D warnings
-- cargo test --workspace
-- cargo audit
-- cargo deny check
--->
+Comandos exactos que el revisor puede ejecutar para validar el cambio
+(por ejemplo `cargo fmt --all -- --check`,
+`cargo clippy --workspace --all-targets -- -D warnings`,
+`cargo test --workspace`, `cargo deny check`).
 
 ## Criterios de salida que avanza
 
-<!-- Casillas concretas de docs/roadmap/STATUS.md que esta PR marca. -->
+Casillas concretas de `docs/roadmap/STATUS.md` que esta PR marca,
+copiadas con su estado actualizado (`[x]` para las completas,
+`[/]` para las parciales con explicacion).
 
 ## Checklist
 
@@ -42,5 +55,6 @@
 - [ ] Sin emojis en ningun archivo modificado.
 - [ ] Sin atribuciones de herramientas IA.
 - [ ] Documentacion actualizada en el mismo PR.
-- [ ] CHANGELOG.md actualizado bajo [Unreleased].
+- [ ] CHANGELOG.md actualizado bajo `[Unreleased]`.
 - [ ] CLAUDE.md respetado (alcance, fase, dependencias, seguridad).
+- [ ] Descriptor pre-rellenado existe en `docs/pr-drafts/`.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -141,6 +141,13 @@ Cambiado:
 - Migracion de `rustls-pemfile` (archivado, RUSTSEC-2025-0134) al
   trait `PemObject` de `rustls-pki-types`. La superficie de API
   publica no se altera.
+- Flujo de pull requests: cada rama trae su descriptor pre-rellenado
+  bajo `docs/pr-drafts/<rama>.md` con resumen, fase, plan de prueba y
+  criterios de salida ya completos. La plantilla
+  `.github/PULL_REQUEST_TEMPLATE.md` se convierte en fallback de
+  emergencia. Regla incorporada a `CLAUDE.md` y `CONTRIBUTING.md`.
+  Descriptor de la rama `phase-0/foundations-and-governance` publicado
+  en `docs/pr-drafts/phase-0-foundations-and-governance.md`.
 
 Cambiado:
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -124,6 +124,23 @@ Anadido:
   incluyendo expiracion, firma incorrecta y issuer no esperado.
 - Dev-dependencies `ed25519-dalek = 2` y `rand_core = 0.6` para
   generar pares de claves Ed25519 en tests.
+- Capa TLS 1.3 (`shield::tls`) detras de la feature `tls` activa por
+  defecto. Construye un `tokio_rustls::TlsAcceptor` desde cert/key
+  PEM declarados en `TlsConfig`. Provider criptografico: `ring`.
+  Cuando la feature `tls` esta presente y `TlsConfig.enabled` es
+  cierto, `Shield::serve(listener, router)` opera el accept loop
+  envolviendo cada conexion con TLS; en otro caso delega a
+  `axum::serve`. Errores de carga mapeados a `AgError::Tls`.
+  Dependencias opcionales `rustls = 0.23`, `rustls-pki-types = 1.10`,
+  `tokio-rustls = 0.26`. Dev-dependency `rcgen = 0.13` para generar
+  certificados auto-firmados en tests. 4 unit tests sobre carga de
+  PEM y 3 tests E2E incluyendo handshake HTTPS real con reqwest.
+
+Cambiado:
+
+- Migracion de `rustls-pemfile` (archivado, RUSTSEC-2025-0134) al
+  trait `PemObject` de `rustls-pki-types`. La superficie de API
+  publica no se altera.
 
 Cambiado:
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -109,6 +109,21 @@ Anadido:
   deshabilitada por defecto, configuracion validada al construir
   Shield. Dependencia opcional `governor = 0.7`. 6 unit tests y 3
   tests E2E.
+- Capa de autenticacion JWT Ed25519 (`shield::auth`) detras de la
+  feature `auth-jwt` activa por defecto. Verifica el header
+  `Authorization: Bearer <token>` contra una clave publica Ed25519
+  cargada al arranque desde `AuthConfig.public_key_pem` o
+  `public_key_path`. Valida firma, expiracion, issuer opcional y
+  audience opcional. Leeway forzado a 0 para evitar tolerancia
+  silenciosa a deriva de reloj. Inyecta `AuthContext` en las
+  extensiones del request; expone el extractor `Claims<T>` que
+  deserializa los claims al tipo de la aplicacion. Fallos mapeados a
+  `AgError::Auth` (status 401). Dependencia opcional
+  `jsonwebtoken = 9` con feature `use_pem`. 6 unit tests sobre
+  parsing y carga de claves y 6 tests E2E sobre flujo completo,
+  incluyendo expiracion, firma incorrecta y issuer no esperado.
+- Dev-dependencies `ed25519-dalek = 2` y `rand_core = 0.6` para
+  generar pares de claves Ed25519 en tests.
 
 Cambiado:
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -879,6 +879,24 @@ una herramienta IA. Esto incluye:
 El trabajo se atribuye unicamente a personas humanas y a la
 organizacion responsable.
 
+### Descriptor pre-rellenado por PR
+
+Toda rama que vaya a producir una pull request acompana sus commits
+con un descriptor pre-rellenado bajo
+`docs/pr-drafts/<nombre-de-rama>.md`. El descriptor contiene el
+resumen final (titulo del PR), fase afectada, tipo de cambio,
+documentos relacionados, plan de prueba, criterios de salida que
+avanza y checklist final, todo con valores concretos en lugar de los
+placeholders de la plantilla.
+
+La plantilla en `.github/PULL_REQUEST_TEMPLATE.md` es un fallback
+para casos excepcionales. En operacion normal, el cuerpo del PR es la
+copia del descriptor pre-rellenado. Esta regla evita PRs sin contexto
+y deja trazabilidad permanente del razonamiento del cambio.
+
+Si un agente o colaborador commitea sin actualizar el descriptor
+correspondiente, la PR no se acepta.
+
 ### Prohibicion absoluta de emojis
 
 No se usan emojis en ningun lugar del proyecto: ni en documentacion, ni

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -36,16 +36,24 @@ Contributions in Spanish and English are equally welcome.
    `claude/...`, `gpt/...`, `ai/...`.
 2. Mantenga el cambio pequeno y enfocado. Una unidad logica por pull
    request. Si hace falta dividir, divida.
-3. Asegurese de que pasa `cargo fmt --all -- --check`,
+3. Cree o actualice el descriptor pre-rellenado del PR en
+   `docs/pr-drafts/<nombre-de-rama>.md`. Sin descriptor, el PR no se
+   acepta. Vease `docs/pr-drafts/README.md` para la convencion. La
+   plantilla en `.github/PULL_REQUEST_TEMPLATE.md` es un fallback;
+   el contenido real vive en el descriptor.
+4. Asegurese de que pasa `cargo fmt --all -- --check`,
    `cargo clippy --workspace --all-targets -- -D warnings`,
    `cargo test --workspace`, `cargo audit` y `cargo deny check`.
-4. Actualice la documentacion en el mismo pull request. Codigo y
+5. Actualice la documentacion en el mismo pull request. Codigo y
    documentacion evolucionan juntos.
-5. Actualice `CHANGELOG.md` bajo la seccion `[Unreleased]`.
-6. Verifique las casillas de la `docs/roadmap/STATUS.md` que su pull
+6. Actualice `CHANGELOG.md` bajo la seccion `[Unreleased]`.
+7. Verifique las casillas de la `docs/roadmap/STATUS.md` que su pull
    request afecta.
-7. Abra el pull request con titulo de 256 caracteres o menos.
-8. En el cuerpo del PR enlace a la RFC o ADR relacionada cuando aplique.
+8. Al abrir el pull request, copie el contenido de
+   `docs/pr-drafts/<nombre-de-rama>.md` al cuerpo del PR en GitHub,
+   reemplazando el fallback de la plantilla. El titulo del PR es el
+   campo "Resumen" del descriptor (256 caracteres o menos).
+9. En el cuerpo del PR enlace a la RFC o ADR relacionada cuando aplique.
 
 ## Convenciones de mensajes
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -37,11 +37,15 @@ dependencies = [
  "jsonwebtoken",
  "pin-project-lite",
  "rand_core 0.6.4",
+ "rcgen",
  "reqwest",
+ "rustls",
+ "rustls-pki-types",
  "serde",
  "serde_json",
  "thiserror 1.0.69",
  "tokio",
+ "tokio-rustls",
  "tokio-test",
  "toml",
  "tower",
@@ -1269,6 +1273,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "rcgen"
+version = "0.13.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "75e669e5202259b5314d1ea5397316ad400819437857b90861765f24c4cf80a2"
+dependencies = [
+ "pem",
+ "ring",
+ "rustls-pki-types",
+ "time",
+ "yasna",
+]
+
+[[package]]
 name = "redox_syscall"
 version = "0.5.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2489,6 +2506,15 @@ name = "writeable"
 version = "0.6.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1ffae5123b2d3fc086436f8834ae3ab053a283cfac8fe0a0b8eaae044768a4c4"
+
+[[package]]
+name = "yasna"
+version = "0.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e17bb3549cc1321ae1296b9cdc2698e2b6cb1992adfa19a8c72e5b7a738f44cd"
+dependencies = [
+ "time",
+]
 
 [[package]]
 name = "yoke"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -28,12 +28,15 @@ version = "0.0.0"
 dependencies = [
  "axum",
  "bytes",
+ "ed25519-dalek",
  "governor",
  "http",
  "http-body-util",
  "hyper",
  "hyper-util",
+ "jsonwebtoken",
  "pin-project-lite",
+ "rand_core 0.6.4",
  "reqwest",
  "serde",
  "serde_json",
@@ -116,6 +119,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1505bd5d3d116872e7271a6d4e16d81d0c8570876c8de68093a09ac269d8aac0"
 
 [[package]]
+name = "autocfg"
+version = "1.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c08606f8c3cbf4ce6ec8e28fb0014a2c086708fe954eaa885384a6165172e7e8"
+
+[[package]]
 name = "axum"
 version = "0.7.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -174,10 +183,25 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "72b3254f16251a8381aa12e40e3c4d2f0199f8c6508fbecb9d91f575e0fbb8c6"
 
 [[package]]
+name = "base64ct"
+version = "1.8.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2af50177e190e07a26ab74f8b1efbfe2ef87da2116221318cb1c2e82baf7de06"
+
+[[package]]
 name = "bitflags"
 version = "2.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c4512299f36f043ab09a583e57bceb5a5aab7a73db1805848e8fef3c9e8c78b3"
+
+[[package]]
+name = "block-buffer"
+version = "0.10.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3078c7629b62d3f0439517fa394996acacc5cbc91c5a20d8c658e77abd503a71"
+dependencies = [
+ "generic-array",
+]
 
 [[package]]
 name = "bumpalo"
@@ -214,10 +238,62 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "613afe47fcd5fac7ccf1db93babcb082c5994d996f20b8b159f2ad1658eb5724"
 
 [[package]]
+name = "const-oid"
+version = "0.9.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c2459377285ad874054d797f3ccebf984978aa39129f6eafde5cdc8315b612f8"
+
+[[package]]
+name = "cpufeatures"
+version = "0.2.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "59ed5838eebb26a2bb2e58f6d5b5316989ae9d08bab10e0e6d103e656d1b0280"
+dependencies = [
+ "libc",
+]
+
+[[package]]
 name = "crossbeam-utils"
 version = "0.8.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d0a5c400df2834b80a4c3327b3aad3a4c4cd4de0629063962b03235697506a28"
+
+[[package]]
+name = "crypto-common"
+version = "0.1.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "78c8292055d1c1df0cce5d180393dc8cce0abec0a7102adb6c7b1eef6016d60a"
+dependencies = [
+ "generic-array",
+ "typenum",
+]
+
+[[package]]
+name = "curve25519-dalek"
+version = "4.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "97fb8b7c4503de7d6ae7b42ab72a5a59857b4c937ec27a3d4539dba95b5ab2be"
+dependencies = [
+ "cfg-if",
+ "cpufeatures",
+ "curve25519-dalek-derive",
+ "digest",
+ "fiat-crypto",
+ "rustc_version",
+ "subtle",
+ "zeroize",
+]
+
+[[package]]
+name = "curve25519-dalek-derive"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f46882e17999c6cc590af592290432be3bce0428cb0d5f8b6715e4dc7b383eb3"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
 
 [[package]]
 name = "dashmap"
@@ -234,6 +310,36 @@ dependencies = [
 ]
 
 [[package]]
+name = "der"
+version = "0.7.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e7c1832837b905bbfb5101e07cc24c8deddf52f93225eee6ead5f4d63d53ddcb"
+dependencies = [
+ "const-oid",
+ "pem-rfc7468",
+ "zeroize",
+]
+
+[[package]]
+name = "deranged"
+version = "0.5.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7cd812cc2bc1d69d4764bd80df88b4317eaef9e773c75226407d9bc0876b211c"
+dependencies = [
+ "powerfmt",
+]
+
+[[package]]
+name = "digest"
+version = "0.10.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9ed9a281f7bc9b7576e61468ba615a66a5c8cfdff42420a70aa82701a3b1e292"
+dependencies = [
+ "block-buffer",
+ "crypto-common",
+]
+
+[[package]]
 name = "displaydoc"
 version = "0.2.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -242,6 +348,30 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn",
+]
+
+[[package]]
+name = "ed25519"
+version = "2.2.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "115531babc129696a58c64a4fef0a8bf9e9698629fb97e9e40767d235cfbcd53"
+dependencies = [
+ "pkcs8",
+ "signature",
+]
+
+[[package]]
+name = "ed25519-dalek"
+version = "2.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "70e796c081cee67dc755e1a36a0a172b897fab85fc3f6bc48307991f64e4eca9"
+dependencies = [
+ "curve25519-dalek",
+ "ed25519",
+ "serde",
+ "sha2",
+ "subtle",
+ "zeroize",
 ]
 
 [[package]]
@@ -259,6 +389,12 @@ dependencies = [
  "libc",
  "windows-sys 0.61.2",
 ]
+
+[[package]]
+name = "fiat-crypto"
+version = "0.2.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "28dea519a9695b9977216879a3ebfddf92f1c08c05d984f8996aecd6ecdc811d"
 
 [[package]]
 name = "find-msvc-tools"
@@ -331,6 +467,16 @@ dependencies = [
  "futures-task",
  "pin-project-lite",
  "slab",
+]
+
+[[package]]
+name = "generic-array"
+version = "0.14.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "85649ca51fd72272d7821adaf274ad91c288277713d9c18820d8499a7ff69e9a"
+dependencies = [
+ "typenum",
+ "version_check",
 ]
 
 [[package]]
@@ -692,6 +838,21 @@ dependencies = [
 ]
 
 [[package]]
+name = "jsonwebtoken"
+version = "9.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5a87cc7a48537badeae96744432de36f4be2b4a34a05a5ef32e9dd8a1c169dde"
+dependencies = [
+ "base64",
+ "js-sys",
+ "pem",
+ "ring",
+ "serde",
+ "serde_json",
+ "simple_asn1",
+]
+
+[[package]]
 name = "lazy_static"
 version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -796,6 +957,40 @@ dependencies = [
 ]
 
 [[package]]
+name = "num-bigint"
+version = "0.4.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a5e44f723f1133c9deac646763579fdb3ac745e418f2a7af9cd0c431da1f20b9"
+dependencies = [
+ "num-integer",
+ "num-traits",
+]
+
+[[package]]
+name = "num-conv"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "521739c6d2bac4aa25192232afe6841231376b2b26d4d9fae5ecf8ca5772e441"
+
+[[package]]
+name = "num-integer"
+version = "0.1.46"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7969661fd2958a5cb096e56c8e1ad0444ac2bbcd0061bd28660485a44879858f"
+dependencies = [
+ "num-traits",
+]
+
+[[package]]
+name = "num-traits"
+version = "0.2.19"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "071dfc062690e90b734c0b2273ce72ad0ffa95f0c74596bc250dcfd960262841"
+dependencies = [
+ "autocfg",
+]
+
+[[package]]
 name = "once_cell"
 version = "1.21.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -825,6 +1020,25 @@ dependencies = [
 ]
 
 [[package]]
+name = "pem"
+version = "3.0.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1d30c53c26bc5b31a98cd02d20f25a7c8567146caf63ed593a9d87b2775291be"
+dependencies = [
+ "base64",
+ "serde_core",
+]
+
+[[package]]
+name = "pem-rfc7468"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "88b39c9bfcfc231068454382784bb460aae594343fb030d46e9f50a645418412"
+dependencies = [
+ "base64ct",
+]
+
+[[package]]
 name = "percent-encoding"
 version = "2.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -835,6 +1049,16 @@ name = "pin-project-lite"
 version = "0.2.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a89322df9ebe1c1578d689c92318e070967d1042b512afbe49518723f4e6d5cd"
+
+[[package]]
+name = "pkcs8"
+version = "0.10.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f950b2377845cebe5cf8b5165cb3cc1a5e0fa5cfa3e1f7f55707d8fd82e0a7b7"
+dependencies = [
+ "der",
+ "spki",
+]
 
 [[package]]
 name = "portable-atomic"
@@ -850,6 +1074,12 @@ checksum = "0103b1cef7ec0cf76490e969665504990193874ea05c85ff9bab8b911d0a0564"
 dependencies = [
  "zerovec",
 ]
+
+[[package]]
+name = "powerfmt"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "439ee305def115ba05938db6eb1644ff94165c5ab5e9420d1c1bcedbba909391"
 
 [[package]]
 name = "ppv-lite86"
@@ -1123,6 +1353,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "94300abf3f1ae2e2b8ffb7b58043de3d399c73fa6f4b73826402a5c457614dbe"
 
 [[package]]
+name = "rustc_version"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cfcb3a22ef46e85b45de6ee7e79d063319ebb6594faafcf1c225ea92ab6e9b92"
+dependencies = [
+ "semver",
+]
+
+[[package]]
 name = "rustls"
 version = "0.23.40"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1257,6 +1496,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "sha2"
+version = "0.10.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a7507d819769d01a365ab707794a4084392c824f54a7a6a7862f8c3d0892b283"
+dependencies = [
+ "cfg-if",
+ "cpufeatures",
+ "digest",
+]
+
+[[package]]
 name = "sharded-slab"
 version = "0.1.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1279,6 +1529,27 @@ checksum = "c4db69cba1110affc0e9f7bcd48bbf87b3f4fc7c61fc9155afd4c469eb3d6c1b"
 dependencies = [
  "errno",
  "libc",
+]
+
+[[package]]
+name = "signature"
+version = "2.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "77549399552de45a898a580c1b41d445bf730df867cc44e6c0233bbc4b8329de"
+dependencies = [
+ "rand_core 0.6.4",
+]
+
+[[package]]
+name = "simple_asn1"
+version = "0.6.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0d585997b0ac10be3c5ee635f1bab02d512760d14b7c468801ac8a01d9ae5f1d"
+dependencies = [
+ "num-bigint",
+ "num-traits",
+ "thiserror 2.0.18",
+ "time",
 ]
 
 [[package]]
@@ -1310,6 +1581,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d96d2d1d716fb500937168cc09353ffdc7a012be8475ac7308e1bdf0e3923300"
 dependencies = [
  "lock_api",
+]
+
+[[package]]
+name = "spki"
+version = "0.7.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d91ed6c858b01f942cd56b37a94b3e0a1798290327d1236e4d9cf4eaca44d29d"
+dependencies = [
+ "base64ct",
+ "der",
 ]
 
 [[package]]
@@ -1402,6 +1683,37 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f60246a4944f24f6e018aa17cdeffb7818b76356965d03b07d6a9886e8962185"
 dependencies = [
  "cfg-if",
+]
+
+[[package]]
+name = "time"
+version = "0.3.47"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "743bd48c283afc0388f9b8827b976905fb217ad9e647fae3a379a9283c4def2c"
+dependencies = [
+ "deranged",
+ "itoa",
+ "num-conv",
+ "powerfmt",
+ "serde_core",
+ "time-core",
+ "time-macros",
+]
+
+[[package]]
+name = "time-core"
+version = "0.1.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7694e1cfe791f8d31026952abf09c69ca6f6fa4e1a1229e18988f06a04a12dca"
+
+[[package]]
+name = "time-macros"
+version = "0.2.27"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2e70e4c5a0e0a8a4823ad65dfe1a6930e4f4d756dcd9dd7939022b5e8c501215"
+dependencies = [
+ "num-conv",
+ "time-core",
 ]
 
 [[package]]
@@ -1670,6 +1982,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e421abadd41a4225275504ea4d6566923418b7f05506fbc9c0fe86ba7396114b"
 
 [[package]]
+name = "typenum"
+version = "1.20.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "40ce102ab67701b8526c123c1bab5cbe42d7040ccfd0f64af1a385808d2f43de"
+
+[[package]]
 name = "unicode-ident"
 version = "1.0.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1721,6 +2039,12 @@ name = "valuable"
 version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ba73ea9cf16a25df0c8caa16c51acb937d5712a8429db78a3ee29d5dcacd3a65"
+
+[[package]]
+name = "version_check"
+version = "0.9.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0b928f33d975fc6ad9f86c8f283853ad26bdd5b10b7f1542aa2fa15e2289105a"
 
 [[package]]
 name = "want"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -41,6 +41,7 @@ axum = { version = "0.7", default-features = false, features = ["http1", "http2"
 bytes = "1"
 governor = "0.7"
 http = "1"
+jsonwebtoken = { version = "9", default-features = false, features = ["use_pem"] }
 http-body-util = "0.1"
 hyper = { version = "1.4", features = ["http1", "http2"] }
 hyper-util = { version = "0.1", features = ["tokio", "server", "server-graceful", "http1", "http2"] }
@@ -56,6 +57,8 @@ tracing = "0.1"
 tracing-subscriber = { version = "0.3", features = ["env-filter", "fmt", "json"] }
 
 # Dev-dependencies compartidas.
+ed25519-dalek = { version = "2", features = ["pkcs8", "pem"] }
+rand_core = { version = "0.6", features = ["getrandom"] }
 reqwest = { version = "0.12", default-features = false, features = ["rustls-tls", "json"] }
 tokio-test = "0.4"
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -42,6 +42,9 @@ bytes = "1"
 governor = "0.7"
 http = "1"
 jsonwebtoken = { version = "9", default-features = false, features = ["use_pem"] }
+rustls = { version = "0.23", default-features = false, features = ["std", "tls12", "ring"] }
+rustls-pki-types = { version = "1.10", features = ["std"] }
+tokio-rustls = { version = "0.26", default-features = false, features = ["ring"] }
 http-body-util = "0.1"
 hyper = { version = "1.4", features = ["http1", "http2"] }
 hyper-util = { version = "0.1", features = ["tokio", "server", "server-graceful", "http1", "http2"] }
@@ -59,6 +62,7 @@ tracing-subscriber = { version = "0.3", features = ["env-filter", "fmt", "json"]
 # Dev-dependencies compartidas.
 ed25519-dalek = { version = "2", features = ["pkcs8", "pem"] }
 rand_core = { version = "0.6", features = ["getrandom"] }
+rcgen = "0.13"
 reqwest = { version = "0.12", default-features = false, features = ["rustls-tls", "json"] }
 tokio-test = "0.4"
 

--- a/crates/ag-core/Cargo.toml
+++ b/crates/ag-core/Cargo.toml
@@ -22,8 +22,8 @@ workspace = true
 # Las capas TLS, JWT y rate-limit llegan en PRs posteriores y por ahora
 # las features simplemente reservan los nombres y compilan vacias.
 [features]
-default = ["validation", "cors", "csrf", "logging", "rate-limit", "auth-jwt"]
-tls = []
+default = ["validation", "cors", "csrf", "logging", "rate-limit", "auth-jwt", "tls"]
+tls = ["dep:rustls", "dep:rustls-pki-types", "dep:tokio-rustls"]
 auth-jwt = ["dep:jsonwebtoken"]
 rate-limit = ["dep:governor"]
 validation = []
@@ -37,6 +37,9 @@ bytes = { workspace = true }
 governor = { workspace = true, optional = true }
 http = { workspace = true }
 jsonwebtoken = { workspace = true, optional = true }
+rustls = { workspace = true, optional = true }
+rustls-pki-types = { workspace = true, optional = true }
+tokio-rustls = { workspace = true, optional = true }
 http-body-util = { workspace = true }
 hyper = { workspace = true }
 hyper-util = { workspace = true }
@@ -54,6 +57,7 @@ tracing-subscriber = { workspace = true }
 [dev-dependencies]
 ed25519-dalek = { workspace = true }
 rand_core = { workspace = true }
+rcgen = { workspace = true }
 reqwest = { workspace = true }
 tokio = { workspace = true, features = ["test-util"] }
 tokio-test = { workspace = true }

--- a/crates/ag-core/Cargo.toml
+++ b/crates/ag-core/Cargo.toml
@@ -22,9 +22,9 @@ workspace = true
 # Las capas TLS, JWT y rate-limit llegan en PRs posteriores y por ahora
 # las features simplemente reservan los nombres y compilan vacias.
 [features]
-default = ["validation", "cors", "csrf", "logging", "rate-limit"]
+default = ["validation", "cors", "csrf", "logging", "rate-limit", "auth-jwt"]
 tls = []
-auth-jwt = []
+auth-jwt = ["dep:jsonwebtoken"]
 rate-limit = ["dep:governor"]
 validation = []
 cors = []
@@ -36,6 +36,7 @@ axum = { workspace = true }
 bytes = { workspace = true }
 governor = { workspace = true, optional = true }
 http = { workspace = true }
+jsonwebtoken = { workspace = true, optional = true }
 http-body-util = { workspace = true }
 hyper = { workspace = true }
 hyper-util = { workspace = true }
@@ -51,6 +52,8 @@ tracing = { workspace = true }
 tracing-subscriber = { workspace = true }
 
 [dev-dependencies]
+ed25519-dalek = { workspace = true }
+rand_core = { workspace = true }
 reqwest = { workspace = true }
 tokio = { workspace = true, features = ["test-util"] }
 tokio-test = { workspace = true }

--- a/crates/ag-core/src/config/mod.rs
+++ b/crates/ag-core/src/config/mod.rs
@@ -37,6 +37,10 @@ pub struct ShieldConfig {
     /// Configuracion de autenticacion JWT Ed25519.
     #[serde(default)]
     pub auth: AuthConfig,
+
+    /// Configuracion TLS 1.3.
+    #[serde(default)]
+    pub tls: TlsConfig,
 }
 
 impl Default for ShieldConfig {
@@ -48,8 +52,32 @@ impl Default for ShieldConfig {
             csrf: CsrfConfig::default(),
             rate_limit: RateLimitConfig::default(),
             auth: AuthConfig::default(),
+            tls: TlsConfig::default(),
         }
     }
+}
+
+/// Configuracion TLS 1.3.
+///
+/// Por defecto deshabilitada para no exigir certificado en
+/// desarrollo. Cuando se activa, `cert_path` y `key_path` deben
+/// apuntar a archivos PEM con la cadena de certificados y la clave
+/// privada respectivamente. Cuando el server vive detras de un
+/// balanceador que termina TLS (Cloudflare, AWS ALB, Nginx) la capa
+/// se deja deshabilitada.
+#[derive(Debug, Clone, Default, Serialize, Deserialize)]
+pub struct TlsConfig {
+    /// Activa la capa TLS.
+    #[serde(default)]
+    pub enabled: bool,
+
+    /// Ruta al archivo PEM con la cadena de certificados.
+    #[serde(default)]
+    pub cert_path: Option<std::path::PathBuf>,
+
+    /// Ruta al archivo PEM con la clave privada (PKCS#8, RSA o EC).
+    #[serde(default)]
+    pub key_path: Option<std::path::PathBuf>,
 }
 
 /// Configuracion CORS.

--- a/crates/ag-core/src/config/mod.rs
+++ b/crates/ag-core/src/config/mod.rs
@@ -33,6 +33,10 @@ pub struct ShieldConfig {
     /// Configuracion de rate limiting por IP.
     #[serde(default)]
     pub rate_limit: RateLimitConfig,
+
+    /// Configuracion de autenticacion JWT Ed25519.
+    #[serde(default)]
+    pub auth: AuthConfig,
 }
 
 impl Default for ShieldConfig {
@@ -43,6 +47,7 @@ impl Default for ShieldConfig {
             cors: CorsConfig::default(),
             csrf: CsrfConfig::default(),
             rate_limit: RateLimitConfig::default(),
+            auth: AuthConfig::default(),
         }
     }
 }
@@ -151,6 +156,42 @@ const fn default_per_ip_rps() -> u32 {
 
 const fn default_burst() -> u32 {
     200
+}
+
+/// Configuracion de autenticacion JWT Ed25519.
+///
+/// Por defecto deshabilitada. Cuando se activa, la pipeline exige un
+/// header `Authorization: Bearer <token>` valido en todas las
+/// peticiones que la capa Auth cubre. La clave publica se entrega como
+/// PEM inline (`public_key_pem`) o como ruta (`public_key_path`).
+///
+/// Opcionalmente se valida que el claim `iss` coincida con
+/// `expected_issuer` y que `aud` contenga `expected_audience`.
+#[derive(Debug, Clone, Default, Serialize, Deserialize)]
+pub struct AuthConfig {
+    /// Activa la capa de autenticacion JWT.
+    #[serde(default)]
+    pub enabled: bool,
+
+    /// Clave publica Ed25519 en formato PEM. Mutuamente excluyente con
+    /// `public_key_path`.
+    #[serde(default)]
+    pub public_key_pem: Option<String>,
+
+    /// Ruta a un archivo PEM con la clave publica Ed25519. Mutuamente
+    /// excluyente con `public_key_pem`.
+    #[serde(default)]
+    pub public_key_path: Option<std::path::PathBuf>,
+
+    /// Issuer esperado en el claim `iss`. `None` desactiva la
+    /// verificacion.
+    #[serde(default)]
+    pub expected_issuer: Option<String>,
+
+    /// Audience esperado en el claim `aud`. `None` desactiva la
+    /// verificacion.
+    #[serde(default)]
+    pub expected_audience: Option<String>,
 }
 
 impl ShieldConfig {

--- a/crates/ag-core/src/shield/auth.rs
+++ b/crates/ag-core/src/shield/auth.rs
@@ -1,0 +1,335 @@
+//! Capa de autenticacion JWT Ed25519.
+//!
+//! Verifica el header `Authorization: Bearer <token>` con una clave
+//! publica Ed25519 cargada al arranque. Valida la firma, la expiracion
+//! y opcionalmente el issuer y la audience declarados en
+//! `AuthConfig`. Cuando la verificacion tiene exito, los claims se
+//! adjuntan a las extensiones del request y los handlers pueden
+//! consumirlos via el extractor `Claims<T>` declarado al final del
+//! modulo.
+//!
+//! Fallos producen `AgError::Auth` con status 401.
+
+use std::future::Future;
+use std::pin::Pin;
+use std::sync::Arc;
+use std::task::{Context, Poll};
+
+use axum::async_trait;
+use axum::extract::{FromRequestParts, Request};
+use axum::http::header::AUTHORIZATION;
+use axum::http::request::Parts;
+use axum::response::{IntoResponse, Response};
+use jsonwebtoken::{Algorithm, DecodingKey, Validation};
+use pin_project_lite::pin_project;
+use serde::de::DeserializeOwned;
+use serde_json::Value;
+use tower::{Layer, Service};
+
+use crate::config::AuthConfig;
+use crate::error::AgError;
+
+/// Contexto de autenticacion adjunto a las extensiones del request.
+#[derive(Debug, Clone)]
+pub struct AuthContext {
+    /// Claims decodificados como JSON generico.
+    pub claims: Value,
+}
+
+struct AuthInner {
+    decoding_key: DecodingKey,
+    validation: Validation,
+}
+
+impl std::fmt::Debug for AuthInner {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("AuthInner")
+            .field("validation", &self.validation)
+            .finish_non_exhaustive()
+    }
+}
+
+/// Tower layer de autenticacion JWT.
+#[derive(Clone)]
+pub struct AuthLayer {
+    inner: Arc<AuthInner>,
+}
+
+impl std::fmt::Debug for AuthLayer {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("AuthLayer").finish_non_exhaustive()
+    }
+}
+
+fn load_public_key(config: &AuthConfig) -> Result<DecodingKey, AgError> {
+    match (&config.public_key_pem, &config.public_key_path) {
+        (Some(_), Some(_)) => Err(AgError::Config(
+            "auth.public_key_pem and auth.public_key_path are mutually exclusive".to_owned(),
+        )),
+        (Some(pem), None) => DecodingKey::from_ed_pem(pem.as_bytes())
+            .map_err(|e| AgError::Config(format!("invalid Ed25519 PEM: {e}"))),
+        (None, Some(path)) => {
+            let bytes = std::fs::read(path)
+                .map_err(|e| AgError::Config(format!("cannot read {}: {e}", path.display())))?;
+            DecodingKey::from_ed_pem(&bytes).map_err(|e| {
+                AgError::Config(format!("invalid Ed25519 PEM at {}: {e}", path.display()))
+            })
+        }
+        (None, None) => Err(AgError::Config(
+            "auth requires public_key_pem or public_key_path".to_owned(),
+        )),
+    }
+}
+
+fn build_validation(config: &AuthConfig) -> Validation {
+    let mut validation = Validation::new(Algorithm::EdDSA);
+    // jsonwebtoken acepta 60 segundos de margen para `exp` y `nbf` por
+    // defecto. Lo dejamos en 0 por seguridad estricta: si una
+    // implementacion requiere tolerar deriva de reloj, hace falta
+    // anadirlo via configuracion explicita.
+    validation.leeway = 0;
+    if let Some(issuer) = &config.expected_issuer {
+        validation.set_issuer(std::slice::from_ref(issuer));
+    }
+    if let Some(audience) = &config.expected_audience {
+        validation.set_audience(std::slice::from_ref(audience));
+    } else {
+        // Por defecto jsonwebtoken exige aud cuando esta declarado; lo
+        // dejamos opcional cuando el operador no la configura.
+        validation.validate_aud = false;
+    }
+    validation
+}
+
+impl AuthLayer {
+    /// Construye la capa cargando y validando la clave publica.
+    ///
+    /// # Errores
+    ///
+    /// Devuelve `AgError::Config` si la clave no esta declarada, no
+    /// existe el archivo, o el contenido no es un PEM Ed25519 valido.
+    pub fn new(config: &AuthConfig) -> Result<Self, AgError> {
+        let decoding_key = load_public_key(config)?;
+        let validation = build_validation(config);
+        Ok(Self {
+            inner: Arc::new(AuthInner {
+                decoding_key,
+                validation,
+            }),
+        })
+    }
+}
+
+impl<S> Layer<S> for AuthLayer {
+    type Service = AuthService<S>;
+
+    fn layer(&self, inner: S) -> Self::Service {
+        AuthService {
+            inner,
+            shared: Arc::clone(&self.inner),
+        }
+    }
+}
+
+/// Servicio Tower que valida el JWT antes de delegar al inner.
+#[derive(Clone)]
+pub struct AuthService<S> {
+    inner: S,
+    shared: Arc<AuthInner>,
+}
+
+impl<S> std::fmt::Debug for AuthService<S> {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("AuthService").finish_non_exhaustive()
+    }
+}
+
+fn extract_bearer(req: &Request) -> Result<&str, AgError> {
+    let header = req
+        .headers()
+        .get(AUTHORIZATION)
+        .ok_or_else(|| AgError::Auth("missing Authorization header".to_owned()))?
+        .to_str()
+        .map_err(|_| AgError::Auth("Authorization header is not valid UTF-8".to_owned()))?;
+    header
+        .strip_prefix("Bearer ")
+        .or_else(|| header.strip_prefix("bearer "))
+        .ok_or_else(|| AgError::Auth("Authorization scheme must be Bearer".to_owned()))
+        .map(str::trim)
+}
+
+fn verify(req: &Request, inner: &AuthInner) -> Result<AuthContext, AgError> {
+    let token = extract_bearer(req)?;
+    let data = jsonwebtoken::decode::<Value>(token, &inner.decoding_key, &inner.validation)
+        .map_err(|e| AgError::Auth(format!("invalid token: {e}")))?;
+    Ok(AuthContext {
+        claims: data.claims,
+    })
+}
+
+impl<S> Service<Request> for AuthService<S>
+where
+    S: Service<Request, Response = Response> + Clone + Send + 'static,
+    S::Future: Send + 'static,
+{
+    type Response = Response;
+    type Error = S::Error;
+    type Future = AuthFuture<S::Future>;
+
+    fn poll_ready(&mut self, cx: &mut Context<'_>) -> Poll<Result<(), Self::Error>> {
+        self.inner.poll_ready(cx)
+    }
+
+    fn call(&mut self, mut req: Request) -> Self::Future {
+        match verify(&req, &self.shared) {
+            Ok(ctx) => {
+                req.extensions_mut().insert(ctx);
+                AuthFuture {
+                    state: AuthState::Inner {
+                        future: self.inner.call(req),
+                    },
+                }
+            }
+            Err(err) => AuthFuture {
+                state: AuthState::Reject {
+                    response: Some(err.into_response()),
+                },
+            },
+        }
+    }
+}
+
+pin_project! {
+    /// Future del servicio de autenticacion.
+    #[derive(Debug)]
+    pub struct AuthFuture<F> {
+        #[pin]
+        state: AuthState<F>,
+    }
+}
+
+pin_project! {
+    #[project = AuthStateProj]
+    #[derive(Debug)]
+    enum AuthState<F> {
+        Inner { #[pin] future: F },
+        Reject { response: Option<Response> },
+    }
+}
+
+impl<F, E> Future for AuthFuture<F>
+where
+    F: Future<Output = Result<Response, E>>,
+{
+    type Output = Result<Response, E>;
+
+    fn poll(self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Self::Output> {
+        let this = self.project();
+        match this.state.project() {
+            AuthStateProj::Inner { future } => future.poll(cx),
+            AuthStateProj::Reject { response } => {
+                let resp = response.take().expect("polled AuthFuture after completion");
+                Poll::Ready(Ok(resp))
+            }
+        }
+    }
+}
+
+/// Extractor tipado de claims del JWT.
+///
+/// Lee el `AuthContext` inyectado por `AuthService` desde las
+/// extensiones del request y deserializa los claims al tipo `T`.
+/// Devuelve `AgError::Auth` si la capa Auth no esta activa para esta
+/// ruta o si la deserializacion falla.
+#[derive(Debug, Clone)]
+pub struct Claims<T>(pub T);
+
+#[async_trait]
+impl<T, S> FromRequestParts<S> for Claims<T>
+where
+    T: DeserializeOwned + Send + 'static,
+    S: Send + Sync,
+{
+    type Rejection = AgError;
+
+    async fn from_request_parts(parts: &mut Parts, _state: &S) -> Result<Self, Self::Rejection> {
+        let ctx = parts
+            .extensions
+            .get::<AuthContext>()
+            .ok_or_else(|| AgError::Auth("AuthContext missing; is AuthLayer active?".to_owned()))?;
+        let value: T = serde_json::from_value(ctx.claims.clone())
+            .map_err(|e| AgError::Auth(format!("cannot deserialize claims: {e}")))?;
+        Ok(Self(value))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use axum::body::Body;
+    use axum::http::HeaderValue;
+
+    #[test]
+    fn missing_authorization_is_rejected() {
+        let req = Request::builder().uri("/x").body(Body::empty()).unwrap();
+        let err = extract_bearer(&req).unwrap_err();
+        assert_eq!(err.code(), "auth_error");
+    }
+
+    #[test]
+    fn non_bearer_scheme_is_rejected() {
+        let req = Request::builder()
+            .uri("/x")
+            .header(
+                AUTHORIZATION,
+                HeaderValue::from_static("Basic dXNlcjpwYXNz"),
+            )
+            .body(Body::empty())
+            .unwrap();
+        let err = extract_bearer(&req).unwrap_err();
+        assert_eq!(err.code(), "auth_error");
+    }
+
+    #[test]
+    fn bearer_extracts_token() {
+        let req = Request::builder()
+            .uri("/x")
+            .header(
+                AUTHORIZATION,
+                HeaderValue::from_static("Bearer abc.def.ghi"),
+            )
+            .body(Body::empty())
+            .unwrap();
+        assert_eq!(extract_bearer(&req).unwrap(), "abc.def.ghi");
+    }
+
+    #[test]
+    fn empty_config_errors() {
+        let cfg = AuthConfig::default();
+        let err = AuthLayer::new(&cfg).unwrap_err();
+        assert_eq!(err.code(), "config_error");
+    }
+
+    #[test]
+    fn both_pem_and_path_errors() {
+        let cfg = AuthConfig {
+            enabled: true,
+            public_key_pem: Some("pem".to_owned()),
+            public_key_path: Some(std::path::PathBuf::from("/nope")),
+            ..AuthConfig::default()
+        };
+        let err = AuthLayer::new(&cfg).unwrap_err();
+        assert_eq!(err.code(), "config_error");
+    }
+
+    #[test]
+    fn invalid_pem_errors() {
+        let cfg = AuthConfig {
+            enabled: true,
+            public_key_pem: Some("not a real PEM".to_owned()),
+            ..AuthConfig::default()
+        };
+        let err = AuthLayer::new(&cfg).unwrap_err();
+        assert_eq!(err.code(), "config_error");
+    }
+}

--- a/crates/ag-core/src/shield/mod.rs
+++ b/crates/ag-core/src/shield/mod.rs
@@ -19,6 +19,8 @@ mod csrf;
 mod logging;
 #[cfg(feature = "rate-limit")]
 mod rate_limit;
+#[cfg(feature = "tls")]
+mod tls;
 #[cfg(feature = "validation")]
 pub mod validation;
 
@@ -34,7 +36,7 @@ pub use validation::{FieldError, Validate, ValidatedJson, ValidationErrors};
 /// origenes CORS). Si la configuracion es invalida, `try_new` devuelve
 /// el error correspondiente y `new` entra en panic. Por convencion el
 /// arranque del proceso usa `try_new` para fallar rapido y limpio.
-#[derive(Debug, Clone)]
+#[derive(Clone)]
 pub struct Shield {
     config: ShieldConfig,
     #[cfg(feature = "cors")]
@@ -43,6 +45,16 @@ pub struct Shield {
     rate_limit_layer: Option<rate_limit::RateLimitLayer>,
     #[cfg(feature = "auth-jwt")]
     auth_layer: Option<auth::AuthLayer>,
+    #[cfg(feature = "tls")]
+    tls_acceptor: Option<tokio_rustls::TlsAcceptor>,
+}
+
+impl std::fmt::Debug for Shield {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("Shield")
+            .field("config", &self.config)
+            .finish_non_exhaustive()
+    }
 }
 
 impl Shield {
@@ -74,6 +86,13 @@ impl Shield {
             None
         };
 
+        #[cfg(feature = "tls")]
+        let tls_acceptor = if config.tls.enabled {
+            Some(tls::build_acceptor(&config.tls)?)
+        } else {
+            None
+        };
+
         Ok(Self {
             config,
             #[cfg(feature = "cors")]
@@ -82,7 +101,36 @@ impl Shield {
             rate_limit_layer,
             #[cfg(feature = "auth-jwt")]
             auth_layer,
+            #[cfg(feature = "tls")]
+            tls_acceptor,
         })
+    }
+
+    /// Sirve la aplicacion sobre el listener dado. Si TLS esta
+    /// activado en la configuracion, envuelve cada conexion con
+    /// rustls; en caso contrario delega en `axum::serve`.
+    ///
+    /// # Errores
+    ///
+    /// Propaga errores de I/O y de TLS. Las desconexiones individuales
+    /// se logean y no detienen el accept loop.
+    #[cfg(feature = "tls")]
+    pub async fn serve(&self, listener: tokio::net::TcpListener, router: Router) -> AgResult<()> {
+        if let Some(acceptor) = self.tls_acceptor.clone() {
+            serve_tls(listener, acceptor, router).await
+        } else {
+            axum::serve(listener, router.into_make_service())
+                .await
+                .map_err(|e| crate::error::AgError::Other(format!("axum::serve failed: {e}")))
+        }
+    }
+
+    /// Variante de `serve` cuando la feature `tls` no esta activa.
+    #[cfg(not(feature = "tls"))]
+    pub async fn serve(&self, listener: tokio::net::TcpListener, router: Router) -> AgResult<()> {
+        axum::serve(listener, router.into_make_service())
+            .await
+            .map_err(|e| crate::error::AgError::Other(format!("axum::serve failed: {e}")))
     }
 
     /// Construye un Shield sin verificar la configuracion.
@@ -146,6 +194,57 @@ impl Shield {
 
         router = router.layer(logging::LoggingLayer);
         router
+    }
+}
+
+#[cfg(feature = "tls")]
+async fn serve_tls(
+    listener: tokio::net::TcpListener,
+    acceptor: tokio_rustls::TlsAcceptor,
+    router: Router,
+) -> AgResult<()> {
+    use hyper_util::rt::{TokioExecutor, TokioIo};
+    use hyper_util::server::conn::auto::Builder;
+    use tower::Service;
+
+    let make_service = router.into_make_service();
+    loop {
+        let (stream, _addr) = listener
+            .accept()
+            .await
+            .map_err(crate::error::AgError::from)?;
+        let acceptor = acceptor.clone();
+        let mut make = make_service.clone();
+        tokio::spawn(async move {
+            let tls_stream = match acceptor.accept(stream).await {
+                Ok(s) => s,
+                Err(err) => {
+                    tracing::warn!(error = %err, "tls handshake failed");
+                    return;
+                }
+            };
+
+            let service = match make.call(()).await {
+                Ok(s) => s,
+                Err(err) => {
+                    tracing::error!(error = %err, "service factory failed");
+                    return;
+                }
+            };
+            let hyper_service =
+                hyper::service::service_fn(move |req: hyper::Request<hyper::body::Incoming>| {
+                    let mut service = service.clone();
+                    async move { service.call(req).await }
+                });
+
+            let io = TokioIo::new(tls_stream);
+            if let Err(err) = Builder::new(TokioExecutor::new())
+                .serve_connection_with_upgrades(io, hyper_service)
+                .await
+            {
+                tracing::warn!(error = %err, "connection serving failed");
+            }
+        });
     }
 }
 

--- a/crates/ag-core/src/shield/mod.rs
+++ b/crates/ag-core/src/shield/mod.rs
@@ -10,6 +10,8 @@ use axum::Router;
 use crate::config::ShieldConfig;
 use crate::error::AgResult;
 
+#[cfg(feature = "auth-jwt")]
+pub mod auth;
 #[cfg(feature = "cors")]
 mod cors;
 #[cfg(feature = "csrf")]
@@ -19,6 +21,9 @@ mod logging;
 mod rate_limit;
 #[cfg(feature = "validation")]
 pub mod validation;
+
+#[cfg(feature = "auth-jwt")]
+pub use auth::{AuthContext, Claims};
 
 #[cfg(feature = "validation")]
 pub use validation::{FieldError, Validate, ValidatedJson, ValidationErrors};
@@ -36,6 +41,8 @@ pub struct Shield {
     cors_layer: Option<tower_http::cors::CorsLayer>,
     #[cfg(feature = "rate-limit")]
     rate_limit_layer: Option<rate_limit::RateLimitLayer>,
+    #[cfg(feature = "auth-jwt")]
+    auth_layer: Option<auth::AuthLayer>,
 }
 
 impl Shield {
@@ -60,12 +67,21 @@ impl Shield {
             None
         };
 
+        #[cfg(feature = "auth-jwt")]
+        let auth_layer = if config.auth.enabled {
+            Some(auth::AuthLayer::new(&config.auth)?)
+        } else {
+            None
+        };
+
         Ok(Self {
             config,
             #[cfg(feature = "cors")]
             cors_layer,
             #[cfg(feature = "rate-limit")]
             rate_limit_layer,
+            #[cfg(feature = "auth-jwt")]
+            auth_layer,
         })
     }
 
@@ -102,9 +118,20 @@ impl Shield {
     pub fn apply(&self, router: Router) -> Router {
         let mut router = router;
 
+        // Orden de adicion (de mas interno a mas externo): la primera
+        // capa anadida envuelve al handler; la ultima ve el request
+        // primero. Por seguridad, rate-limit y auth vienen antes que
+        // las capas de proteccion semantica (CORS, CSRF), y logging
+        // queda al borde para trazar absolutamente todo.
+
         #[cfg(feature = "csrf")]
         if self.config.csrf.enabled {
             router = router.layer(csrf::CsrfLayer::new(self.config.csrf.clone()));
+        }
+
+        #[cfg(feature = "auth-jwt")]
+        if let Some(layer) = self.auth_layer.clone() {
+            router = router.layer(layer);
         }
 
         #[cfg(feature = "cors")]

--- a/crates/ag-core/src/shield/tls.rs
+++ b/crates/ag-core/src/shield/tls.rs
@@ -1,0 +1,139 @@
+//! Capa TLS 1.3 con rustls.
+//!
+//! TLS opera a nivel de conexion, no de request, por lo que esta capa
+//! no se integra como Tower middleware. Se materializa como un
+//! `TlsAcceptor` que envuelve cada `TcpStream` aceptado antes de
+//! delegar al router HTTP.
+//!
+//! El helper publico de uso comun es `Shield::serve(listener, router)`
+//! en el modulo padre, que detecta si la capa TLS esta activa y
+//! despacha al transporte correcto.
+
+use std::path::Path;
+use std::sync::Arc;
+
+use rustls::pki_types::pem::PemObject;
+use rustls::pki_types::{CertificateDer, PrivateKeyDer};
+use rustls::ServerConfig;
+use tokio_rustls::TlsAcceptor;
+
+use crate::config::TlsConfig;
+use crate::error::AgError;
+
+/// Construye un `TlsAcceptor` desde la configuracion declarativa.
+///
+/// # Errores
+///
+/// Devuelve `AgError::Tls` si los archivos no existen, no se pueden
+/// parsear como PEM o no contienen al menos un certificado y una
+/// clave privada compatibles.
+pub fn build_acceptor(config: &TlsConfig) -> Result<TlsAcceptor, AgError> {
+    let cert_path = config
+        .cert_path
+        .as_deref()
+        .ok_or_else(|| AgError::Tls("tls.cert_path is required when tls.enabled".to_owned()))?;
+    let key_path = config
+        .key_path
+        .as_deref()
+        .ok_or_else(|| AgError::Tls("tls.key_path is required when tls.enabled".to_owned()))?;
+
+    let certs = load_certs(cert_path)?;
+    let key = load_private_key(key_path)?;
+
+    let server_config = ServerConfig::builder()
+        .with_no_client_auth()
+        .with_single_cert(certs, key)
+        .map_err(|e| AgError::Tls(format!("invalid server certificate: {e}")))?;
+
+    Ok(TlsAcceptor::from(Arc::new(server_config)))
+}
+
+fn load_certs(path: &Path) -> Result<Vec<CertificateDer<'static>>, AgError> {
+    let certs: Vec<CertificateDer<'static>> = CertificateDer::pem_file_iter(path)
+        .map_err(|e| {
+            AgError::Tls(format!(
+                "cannot read certificates at {}: {e}",
+                path.display()
+            ))
+        })?
+        .collect::<Result<Vec<_>, _>>()
+        .map_err(|e| AgError::Tls(format!("invalid PEM at {}: {e}", path.display())))?;
+    if certs.is_empty() {
+        return Err(AgError::Tls(format!(
+            "no certificates found at {}",
+            path.display()
+        )));
+    }
+    Ok(certs)
+}
+
+fn load_private_key(path: &Path) -> Result<PrivateKeyDer<'static>, AgError> {
+    PrivateKeyDer::from_pem_file(path)
+        .map_err(|e| AgError::Tls(format!("invalid private key at {}: {e}", path.display())))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::io::Write;
+
+    fn tmpfile(contents: &[u8]) -> std::path::PathBuf {
+        let mut path = std::env::temp_dir();
+        let nanos = std::time::SystemTime::now()
+            .duration_since(std::time::UNIX_EPOCH)
+            .unwrap()
+            .as_nanos();
+        path.push(format!("ag-core-tls-{nanos}.pem"));
+        let mut f = std::fs::File::create(&path).unwrap();
+        f.write_all(contents).unwrap();
+        path
+    }
+
+    fn assert_tls_error(cfg: &TlsConfig) {
+        match build_acceptor(cfg) {
+            Ok(_) => panic!("expected TLS error"),
+            Err(err) => assert_eq!(err.code(), "tls_error"),
+        }
+    }
+
+    #[test]
+    fn missing_cert_path_errors() {
+        let cfg = TlsConfig {
+            enabled: true,
+            cert_path: None,
+            key_path: Some(std::path::PathBuf::from("/nope")),
+        };
+        assert_tls_error(&cfg);
+    }
+
+    #[test]
+    fn missing_key_path_errors() {
+        let cfg = TlsConfig {
+            enabled: true,
+            cert_path: Some(std::path::PathBuf::from("/nope")),
+            key_path: None,
+        };
+        assert_tls_error(&cfg);
+    }
+
+    #[test]
+    fn nonexistent_cert_file_errors() {
+        let cfg = TlsConfig {
+            enabled: true,
+            cert_path: Some(std::path::PathBuf::from("/does/not/exist.pem")),
+            key_path: Some(std::path::PathBuf::from("/does/not/exist.pem")),
+        };
+        assert_tls_error(&cfg);
+    }
+
+    #[test]
+    fn empty_pem_errors() {
+        let path = tmpfile(b"");
+        let cfg = TlsConfig {
+            enabled: true,
+            cert_path: Some(path.clone()),
+            key_path: Some(path),
+        };
+        assert_tls_error(&cfg);
+    }
+}

--- a/crates/ag-core/tests/shield_auth.rs
+++ b/crates/ag-core/tests/shield_auth.rs
@@ -1,0 +1,236 @@
+//! Tests E2E de la capa de autenticacion JWT Ed25519.
+
+#![cfg(feature = "auth-jwt")]
+
+use ag_core::config::AuthConfig;
+use ag_core::shield::Claims;
+use ag_core::{Shield, ShieldConfig};
+use axum::routing::get;
+use axum::Router;
+use ed25519_dalek::pkcs8::spki::der::pem::LineEnding;
+use ed25519_dalek::pkcs8::EncodePrivateKey;
+use ed25519_dalek::pkcs8::EncodePublicKey;
+use ed25519_dalek::SigningKey;
+use jsonwebtoken::{Algorithm, EncodingKey, Header};
+use serde::{Deserialize, Serialize};
+use std::net::SocketAddr;
+use std::time::{SystemTime, UNIX_EPOCH};
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+struct AppClaims {
+    sub: String,
+    exp: u64,
+    iss: Option<String>,
+}
+
+struct TestKeys {
+    public_pem: String,
+    signing_pem: String,
+}
+
+fn generate_keys() -> TestKeys {
+    use rand_core::{OsRng, RngCore};
+    let mut secret = [0u8; 32];
+    OsRng.fill_bytes(&mut secret);
+    let signing_key = SigningKey::from_bytes(&secret);
+    let verifying_key = signing_key.verifying_key();
+    let public_pem = verifying_key.to_public_key_pem(LineEnding::LF).unwrap();
+    let signing_pem = signing_key
+        .to_pkcs8_pem(LineEnding::LF)
+        .unwrap()
+        .to_string();
+    TestKeys {
+        public_pem,
+        signing_pem,
+    }
+}
+
+fn now() -> u64 {
+    SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .unwrap()
+        .as_secs()
+}
+
+fn sign(claims: &AppClaims, signing_pem: &str) -> String {
+    let header = Header::new(Algorithm::EdDSA);
+    let encoding_key = EncodingKey::from_ed_pem(signing_pem.as_bytes()).unwrap();
+    jsonwebtoken::encode(&header, claims, &encoding_key).unwrap()
+}
+
+async fn protected_handler(Claims(c): Claims<AppClaims>) -> String {
+    format!("hello {}", c.sub)
+}
+
+async fn start_server(auth: AuthConfig) -> (SocketAddr, tokio::task::JoinHandle<()>) {
+    let config = ShieldConfig {
+        auth,
+        ..ShieldConfig::default()
+    };
+    let shield = Shield::try_new(config).unwrap();
+    let app = shield.apply(Router::new().route("/me", get(protected_handler)));
+
+    let listener = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
+    let addr = listener.local_addr().unwrap();
+    let handle = tokio::spawn(async move {
+        axum::serve(listener, app.into_make_service())
+            .await
+            .unwrap();
+    });
+    (addr, handle)
+}
+
+#[tokio::test]
+async fn missing_authorization_returns_401() {
+    let keys = generate_keys();
+    let cfg = AuthConfig {
+        enabled: true,
+        public_key_pem: Some(keys.public_pem.clone()),
+        ..AuthConfig::default()
+    };
+    let (addr, handle) = start_server(cfg).await;
+    let client = reqwest::Client::new();
+    let resp = client
+        .get(format!("http://{addr}/me"))
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(resp.status(), reqwest::StatusCode::UNAUTHORIZED);
+    let body: serde_json::Value = resp.json().await.unwrap();
+    assert_eq!(body["code"], "auth_error");
+    handle.abort();
+}
+
+#[tokio::test]
+async fn valid_token_passes_and_handler_sees_claims() {
+    let keys = generate_keys();
+    let token = sign(
+        &AppClaims {
+            sub: "angel".into(),
+            exp: now() + 60,
+            iss: None,
+        },
+        &keys.signing_pem,
+    );
+
+    let cfg = AuthConfig {
+        enabled: true,
+        public_key_pem: Some(keys.public_pem.clone()),
+        ..AuthConfig::default()
+    };
+    let (addr, handle) = start_server(cfg).await;
+    let client = reqwest::Client::new();
+    let resp = client
+        .get(format!("http://{addr}/me"))
+        .bearer_auth(&token)
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(resp.status(), reqwest::StatusCode::OK);
+    assert_eq!(resp.text().await.unwrap(), "hello angel");
+    handle.abort();
+}
+
+#[tokio::test]
+async fn expired_token_is_rejected() {
+    let keys = generate_keys();
+    let token = sign(
+        &AppClaims {
+            sub: "angel".into(),
+            exp: now() - 120,
+            iss: None,
+        },
+        &keys.signing_pem,
+    );
+
+    let cfg = AuthConfig {
+        enabled: true,
+        public_key_pem: Some(keys.public_pem.clone()),
+        ..AuthConfig::default()
+    };
+    let (addr, handle) = start_server(cfg).await;
+    let client = reqwest::Client::new();
+    let resp = client
+        .get(format!("http://{addr}/me"))
+        .bearer_auth(&token)
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(resp.status(), reqwest::StatusCode::UNAUTHORIZED);
+    handle.abort();
+}
+
+#[tokio::test]
+async fn token_signed_with_other_key_is_rejected() {
+    let keys_a = generate_keys();
+    let keys_b = generate_keys();
+    let token = sign(
+        &AppClaims {
+            sub: "intruder".into(),
+            exp: now() + 60,
+            iss: None,
+        },
+        &keys_b.signing_pem,
+    );
+
+    let cfg = AuthConfig {
+        enabled: true,
+        public_key_pem: Some(keys_a.public_pem.clone()),
+        ..AuthConfig::default()
+    };
+    let (addr, handle) = start_server(cfg).await;
+    let client = reqwest::Client::new();
+    let resp = client
+        .get(format!("http://{addr}/me"))
+        .bearer_auth(&token)
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(resp.status(), reqwest::StatusCode::UNAUTHORIZED);
+    handle.abort();
+}
+
+#[tokio::test]
+async fn wrong_issuer_is_rejected() {
+    let keys = generate_keys();
+    let token = sign(
+        &AppClaims {
+            sub: "angel".into(),
+            exp: now() + 60,
+            iss: Some("https://other.example/".into()),
+        },
+        &keys.signing_pem,
+    );
+
+    let cfg = AuthConfig {
+        enabled: true,
+        public_key_pem: Some(keys.public_pem.clone()),
+        expected_issuer: Some("https://expected.example/".into()),
+        ..AuthConfig::default()
+    };
+    let (addr, handle) = start_server(cfg).await;
+    let client = reqwest::Client::new();
+    let resp = client
+        .get(format!("http://{addr}/me"))
+        .bearer_auth(&token)
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(resp.status(), reqwest::StatusCode::UNAUTHORIZED);
+    handle.abort();
+}
+
+#[tokio::test]
+async fn auth_disabled_lets_request_through_but_extractor_fails() {
+    let cfg = AuthConfig::default();
+    let (addr, handle) = start_server(cfg).await;
+    let client = reqwest::Client::new();
+    // El handler usa Claims<T> que falla porque no hay AuthContext.
+    let resp = client
+        .get(format!("http://{addr}/me"))
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(resp.status(), reqwest::StatusCode::UNAUTHORIZED);
+    handle.abort();
+}

--- a/crates/ag-core/tests/shield_tls.rs
+++ b/crates/ag-core/tests/shield_tls.rs
@@ -1,0 +1,105 @@
+//! Tests E2E de la capa TLS 1.3.
+
+#![cfg(feature = "tls")]
+
+use ag_core::config::TlsConfig;
+use ag_core::{Shield, ShieldConfig};
+use axum::routing::get;
+use axum::Router;
+use std::io::Write;
+use std::path::PathBuf;
+
+fn generate_cert_pair() -> (PathBuf, PathBuf) {
+    let subject_alt_names = vec!["localhost".to_owned(), "127.0.0.1".to_owned()];
+    let cert = rcgen::generate_simple_self_signed(subject_alt_names).unwrap();
+    let cert_pem = cert.cert.pem();
+    let key_pem = cert.key_pair.serialize_pem();
+
+    let nanos = std::time::SystemTime::now()
+        .duration_since(std::time::UNIX_EPOCH)
+        .unwrap()
+        .as_nanos();
+    let dir = std::env::temp_dir();
+    let cert_path = dir.join(format!("ag-tls-cert-{nanos}.pem"));
+    let key_path = dir.join(format!("ag-tls-key-{nanos}.pem"));
+
+    let mut cf = std::fs::File::create(&cert_path).unwrap();
+    cf.write_all(cert_pem.as_bytes()).unwrap();
+    let mut kf = std::fs::File::create(&key_path).unwrap();
+    kf.write_all(key_pem.as_bytes()).unwrap();
+
+    (cert_path, key_path)
+}
+
+#[tokio::test]
+async fn tls_disabled_serves_plain_http() {
+    let shield = Shield::try_new(ShieldConfig::default()).unwrap();
+    let app = shield.apply(Router::new().route("/ping", get(|| async { "pong" })));
+    let listener = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
+    let addr = listener.local_addr().unwrap();
+    let shield_clone = shield.clone();
+    let handle = tokio::spawn(async move {
+        let _ = shield_clone.serve(listener, app).await;
+    });
+
+    let client = reqwest::Client::new();
+    let resp = client
+        .get(format!("http://{addr}/ping"))
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(resp.status(), reqwest::StatusCode::OK);
+    handle.abort();
+}
+
+#[tokio::test]
+async fn tls_enabled_serves_https() {
+    // rustls requiere un crypto provider instalado por proceso.
+    let _ = rustls::crypto::ring::default_provider().install_default();
+
+    let (cert_path, key_path) = generate_cert_pair();
+    let config = ShieldConfig {
+        tls: TlsConfig {
+            enabled: true,
+            cert_path: Some(cert_path),
+            key_path: Some(key_path),
+        },
+        ..ShieldConfig::default()
+    };
+    let shield = Shield::try_new(config).unwrap();
+    let app = shield.apply(Router::new().route("/secure", get(|| async { "tls-ok" })));
+    let listener = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
+    let addr = listener.local_addr().unwrap();
+    let shield_clone = shield.clone();
+    let handle = tokio::spawn(async move {
+        let _ = shield_clone.serve(listener, app).await;
+    });
+
+    let client = reqwest::Client::builder()
+        .danger_accept_invalid_certs(true)
+        .build()
+        .unwrap();
+    let resp = client
+        .get(format!("https://{addr}/secure"))
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(resp.status(), reqwest::StatusCode::OK);
+    let body = resp.text().await.unwrap();
+    assert_eq!(body, "tls-ok");
+    handle.abort();
+}
+
+#[tokio::test]
+async fn tls_enabled_without_cert_paths_fails_construction() {
+    let config = ShieldConfig {
+        tls: TlsConfig {
+            enabled: true,
+            cert_path: None,
+            key_path: None,
+        },
+        ..ShieldConfig::default()
+    };
+    let err = Shield::try_new(config).unwrap_err();
+    assert_eq!(err.code(), "tls_error");
+}

--- a/docs/pr-drafts/README.md
+++ b/docs/pr-drafts/README.md
@@ -1,0 +1,58 @@
+# Descriptores de Pull Request
+
+Esta carpeta contiene un archivo Markdown por cada pull request o por
+cada rama de trabajo. El archivo es la version pre-rellenada del
+descriptor del PR: resumen, fase afectada, tipo de cambio, documentos
+relacionados, plan de prueba, criterios de salida y checklist final.
+
+## Por que existe esta carpeta
+
+La plantilla en `.github/PULL_REQUEST_TEMPLATE.md` describe la
+estructura esperada del descriptor. En la practica, dejar la plantilla
+vacia produce PRs sin contexto y sin trazabilidad. Esta carpeta
+resuelve el problema: cada commit o cada rama que va a producir un PR
+trae su descriptor ya escrito por la persona o agente que hizo el
+cambio, con los detalles concretos en lugar de los placeholders.
+
+Cuando se abre el PR, el contenido del descriptor se copia al cuerpo
+del PR en GitHub. Asi el revisor recibe la informacion sin que nadie
+tenga que improvisar.
+
+## Convencion de nombre
+
+Un archivo por unidad de PR:
+
+- `<nombre-de-rama>.md` cuando un PR consolida toda la rama.
+- `<nombre-de-rama>-<n>.md` cuando una rama produce varios PRs.
+
+Si la rama es larga y aglomera varios cambios en commits separados, el
+descriptor refleja el conjunto, no cada commit individual. Si se
+desea descomponer en PRs mas pequenos, se divide la rama y cada
+subrama tiene su archivo.
+
+## Cuando se escribe
+
+- Antes o durante el commit, no despues.
+- Si los detalles cambian en commits subsiguientes, se actualiza el
+  archivo en el mismo commit que introduce el cambio.
+- Al abrir el PR en GitHub, el contenido del archivo se copia al
+  cuerpo del PR. Los `<!-- comentarios -->` del template no aparecen
+  porque ya estan reemplazados por texto concreto.
+
+## Que debe contener cada descriptor
+
+- **Resumen**: una sola linea, maximo 256 caracteres, usable tambien
+  como titulo del PR.
+- **Fase afectada**: que fase de la Hoja de Ruta tocan estos cambios.
+- **Tipo de cambio**: checklist marcado con `[x]` segun corresponda.
+- **Documentos relacionados**: RFC, ADR y maestros referenciados.
+- **Plan de prueba**: comandos exactos que el revisor puede ejecutar.
+- **Criterios de salida que avanza**: casillas concretas de
+  `docs/roadmap/STATUS.md` que esta unidad de cambio marca.
+- **Checklist**: las cinco casillas siempre, marcadas o explicitas.
+
+## Indice
+
+| Archivo | Rama | Resumen |
+| --- | --- | --- |
+| `phase-0-foundations-and-governance.md` | `phase-0/foundations-and-governance` | Setup Fase 0 completo (docs maestros, gobernanza, workspace de 15 crates, CI multiplataforma, plantillas) mas implementacion de Fase 1 PRs 1-7 (Shield bootstrap, validation, CORS, CSRF, rate-limit, JWT Ed25519, TLS 1.3). |

--- a/docs/pr-drafts/phase-0-foundations-and-governance.md
+++ b/docs/pr-drafts/phase-0-foundations-and-governance.md
@@ -1,0 +1,207 @@
+# PR: Fase 0 completa y Fase 1 PRs 1-7 (Shield MVP en construccion)
+
+## Resumen
+
+Fase 0 fundaciones y gobernanza completa en repositorio y siete capas del Shield MVP (HTTP, validacion, CORS, CSRF, rate-limit, JWT Ed25519, TLS 1.3) operativas con 73 tests verde y CI multiplataforma.
+
+## Fase afectada
+
+Fase 0 (Fundaciones y Gobernanza) y Fase 1 (Shield MVP, PRs 1-7 de 11 segun
+RFC-0002).
+
+La paralelizacion entre el cierre de las puertas externas de Fase 0 (primer
+star externo, Discord con cinco miembros, landing page) y el inicio de
+implementacion de Fase 1 esta autorizada explicitamente en
+`docs/rfc/RFC-0001-paralelizar-fase-0-externa-y-fase-1.md`. La regla 1 del
+proceso queda vigente para fases sucesivas; esta es una excepcion documentada.
+
+## Tipo de cambio
+
+- [x] Documentacion
+- [x] Codigo
+- [x] Infraestructura o CI
+- [x] RFC nueva o actualizacion de RFC
+- [x] ADR nuevo
+- [x] Seguridad
+
+## Documentos relacionados
+
+- RFC: `docs/rfc/RFC-0001-paralelizar-fase-0-externa-y-fase-1.md`,
+  `docs/rfc/RFC-0002-diseno-shield-mvp.md`.
+- ADR: `docs/adr/0001-monorepo-workspace.md`,
+  `docs/adr/0002-bilingual-documentation.md`,
+  `docs/adr/0003-bdfl-governance.md`,
+  `docs/adr/0004-descomposicion-de-maestros.md`,
+  `docs/adr/0005-contact-identities.md`.
+- Maestro afectado: ambos maestros markdown bajo `docs/master/`:
+  - `docs/master/ANTI-GRAVITAL-Arquitectura-Tecnica.md` (seccion 15.3
+    actualizada con los correos reales).
+  - `docs/master/ANTI-GRAVITAL-Hoja-de-Ruta.md` (entregables de Fase 0
+    actualizados con los correos reales).
+  - Hashes SHA-256 recomputados en `docs/master/VERSION.md` y en el
+    workflow `.github/workflows/docs.yml`.
+
+## Detalle por capa entregada
+
+### Fase 0 (commits `0567faa`, `18f2487`)
+
+- Instalacion verbatim de los tres documentos maestros en `docs/master/`.
+- Descomposicion navegable de los maestros bajo `docs/architecture/` (20
+  capitulos), `docs/roadmap/` (11 fases mas preambulo y reglas de oro),
+  `docs/modules/<crate>/` (15 modulos), `docs/dsl/`, `docs/security/`,
+  `docs/governance/` y `docs/benchmarks/`.
+- `CLAUDE.md` con las 40 reglas de gobernanza tecnica.
+- Bilinguidad: `README.md` con bloques espanol e ingles. Indices en
+  `docs/es/` y `docs/en/`.
+- Gobernanza: `CONTRIBUTING.md`, `GOVERNANCE.md`, `SECURITY.md`,
+  `CODE_OF_CONDUCT.md` (Contributor Covenant 2.1), `CHANGELOG.md`.
+- Workspace Cargo con los 15 crates declarados y compilando.
+- Workflows GitHub Actions: `ci.yml` matriz Linux x86-64 / Linux ARM64 /
+  macOS ARM64 / Windows x64, `quality.yml` con fmt, clippy `-D warnings`,
+  audit y deny, `docs.yml` con cargo doc, validacion de hashes de
+  maestros, rechazo de evidencia IA y rechazo de emojis.
+- Plantillas de issue (bug, feature, RFC), `PULL_REQUEST_TEMPLATE.md` y
+  `CODEOWNERS`.
+- Identidades de contacto oficiales: `anti@gravitalcloud.com` (raiz),
+  `angelnereira@gravitalcloud.com` (BDFL), respaldados con ADR-0005 y
+  reflejados en maestros, gobernanza y workflows.
+
+### Fase 1 PR 1 (commit `81026f4`)
+
+Bootstrap de `ag-core` con HTTP/1.1 y HTTP/2 sobre Axum + Tokio. Modulos
+`error`, `config`, `runtime`, `shield` (con la primera capa, logging
+estructurado) y `core` (placeholder estable). `AgError` con
+`IntoResponse` y mapeo a status HTTP. `ShieldConfig` deserializable
+desde TOML.
+
+### Fase 1 PR 2 (commit `7ea6f94`)
+
+Capa de validacion de payload (`shield::validation`). Trait `Validate`,
+agregado `ValidationErrors` con `FieldError` serializable y extractor
+`ValidatedJson<T>`. Fallos mapeados a `AgError::Validation` (422) con
+detalle estructurado.
+
+### Fix CI (commit `e130e73`)
+
+`Unicode-3.0` anadido a `deny.toml` para destrabar el job
+`quality/cargo-deny` tras la entrada de Axum y reqwest (cadena url ->
+idna -> icu).
+
+### Fase 1 PR 3 (commit `a5fc479`)
+
+Capa CORS (`shield::cors`) sobre `tower_http::cors::CorsLayer`. API
+publica refactorizada de `Shield::layer()` a `Shield::apply(router)`
+para que cada capa nueva no rompa la firma de tipos de la pipeline.
+
+### Fase 1 PR 4 (commit `cf2eb7c`)
+
+Capa CSRF (`shield::csrf`) con patron double-submit cookie apatrida.
+Skip en metodos seguros (GET, HEAD, OPTIONS, TRACE).
+
+### Fase 1 PR 5 (commit `1a7226d`)
+
+Capa rate-limit (`shield::rate_limit`) con governor sobre token bucket
+por IP. Sin `ConnectInfo` la capa pasa transparente.
+
+### Fase 1 PR 6 (commit `8272bdf`)
+
+Capa de autenticacion JWT Ed25519 (`shield::auth`). Verifica
+`Authorization: Bearer <token>` contra una clave publica Ed25519
+cargada al arranque. Leeway forzado a 0. Inyecta `AuthContext` en las
+extensiones del request. Extractor `Claims<T>` para handlers tipados.
+
+### Fase 1 PR 7 (commit `26b6161`)
+
+Capa TLS 1.3 (`shield::tls`) con rustls (provider ring). `TlsAcceptor`
+construido desde cert/key PEM. Helper `Shield::serve(listener, router)`
+que decide entre transporte plano o TLS segun config. Migracion de
+`rustls-pemfile` (RUSTSEC-2025-0134) a `rustls-pki-types::PemObject`.
+
+## Plan de prueba
+
+Desde la raiz del repositorio, sobre la rama
+`phase-0/foundations-and-governance`:
+
+```sh
+# Workspace completo construye.
+cargo build --workspace
+
+# Tests pasan: 45 unit + 27 E2E + 1 doctest = 73 verdes en ag-core.
+cargo test --workspace
+
+# Formato sin diferencias.
+cargo fmt --all -- --check
+
+# Clippy estricto sin warnings.
+cargo clippy --workspace --all-targets -- -D warnings
+
+# Politica de dependencias y advisories al dia.
+cargo deny check
+
+# Documentacion sin warnings.
+cargo doc --workspace --no-deps
+
+# Integridad de los documentos maestros.
+sha256sum docs/master/ANTI-GRAVITAL-Blueprint-v4.0.pdf \
+          docs/master/ANTI-GRAVITAL-Arquitectura-Tecnica.md \
+          docs/master/ANTI-GRAVITAL-Hoja-de-Ruta.md
+# Los valores devueltos deben coincidir con docs/master/VERSION.md.
+
+# Ausencia de atribuciones a herramientas IA en archivos del repo.
+grep -RIE "Co-Authored-By: (Claude|GPT|Copilot)|claude\.ai/code/session_" \
+  --exclude-dir=.git --exclude-dir=target .
+
+# Ausencia de emojis en archivos del repo.
+perl -ne 'if (/[\x{1F300}-\x{1FAFF}]|[\x{2600}-\x{27BF}]|[\x{1F000}-\x{1F2FF}]/) { print "$ARGV:$.:$_" }' \
+  $(find . -type f \( -name '*.md' -o -name '*.rs' -o -name '*.toml' -o -name '*.yml' -o -name '*.yaml' -o -name '*.sh' \) -not -path './target/*' -not -path './.git/*')
+```
+
+## Criterios de salida que avanza
+
+De `docs/roadmap/STATUS.md`, esta unidad de cambio marca:
+
+Fase 0:
+
+- [x] Repositorio creado y publico.
+- [x] LICENSE Apache 2.0.
+- [x] README.md bilingue.
+- [x] CONTRIBUTING.md, CODE_OF_CONDUCT.md, SECURITY.md, GOVERNANCE.md.
+- [x] CI en cuatro plataformas (pendiente de verde en el primer run).
+- [x] Plantillas de issue, PR y RFC.
+- [x] Estructura del monorepo definida.
+- [x] Workspace Cargo con 15 crates vacios.
+- [x] Email institucional operativo (`anti@gravitalcloud.com`).
+
+Fase 1:
+
+- [x] Crate `ag-core` con modulo `shield` operativo.
+- [x] Soporte HTTP/1.1 y HTTP/2 via Axum + Tokio.
+- [x] Terminacion TLS 1.3 con rustls.
+- [x] Middleware de validacion de payload basico.
+- [x] Middleware de autenticacion JWT con verificacion Ed25519.
+- [x] Middleware de rate limiting con governor.
+- [x] Middleware CORS y CSRF con defaults seguros.
+- [x] Middleware de logging estructurado con `tracing`.
+
+Queda fuera de este PR y pendiente para PRs siguientes de Fase 1:
+configuracion minima desde archivo TOML completa (PR 8), tests con
+cobertura >=80% del crate (en buen camino; PR 10), tests E2E del
+pipeline completo (PR 10), benchmark Hello World con criterion (PR 9),
+documentacion API en docs.rs (PR 11), capitulo del manual de usuario
+(PR 11), y las metricas duras de cierre de Fase 1 (>=300K req/s en
+hardware de referencia, p99 <=1ms, memoria idle <=15MB, arranque
+<=100ms, blog post, 10 stars).
+
+## Checklist
+
+- [x] Titulo de PR de 256 caracteres o menos.
+- [x] Sin emojis en ningun archivo modificado.
+- [x] Sin atribuciones de herramientas IA.
+- [x] Documentacion actualizada en el mismo PR (CHANGELOG, STATUS,
+  RFCs, ADRs, READMEs por modulo).
+- [x] CHANGELOG.md actualizado bajo `[Unreleased]` con seccion Fase 0 y
+  seccion Fase 1.
+- [x] CLAUDE.md respetado: alcance (Fase 0 + Fase 1 dentro de scope),
+  fase (transicion documentada en RFC-0001), dependencias (solo las
+  declaradas en RFC-0002), seguridad (defaults seguros, leeway JWT 0,
+  CORS deshabilitado por defecto, sin `unsafe` en codigo propio).

--- a/docs/roadmap/STATUS.md
+++ b/docs/roadmap/STATUS.md
@@ -86,7 +86,7 @@ externas de Fase 0. El diseno de Shield esta fijado en
 - [ ] Soporte de HTTP/1.1 y HTTP/2 via Axum + Tokio.
 - [ ] Terminacion TLS 1.3 con rustls.
 - [x] Middleware de validacion de payload basico. Trait `Validate` y extractor `ValidatedJson<T>` bajo `shield::validation`.
-- [ ] Middleware de autenticacion JWT con verificacion Ed25519.
+- [x] Middleware de autenticacion JWT con verificacion Ed25519. `shield::auth` con `AuthLayer`, `AuthContext` y extractor `Claims<T>`.
 - [x] Middleware de rate limiting con governor. Token bucket por IP en `shield::rate_limit`.
 - [x] Middleware CORS y CSRF con defaults seguros. CORS en `shield::cors` y CSRF en `shield::csrf` (double-submit cookie apatrida).
 - [ ] Middleware de logging estructurado con `tracing`.

--- a/docs/roadmap/STATUS.md
+++ b/docs/roadmap/STATUS.md
@@ -84,7 +84,7 @@ externas de Fase 0. El diseno de Shield esta fijado en
 
 - [/] Crate `ag-core` con modulo `shield` operativo. (En bootstrap.)
 - [ ] Soporte de HTTP/1.1 y HTTP/2 via Axum + Tokio.
-- [ ] Terminacion TLS 1.3 con rustls.
+- [x] Terminacion TLS 1.3 con rustls. `shield::tls` + helper `Shield::serve(listener, router)` que despacha a TLS o plain segun config.
 - [x] Middleware de validacion de payload basico. Trait `Validate` y extractor `ValidatedJson<T>` bajo `shield::validation`.
 - [x] Middleware de autenticacion JWT con verificacion Ed25519. `shield::auth` con `AuthLayer`, `AuthContext` y extractor `Claims<T>`.
 - [x] Middleware de rate limiting con governor. Token bucket por IP en `shield::rate_limit`.


### PR DESCRIPTION
## Resumen

<!-- Una linea, maximo 256 caracteres. Misma frase puede usarse como
     titulo de la PR. Sin emojis ni atribuciones a herramientas IA. -->

## Fase afectada

<!-- Fase 0, 1, ... 10. Vease docs/roadmap/. -->

## Tipo de cambio

- [ ] Documentacion
- [ ] Codigo
- [ ] Infraestructura o CI
- [ ] RFC nueva o actualizacion de RFC
- [ ] ADR nuevo
- [ ] Seguridad

## Documentos relacionados

- RFC: <!-- docs/rfc/RFC-XXXX-...md o N/A -->
- ADR: <!-- docs/adr/XXXX-...md o N/A -->
- Maestro afectado: <!-- docs/master/... o N/A -->

## Plan de prueba

<!-- Pasos concretos para verificar el cambio. Si aplica:
- cargo fmt --all -- --check
- cargo clippy --workspace --all-targets -- -D warnings
- cargo test --workspace
- cargo audit
- cargo deny check
-->

## Criterios de salida que avanza

<!-- Casillas concretas de docs/roadmap/STATUS.md que esta PR marca. -->

## Checklist

- [ ] Titulo de PR de 256 caracteres o menos.
- [ ] Sin emojis en ningun archivo modificado.
- [ ] Sin atribuciones de herramientas IA.
- [ ] Documentacion actualizada en el mismo PR.
- [ ] CHANGELOG.md actualizado bajo [Unreleased].
- [ ] CLAUDE.md respetado (alcance, fase, dependencias, seguridad).
