### PR TITLE
ci: autofill del cuerpo de la PR desde docs/pr-drafts al abrirla

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,60 +1,20 @@
 <!--
-  Esta plantilla es solo un fallback. Cada pull request del proyecto
-  trae su descriptor pre-rellenado en `docs/pr-drafts/<rama>.md`.
-  Antes de abrir el PR:
-    1. Localice `docs/pr-drafts/<nombre-de-rama>.md` en la rama.
-    2. Copie su contenido completo y peguelo aqui, reemplazando este
-       comentario y todas las secciones que siguen.
-    3. Verifique que el titulo del PR (campo de arriba en GitHub) no
-       excede 256 caracteres y coincide con el "Resumen" del
-       descriptor.
-  Si el descriptor no existe, hay que crearlo en el mismo commit que
-  abre la rama. Vease `docs/pr-drafts/README.md` para la convencion.
+  Esta plantilla se reemplaza automaticamente al abrir la pull request.
+
+  El workflow `.github/workflows/pr-autofill.yml` busca el descriptor
+  pre-rellenado en `docs/pr-drafts/<rama-aplanada>.md` (las barras de
+  la rama se convierten en guiones) y, si existe, sustituye el cuerpo
+  de esta PR por su contenido completo.
+
+  Si abre la PR y este texto sigue visible despues de unos segundos:
+
+    1. Asegurese de que la rama tiene su descriptor en
+       `docs/pr-drafts/`. Sin descriptor, la PR no avanza.
+    2. Pushee el descriptor a la rama.
+    3. Cierre y reabra esta PR (o marquela como ready-for-review).
+
+  Vease `docs/pr-drafts/README.md` para la convencion.
+
+  El titulo de la pull request es la linea `Resumen` del descriptor,
+  con un maximo de 256 caracteres.
 -->
-
-## Resumen
-
-Una linea, maximo 256 caracteres. Misma frase usable como titulo del
-PR. Sin emojis ni atribuciones a herramientas IA.
-
-## Fase afectada
-
-Fase N. Vease `docs/roadmap/`.
-
-## Tipo de cambio
-
-- [ ] Documentacion
-- [ ] Codigo
-- [ ] Infraestructura o CI
-- [ ] RFC nueva o actualizacion de RFC
-- [ ] ADR nuevo
-- [ ] Seguridad
-
-## Documentos relacionados
-
-- RFC: `docs/rfc/RFC-XXXX-...md` o N/A.
-- ADR: `docs/adr/XXXX-...md` o N/A.
-- Maestro afectado: `docs/master/...` o N/A.
-
-## Plan de prueba
-
-Comandos exactos que el revisor puede ejecutar para validar el cambio
-(por ejemplo `cargo fmt --all -- --check`,
-`cargo clippy --workspace --all-targets -- -D warnings`,
-`cargo test --workspace`, `cargo deny check`).
-
-## Criterios de salida que avanza
-
-Casillas concretas de `docs/roadmap/STATUS.md` que esta PR marca,
-copiadas con su estado actualizado (`[x]` para las completas,
-`[/]` para las parciales con explicacion).
-
-## Checklist
-
-- [ ] Titulo de PR de 256 caracteres o menos.
-- [ ] Sin emojis en ningun archivo modificado.
-- [ ] Sin atribuciones de herramientas IA.
-- [ ] Documentacion actualizada en el mismo PR.
-- [ ] CHANGELOG.md actualizado bajo `[Unreleased]`.
-- [ ] CLAUDE.md respetado (alcance, fase, dependencias, seguridad).
-- [ ] Descriptor pre-rellenado existe en `docs/pr-drafts/`.

--- a/.github/workflows/pr-autofill.yml
+++ b/.github/workflows/pr-autofill.yml
@@ -1,0 +1,66 @@
+name: pr-autofill
+
+# Cuando se abre o se reabre una pull request, este workflow busca un
+# descriptor pre-rellenado en `docs/pr-drafts/<rama-aplanada>.md` y, si
+# existe, sobreescribe el cuerpo del PR con su contenido. Si no existe,
+# comenta el PR avisando y deja un warning en el job.
+#
+# Convencion de nombre del descriptor: el nombre de la rama del PR
+# (`github.head_ref`) con `/` reemplazado por `-`. Ejemplo: la rama
+# `phase-1/shield-mvp` busca el descriptor
+# `docs/pr-drafts/phase-1-shield-mvp.md`.
+
+on:
+  pull_request:
+    types: [opened, reopened, ready_for_review]
+
+permissions:
+  pull-requests: write
+  contents: read
+
+jobs:
+  autofill:
+    name: descriptor pre-rellenado
+    runs-on: ubuntu-latest
+    if: github.event.pull_request.draft == false || github.event.action == 'ready_for_review'
+    steps:
+      - name: Checkout de la rama del PR
+        uses: actions/checkout@v4
+        with:
+          ref: ${{ github.event.pull_request.head.sha }}
+          fetch-depth: 1
+
+      - name: Buscar y aplicar descriptor
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+          PR_BRANCH: ${{ github.event.pull_request.head.ref }}
+          REPO: ${{ github.repository }}
+        run: |
+          set -euo pipefail
+          slug="$(printf '%s' "$PR_BRANCH" | tr '/' '-')"
+
+          candidates=(
+            "docs/pr-drafts/${slug}.md"
+            "docs/pr-drafts/${PR_BRANCH}.md"
+          )
+
+          for candidate in "${candidates[@]}"; do
+            if [ -f "$candidate" ]; then
+              echo "Descriptor encontrado: $candidate"
+              gh pr edit "$PR_NUMBER" --repo "$REPO" --body-file "$candidate"
+              echo "::notice title=PR autocompletado::Cuerpo reemplazado desde $candidate."
+              exit 0
+            fi
+          done
+
+          echo "::warning title=Sin descriptor::No hay descriptor para la rama $PR_BRANCH."
+          tmpfile="$(mktemp)"
+          {
+            printf 'Esta pull request no trae descriptor pre-rellenado.\n\n'
+            printf 'Cree el archivo `docs/pr-drafts/%s.md` en la rama `%s` con el resumen, fase afectada, tipo de cambio, documentos relacionados, plan de prueba, criterios de salida y checklist marcados.\n\n' "$slug" "$PR_BRANCH"
+            printf 'Vease `docs/pr-drafts/README.md` para la convencion completa. Tras pushear el descriptor, cierre y reabra esta pull request (o marquela como ready-for-review) para que el cuerpo se autocomplete.\n'
+          } > "$tmpfile"
+          gh pr comment "$PR_NUMBER" --repo "$REPO" --body-file "$tmpfile"
+          rm -f "$tmpfile"
+          exit 1

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -141,13 +141,17 @@ Cambiado:
 - Migracion de `rustls-pemfile` (archivado, RUSTSEC-2025-0134) al
   trait `PemObject` de `rustls-pki-types`. La superficie de API
   publica no se altera.
-- Flujo de pull requests: cada rama trae su descriptor pre-rellenado
-  bajo `docs/pr-drafts/<rama>.md` con resumen, fase, plan de prueba y
-  criterios de salida ya completos. La plantilla
-  `.github/PULL_REQUEST_TEMPLATE.md` se convierte en fallback de
-  emergencia. Regla incorporada a `CLAUDE.md` y `CONTRIBUTING.md`.
-  Descriptor de la rama `phase-0/foundations-and-governance` publicado
-  en `docs/pr-drafts/phase-0-foundations-and-governance.md`.
+- Flujo de pull requests con autofill automatizado: cada rama trae su
+  descriptor pre-rellenado bajo `docs/pr-drafts/<rama-aplanada>.md`
+  (las `/` de la rama se convierten en `-`). El nuevo workflow
+  `.github/workflows/pr-autofill.yml` se dispara al abrir o reabrir
+  la pull request, busca el descriptor y reemplaza el cuerpo del PR
+  con su contenido completo. Si no encuentra descriptor, comenta el
+  PR avisando. La plantilla `.github/PULL_REQUEST_TEMPLATE.md` queda
+  como aviso visible solo en ese caso. Regla incorporada a
+  `CLAUDE.md` y `CONTRIBUTING.md`. Descriptor de la rama
+  `phase-0/foundations-and-governance` publicado en
+  `docs/pr-drafts/phase-0-foundations-and-governance.md`.
 
 Cambiado:
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -879,23 +879,28 @@ una herramienta IA. Esto incluye:
 El trabajo se atribuye unicamente a personas humanas y a la
 organizacion responsable.
 
-### Descriptor pre-rellenado por PR
+### Descriptor pre-rellenado y autofill por PR
 
 Toda rama que vaya a producir una pull request acompana sus commits
 con un descriptor pre-rellenado bajo
-`docs/pr-drafts/<nombre-de-rama>.md`. El descriptor contiene el
-resumen final (titulo del PR), fase afectada, tipo de cambio,
-documentos relacionados, plan de prueba, criterios de salida que
-avanza y checklist final, todo con valores concretos en lugar de los
-placeholders de la plantilla.
+`docs/pr-drafts/<rama-aplanada>.md` (las `/` del nombre de la rama se
+convierten en `-`). El descriptor contiene el resumen final (titulo
+del PR), fase afectada, tipo de cambio, documentos relacionados,
+plan de prueba, criterios de salida que avanza y checklist final,
+todo con valores concretos en lugar de los placeholders de la
+plantilla.
 
-La plantilla en `.github/PULL_REQUEST_TEMPLATE.md` es un fallback
-para casos excepcionales. En operacion normal, el cuerpo del PR es la
-copia del descriptor pre-rellenado. Esta regla evita PRs sin contexto
-y deja trazabilidad permanente del razonamiento del cambio.
+El workflow `.github/workflows/pr-autofill.yml` se dispara al abrir
+o reabrir la pull request, busca el descriptor por nombre de rama
+aplanada y reemplaza el cuerpo del PR con su contenido completo. Si
+no encuentra descriptor, comenta el PR avisando y marca el job como
+warning.
 
-Si un agente o colaborador commitea sin actualizar el descriptor
-correspondiente, la PR no se acepta.
+La plantilla en `.github/PULL_REQUEST_TEMPLATE.md` es solo un aviso
+que aparece cuando el autofill no encuentra descriptor.
+
+Si un agente o colaborador commitea sin crear o actualizar el
+descriptor correspondiente, la PR no se acepta.
 
 ### Prohibicion absoluta de emojis
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -37,10 +37,13 @@ Contributions in Spanish and English are equally welcome.
 2. Mantenga el cambio pequeno y enfocado. Una unidad logica por pull
    request. Si hace falta dividir, divida.
 3. Cree o actualice el descriptor pre-rellenado del PR en
-   `docs/pr-drafts/<nombre-de-rama>.md`. Sin descriptor, el PR no se
-   acepta. Vease `docs/pr-drafts/README.md` para la convencion. La
-   plantilla en `.github/PULL_REQUEST_TEMPLATE.md` es un fallback;
-   el contenido real vive en el descriptor.
+   `docs/pr-drafts/<rama-aplanada>.md` (las `/` se convierten en
+   `-`). Sin descriptor, el PR no se acepta. Vease
+   `docs/pr-drafts/README.md` para la convencion. Al abrir la PR en
+   GitHub, el workflow `pr-autofill` reemplaza automaticamente el
+   cuerpo con el contenido del descriptor. La plantilla en
+   `.github/PULL_REQUEST_TEMPLATE.md` queda como aviso para casos en
+   que el descriptor no exista.
 4. Asegurese de que pasa `cargo fmt --all -- --check`,
    `cargo clippy --workspace --all-targets -- -D warnings`,
    `cargo test --workspace`, `cargo audit` y `cargo deny check`.
@@ -49,10 +52,13 @@ Contributions in Spanish and English are equally welcome.
 6. Actualice `CHANGELOG.md` bajo la seccion `[Unreleased]`.
 7. Verifique las casillas de la `docs/roadmap/STATUS.md` que su pull
    request afecta.
-8. Al abrir el pull request, copie el contenido de
-   `docs/pr-drafts/<nombre-de-rama>.md` al cuerpo del PR en GitHub,
-   reemplazando el fallback de la plantilla. El titulo del PR es el
-   campo "Resumen" del descriptor (256 caracteres o menos).
+8. Al abrir el pull request en GitHub, el workflow `pr-autofill`
+   reemplaza automaticamente el cuerpo con el descriptor de
+   `docs/pr-drafts/`. Si abre la PR y el cuerpo sigue siendo la
+   plantilla de aviso, significa que falta el descriptor: cree el
+   archivo, pushee, y reabra la PR (o marquela ready-for-review)
+   para que se autocomplete. El titulo del PR es el campo "Resumen"
+   del descriptor (256 caracteres o menos).
 9. En el cuerpo del PR enlace a la RFC o ADR relacionada cuando aplique.
 
 ## Convenciones de mensajes

--- a/docs/pr-drafts/README.md
+++ b/docs/pr-drafts/README.md
@@ -35,9 +35,24 @@ subrama tiene su archivo.
 - Antes o durante el commit, no despues.
 - Si los detalles cambian en commits subsiguientes, se actualiza el
   archivo en el mismo commit que introduce el cambio.
-- Al abrir el PR en GitHub, el contenido del archivo se copia al
-  cuerpo del PR. Los `<!-- comentarios -->` del template no aparecen
-  porque ya estan reemplazados por texto concreto.
+- Al abrir el PR en GitHub, el workflow
+  `.github/workflows/pr-autofill.yml` se dispara automaticamente:
+  busca el descriptor por nombre de rama aplanada (las `/` se
+  convierten en `-`), y si lo encuentra reemplaza el cuerpo del PR
+  con su contenido completo. Si no existe, comenta el PR avisando y
+  marca el job como warning.
+
+## Convencion de nombre del archivo (importante para el autofill)
+
+El workflow busca dos rutas, en este orden:
+
+1. `docs/pr-drafts/<rama-aplanada>.md` donde la rama del PR tiene sus
+   `/` reemplazadas por `-`. Ejemplo: para la rama
+   `phase-1/shield-mvp` el archivo es
+   `docs/pr-drafts/phase-1-shield-mvp.md`.
+2. `docs/pr-drafts/<rama-literal>.md` como respaldo, conservando las
+   `/` (lo que crearia subdirectorios). Se recomienda usar la forma
+   aplanada para evitar subdirectorios y simplificar la navegacion.
 
 ## Que debe contener cada descriptor
 

--- a/docs/pr-drafts/phase-0-foundations-and-governance.md
+++ b/docs/pr-drafts/phase-0-foundations-and-governance.md
@@ -117,6 +117,18 @@ construido desde cert/key PEM. Helper `Shield::serve(listener, router)`
 que decide entre transporte plano o TLS segun config. Migracion de
 `rustls-pemfile` (RUSTSEC-2025-0134) a `rustls-pki-types::PemObject`.
 
+### Flujo de descriptores y autofill (commits posteriores)
+
+Introduccion del flujo de descriptor pre-rellenado bajo
+`docs/pr-drafts/<rama-aplanada>.md` y del workflow
+`.github/workflows/pr-autofill.yml`. Al abrir o reabrir una PR, el
+workflow busca el descriptor por nombre de rama (con `/` aplanada a
+`-`) y reemplaza automaticamente el cuerpo del PR con su contenido.
+Si falta, comenta el PR pidiendo crearlo y deja warning en el job.
+Plantilla `.github/PULL_REQUEST_TEMPLATE.md` queda como aviso
+visible solo cuando no hay descriptor. Regla incorporada a
+`CLAUDE.md` y `CONTRIBUTING.md`.
+
 ## Plan de prueba
 
 Desde la raiz del repositorio, sobre la rama


### PR DESCRIPTION
# PR: Fase 0 completa y Fase 1 PRs 1-7 (Shield MVP en construccion)

## Resumen

Fase 0 fundaciones y gobernanza completa en repositorio y siete capas del Shield MVP (HTTP, validacion, CORS, CSRF, rate-limit, JWT Ed25519, TLS 1.3) operativas con 73 tests verde y CI multiplataforma.

## Fase afectada

Fase 0 (Fundaciones y Gobernanza) y Fase 1 (Shield MVP, PRs 1-7 de 11 segun
RFC-0002).

La paralelizacion entre el cierre de las puertas externas de Fase 0 (primer
star externo, Discord con cinco miembros, landing page) y el inicio de
implementacion de Fase 1 esta autorizada explicitamente en
`docs/rfc/RFC-0001-paralelizar-fase-0-externa-y-fase-1.md`. La regla 1 del
proceso queda vigente para fases sucesivas; esta es una excepcion documentada.

## Tipo de cambio

- [x] Documentacion
- [x] Codigo
- [x] Infraestructura o CI
- [x] RFC nueva o actualizacion de RFC
- [x] ADR nuevo
- [x] Seguridad

## Documentos relacionados

- RFC: `docs/rfc/RFC-0001-paralelizar-fase-0-externa-y-fase-1.md`,
  `docs/rfc/RFC-0002-diseno-shield-mvp.md`.
- ADR: `docs/adr/0001-monorepo-workspace.md`,
  `docs/adr/0002-bilingual-documentation.md`,
  `docs/adr/0003-bdfl-governance.md`,
  `docs/adr/0004-descomposicion-de-maestros.md`,
  `docs/adr/0005-contact-identities.md`.
- Maestro afectado: ambos maestros markdown bajo `docs/master/`:
  - `docs/master/ANTI-GRAVITAL-Arquitectura-Tecnica.md` (seccion 15.3
    actualizada con los correos reales).
  - `docs/master/ANTI-GRAVITAL-Hoja-de-Ruta.md` (entregables de Fase 0
    actualizados con los correos reales).
  - Hashes SHA-256 recomputados en `docs/master/VERSION.md` y en el
    workflow `.github/workflows/docs.yml`.

## Detalle por capa entregada

### Fase 0 (commits `0567faa`, `18f2487`)

- Instalacion verbatim de los tres documentos maestros en `docs/master/`.
- Descomposicion navegable de los maestros bajo `docs/architecture/` (20
  capitulos), `docs/roadmap/` (11 fases mas preambulo y reglas de oro),
  `docs/modules/<crate>/` (15 modulos), `docs/dsl/`, `docs/security/`,
  `docs/governance/` y `docs/benchmarks/`.
- `CLAUDE.md` con las 40 reglas de gobernanza tecnica.
- Bilinguidad: `README.md` con bloques espanol e ingles. Indices en
  `docs/es/` y `docs/en/`.
- Gobernanza: `CONTRIBUTING.md`, `GOVERNANCE.md`, `SECURITY.md`,
  `CODE_OF_CONDUCT.md` (Contributor Covenant 2.1), `CHANGELOG.md`.
- Workspace Cargo con los 15 crates declarados y compilando.
- Workflows GitHub Actions: `ci.yml` matriz Linux x86-64 / Linux ARM64 /
  macOS ARM64 / Windows x64, `quality.yml` con fmt, clippy `-D warnings`,
  audit y deny, `docs.yml` con cargo doc, validacion de hashes de
  maestros, rechazo de evidencia IA y rechazo de emojis.
- Plantillas de issue (bug, feature, RFC), `PULL_REQUEST_TEMPLATE.md` y
  `CODEOWNERS`.
- Identidades de contacto oficiales: `anti@gravitalcloud.com` (raiz),
  `angelnereira@gravitalcloud.com` (BDFL), respaldados con ADR-0005 y
  reflejados en maestros, gobernanza y workflows.

### Fase 1 PR 1 (commit `81026f4`)

Bootstrap de `ag-core` con HTTP/1.1 y HTTP/2 sobre Axum + Tokio. Modulos
`error`, `config`, `runtime`, `shield` (con la primera capa, logging
estructurado) y `core` (placeholder estable). `AgError` con
`IntoResponse` y mapeo a status HTTP. `ShieldConfig` deserializable
desde TOML.

### Fase 1 PR 2 (commit `7ea6f94`)

Capa de validacion de payload (`shield::validation`). Trait `Validate`,
agregado `ValidationErrors` con `FieldError` serializable y extractor
`ValidatedJson<T>`. Fallos mapeados a `AgError::Validation` (422) con
detalle estructurado.

### Fix CI (commit `e130e73`)

`Unicode-3.0` anadido a `deny.toml` para destrabar el job
`quality/cargo-deny` tras la entrada de Axum y reqwest (cadena url ->
idna -> icu).

### Fase 1 PR 3 (commit `a5fc479`)

Capa CORS (`shield::cors`) sobre `tower_http::cors::CorsLayer`. API
publica refactorizada de `Shield::layer()` a `Shield::apply(router)`
para que cada capa nueva no rompa la firma de tipos de la pipeline.

### Fase 1 PR 4 (commit `cf2eb7c`)

Capa CSRF (`shield::csrf`) con patron double-submit cookie apatrida.
Skip en metodos seguros (GET, HEAD, OPTIONS, TRACE).

### Fase 1 PR 5 (commit `1a7226d`)

Capa rate-limit (`shield::rate_limit`) con governor sobre token bucket
por IP. Sin `ConnectInfo` la capa pasa transparente.

### Fase 1 PR 6 (commit `8272bdf`)

Capa de autenticacion JWT Ed25519 (`shield::auth`). Verifica
`Authorization: Bearer <token>` contra una clave publica Ed25519
cargada al arranque. Leeway forzado a 0. Inyecta `AuthContext` en las
extensiones del request. Extractor `Claims<T>` para handlers tipados.

### Fase 1 PR 7 (commit `26b6161`)

Capa TLS 1.3 (`shield::tls`) con rustls (provider ring). `TlsAcceptor`
construido desde cert/key PEM. Helper `Shield::serve(listener, router)`
que decide entre transporte plano o TLS segun config. Migracion de
`rustls-pemfile` (RUSTSEC-2025-0134) a `rustls-pki-types::PemObject`.

### Flujo de descriptores y autofill (commits posteriores)

Introduccion del flujo de descriptor pre-rellenado bajo
`docs/pr-drafts/<rama-aplanada>.md` y del workflow
`.github/workflows/pr-autofill.yml`. Al abrir o reabrir una PR, el
workflow busca el descriptor por nombre de rama (con `/` aplanada a
`-`) y reemplaza automaticamente el cuerpo del PR con su contenido.
Si falta, comenta el PR pidiendo crearlo y deja warning en el job.
Plantilla `.github/PULL_REQUEST_TEMPLATE.md` queda como aviso
visible solo cuando no hay descriptor. Regla incorporada a
`CLAUDE.md` y `CONTRIBUTING.md`.

## Plan de prueba

Desde la raiz del repositorio, sobre la rama
`phase-0/foundations-and-governance`:

```sh
# Workspace completo construye.
cargo build --workspace

# Tests pasan: 45 unit + 27 E2E + 1 doctest = 73 verdes en ag-core.
cargo test --workspace

# Formato sin diferencias.
cargo fmt --all -- --check

# Clippy estricto sin warnings.
cargo clippy --workspace --all-targets -- -D warnings

# Politica de dependencias y advisories al dia.
cargo deny check

# Documentacion sin warnings.
cargo doc --workspace --no-deps

# Integridad de los documentos maestros.
sha256sum docs/master/ANTI-GRAVITAL-Blueprint-v4.0.pdf \
          docs/master/ANTI-GRAVITAL-Arquitectura-Tecnica.md \
          docs/master/ANTI-GRAVITAL-Hoja-de-Ruta.md
# Los valores devueltos deben coincidir con docs/master/VERSION.md.

# Ausencia de atribuciones a herramientas IA en archivos del repo.
grep -RIE "Co-Authored-By: (Claude|GPT|Copilot)|claude\.ai/code/session_" \
  --exclude-dir=.git --exclude-dir=target .

# Ausencia de emojis en archivos del repo.
perl -ne 'if (/[\x{1F300}-\x{1FAFF}]|[\x{2600}-\x{27BF}]|[\x{1F000}-\x{1F2FF}]/) { print "$ARGV:$.:$_" }' \
  $(find . -type f \( -name '*.md' -o -name '*.rs' -o -name '*.toml' -o -name '*.yml' -o -name '*.yaml' -o -name '*.sh' \) -not -path './target/*' -not -path './.git/*')
```

## Criterios de salida que avanza

De `docs/roadmap/STATUS.md`, esta unidad de cambio marca:

Fase 0:

- [x] Repositorio creado y publico.
- [x] LICENSE Apache 2.0.
- [x] README.md bilingue.
- [x] CONTRIBUTING.md, CODE_OF_CONDUCT.md, SECURITY.md, GOVERNANCE.md.
- [x] CI en cuatro plataformas (pendiente de verde en el primer run).
- [x] Plantillas de issue, PR y RFC.
- [x] Estructura del monorepo definida.
- [x] Workspace Cargo con 15 crates vacios.
- [x] Email institucional operativo (`anti@gravitalcloud.com`).

Fase 1:

- [x] Crate `ag-core` con modulo `shield` operativo.
- [x] Soporte HTTP/1.1 y HTTP/2 via Axum + Tokio.
- [x] Terminacion TLS 1.3 con rustls.
- [x] Middleware de validacion de payload basico.
- [x] Middleware de autenticacion JWT con verificacion Ed25519.
- [x] Middleware de rate limiting con governor.
- [x] Middleware CORS y CSRF con defaults seguros.
- [x] Middleware de logging estructurado con `tracing`.

Queda fuera de este PR y pendiente para PRs siguientes de Fase 1:
configuracion minima desde archivo TOML completa (PR 8), tests con
cobertura >=80% del crate (en buen camino; PR 10), tests E2E del
pipeline completo (PR 10), benchmark Hello World con criterion (PR 9),
documentacion API en docs.rs (PR 11), capitulo del manual de usuario
(PR 11), y las metricas duras de cierre de Fase 1 (>=300K req/s en
hardware de referencia, p99 <=1ms, memoria idle <=15MB, arranque
<=100ms, blog post, 10 stars).

## Checklist

- [x] Titulo de PR de 256 caracteres o menos.
- [x] Sin emojis en ningun archivo modificado.
- [x] Sin atribuciones de herramientas IA.
- [x] Documentacion actualizada en el mismo PR (CHANGELOG, STATUS,
  RFCs, ADRs, READMEs por modulo).
- [x] CHANGELOG.md actualizado bajo `[Unreleased]` con seccion Fase 0 y
  seccion Fase 1.
- [x] CLAUDE.md respetado: alcance (Fase 0 + Fase 1 dentro de scope),
  fase (transicion documentada en RFC-0001), dependencias (solo las
  declaradas en RFC-0002), seguridad (defaults seguros, leeway JWT 0,
  CORS deshabilitado por defecto, sin `unsafe` en codigo propio).
