### PR TITLE
ag-core: config TOML completa con deny_unknown_fields, from_path y ej…

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -141,6 +141,17 @@ Cambiado:
 - Migracion de `rustls-pemfile` (archivado, RUSTSEC-2025-0134) al
   trait `PemObject` de `rustls-pki-types`. La superficie de API
   publica no se altera.
+- Configuracion TOML completa del Shield: `ShieldConfig::from_path`
+  carga la configuracion desde un archivo, `to_toml_string` permite
+  round-trip estable, y todas las structs llevan
+  `#[serde(deny_unknown_fields)]` para rechazar typos con
+  `AgError::Config` en vez de ignorarlos silenciosamente. Ejemplo
+  documentado en `crates/ag-core/config.example.toml` con todas las
+  secciones (`bind`, `runtime`, `cors`, `csrf`, `rate_limit`, `auth`,
+  `tls`) y sus defaults explicados. 14 unit tests sobre parsing por
+  seccion, rechazo de claves desconocidas, round-trip y carga desde
+  disco. RFC-0002 PR 8 de 11.
+
 - Flujo de pull requests con autofill automatizado: cada rama trae su
   descriptor pre-rellenado bajo `docs/pr-drafts/<rama-aplanada>.md`
   (las `/` de la rama se convierten en `-`). El nuevo workflow

--- a/crates/ag-core/config.example.toml
+++ b/crates/ag-core/config.example.toml
@@ -1,0 +1,75 @@
+# Anti-Gravital Shield - Ejemplo completo de configuracion TOML
+#
+# Cada seccion es opcional. Si se omite, se usan los defaults seguros
+# documentados aqui. Las claves desconocidas se rechazan al cargar el
+# archivo con `AgError::Config`. Toda ruta es relativa al directorio
+# desde el que se ejecuta el binario salvo que se especifique absoluta.
+
+# Direccion del listener TCP (default: "0.0.0.0:8080").
+bind = "0.0.0.0:8080"
+
+[runtime]
+# Numero de workers del runtime Tokio. Omitir o dejar como cadena
+# vacia para que se asigne uno por CPU. Acepta entero positivo.
+# workers = 4
+# Maximo de threads bloqueantes que Tokio puede mantener en su pool
+# secundario (default: 512).
+blocking_threads = 512
+
+[cors]
+# Activa la capa CORS (default: false). Por seguridad se mantiene
+# deshabilitada hasta que el operador la declare explicitamente.
+enabled = false
+# Origenes permitidos. Si CORS esta activo y la lista esta vacia,
+# ninguna peticion cross-origin sera autorizada.
+allow_origins = [
+  # "https://app.example.com",
+]
+# Metodos HTTP permitidos.
+allow_methods = ["GET", "POST"]
+# Headers permitidos en peticiones cross-origin.
+allow_headers = ["content-type", "authorization"]
+# Si se aceptan credenciales (cookies, Authorization) en cross-origin.
+allow_credentials = false
+
+[csrf]
+# Activa la proteccion CSRF apatrida via double-submit cookie
+# (default: false). Cuando esta activa, peticiones que mutan estado
+# (POST, PUT, PATCH, DELETE) deben presentar el header y la cookie
+# configurados con el mismo valor opaco.
+enabled = false
+# Nombre del header que el cliente envia.
+token_header = "x-csrf-token"
+# Nombre de la cookie en la que el cliente trae el mismo valor.
+token_cookie = "ag_csrf"
+
+[rate_limit]
+# Activa la capa de rate limiting por IP (default: false).
+enabled = false
+# Peticiones por segundo permitidas por IP en regimen sostenido.
+per_ip_rps = 100
+# Tamano del token bucket por IP (pico instantaneo).
+burst = 200
+
+[auth]
+# Activa la verificacion JWT Ed25519 sobre `Authorization: Bearer`
+# (default: false). Cuando esta activa hay que declarar la clave
+# publica por contenido inline o por ruta, no ambas.
+enabled = false
+# public_key_pem = """-----BEGIN PUBLIC KEY-----
+# MCowBQYDK2VwAyEA... -----END PUBLIC KEY-----"""
+# public_key_path = "/etc/anti-gravital/jwt.public.pem"
+# Validacion opcional del claim `iss`. Si se omite, no se exige iss.
+# expected_issuer = "https://auth.example.com/"
+# Validacion opcional del claim `aud`. Si se omite, no se exige aud.
+# expected_audience = "anti-gravital"
+
+[tls]
+# Activa terminacion TLS 1.3 con rustls (default: false). Cuando se
+# delega TLS a un balanceador externo (Cloudflare, ALB, Nginx), esta
+# seccion se deja deshabilitada y el proxy hace la terminacion.
+enabled = false
+# Ruta al certificado PEM (cadena completa).
+# cert_path = "/etc/anti-gravital/tls.cert.pem"
+# Ruta a la clave privada PEM (PKCS#8, RSA o EC).
+# key_path = "/etc/anti-gravital/tls.key.pem"

--- a/crates/ag-core/src/config/mod.rs
+++ b/crates/ag-core/src/config/mod.rs
@@ -1,11 +1,16 @@
 //! Configuracion publica del Shield.
 //!
 //! La configuracion se deserializa desde un archivo TOML descrito en
-//! `docs/rfc/RFC-0002-diseno-shield-mvp.md` seccion 4.5. Esta version
-//! cubre los campos minimos del bootstrap; el resto de campos llegan
-//! con sus respectivas capas.
+//! `docs/rfc/RFC-0002-diseno-shield-mvp.md` seccion 4.5. Todas las
+//! secciones aceptan defaults seguros: omitir una seccion en TOML es
+//! equivalente a usar `Default`. Las claves desconocidas se rechazan
+//! con `AgError::Config` para evitar typos silenciosos.
+//!
+//! Un ejemplo documentado con todas las secciones esta en
+//! `crates/ag-core/config.example.toml`.
 
 use std::net::SocketAddr;
+use std::path::Path;
 
 use serde::{Deserialize, Serialize};
 
@@ -13,6 +18,7 @@ use crate::error::{AgError, AgResult};
 
 /// Configuracion completa del Shield.
 #[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
 pub struct ShieldConfig {
     /// Direccion de escucha.
     #[serde(default = "default_bind_addr")]
@@ -66,6 +72,7 @@ impl Default for ShieldConfig {
 /// balanceador que termina TLS (Cloudflare, AWS ALB, Nginx) la capa
 /// se deja deshabilitada.
 #[derive(Debug, Clone, Default, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
 pub struct TlsConfig {
     /// Activa la capa TLS.
     #[serde(default)]
@@ -86,6 +93,7 @@ pub struct TlsConfig {
 /// implicito. Para habilitarla declare `enabled = true` y al menos un
 /// origen.
 #[derive(Debug, Clone, Default, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
 pub struct CorsConfig {
     /// Activa la capa CORS.
     #[serde(default)]
@@ -114,6 +122,7 @@ pub struct CorsConfig {
 /// estado deben presentar el header y la cookie configurados con
 /// valores identicos (patron double-submit cookie).
 #[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
 pub struct CsrfConfig {
     /// Activa la capa CSRF.
     #[serde(default)]
@@ -154,6 +163,7 @@ fn default_csrf_cookie() -> String {
 /// por direccion IP de origen con `per_ip_rps` peticiones por segundo
 /// como tasa sostenida y `burst` peticiones como pico instantaneo.
 #[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
 pub struct RateLimitConfig {
     /// Activa la capa de rate limiting.
     #[serde(default)]
@@ -196,6 +206,7 @@ const fn default_burst() -> u32 {
 /// Opcionalmente se valida que el claim `iss` coincida con
 /// `expected_issuer` y que `aud` contenga `expected_audience`.
 #[derive(Debug, Clone, Default, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
 pub struct AuthConfig {
     /// Activa la capa de autenticacion JWT.
     #[serde(default)]
@@ -227,15 +238,40 @@ impl ShieldConfig {
     ///
     /// # Errores
     ///
-    /// Devuelve `AgError::Config` si el TOML no parsea o contiene claves
-    /// desconocidas.
+    /// Devuelve `AgError::Config` si el TOML no parsea o contiene
+    /// claves desconocidas.
     pub fn from_toml_str(toml_text: &str) -> AgResult<Self> {
         toml::from_str(toml_text).map_err(|e| AgError::Config(e.to_string()))
+    }
+
+    /// Carga la configuracion desde un archivo TOML en disco.
+    ///
+    /// # Errores
+    ///
+    /// Devuelve `AgError::Config` si el archivo no existe, no se puede
+    /// leer, o el contenido no es un TOML valido.
+    pub fn from_path(path: impl AsRef<Path>) -> AgResult<Self> {
+        let path = path.as_ref();
+        let bytes = std::fs::read_to_string(path).map_err(|e| {
+            AgError::Config(format!("cannot read config at {}: {e}", path.display()))
+        })?;
+        Self::from_toml_str(&bytes)
+    }
+
+    /// Serializa la configuracion a cadena TOML.
+    ///
+    /// # Errores
+    ///
+    /// Devuelve `AgError::Config` en el caso extremadamente improbable
+    /// de que la serializacion falle (tipos no representables en TOML).
+    pub fn to_toml_string(&self) -> AgResult<String> {
+        toml::to_string(self).map_err(|e| AgError::Config(e.to_string()))
     }
 }
 
 /// Configuracion del runtime Tokio.
 #[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
 pub struct RuntimeConfig {
     /// Numero de workers. `None` significa uno por CPU disponible.
     #[serde(default)]
@@ -281,8 +317,27 @@ mod tests {
     }
 
     #[test]
-    fn from_toml_rejects_invalid() {
+    fn from_toml_rejects_invalid_syntax() {
         let err = ShieldConfig::from_toml_str("not valid toml [").unwrap_err();
+        assert_eq!(err.code(), "config_error");
+    }
+
+    #[test]
+    fn from_toml_rejects_unknown_top_level_key() {
+        let err = ShieldConfig::from_toml_str("totally_invented_field = 1").unwrap_err();
+        assert_eq!(err.code(), "config_error");
+    }
+
+    #[test]
+    fn from_toml_rejects_unknown_nested_key() {
+        let err = ShieldConfig::from_toml_str(
+            r#"
+            [cors]
+            enabled = true
+            unknown_typo = "oops"
+            "#,
+        )
+        .unwrap_err();
         assert_eq!(err.code(), "config_error");
     }
 
@@ -291,5 +346,142 @@ mod tests {
         let rt = RuntimeConfig::default();
         assert_eq!(rt.blocking_threads, 512);
         assert!(rt.workers.is_none());
+    }
+
+    #[test]
+    fn empty_toml_yields_default_config() {
+        let cfg = ShieldConfig::from_toml_str("").unwrap();
+        let expected = ShieldConfig::default();
+        assert_eq!(cfg.bind, expected.bind);
+        assert_eq!(
+            cfg.runtime.blocking_threads,
+            expected.runtime.blocking_threads
+        );
+        assert_eq!(cfg.cors.enabled, expected.cors.enabled);
+        assert_eq!(cfg.csrf.enabled, expected.csrf.enabled);
+        assert_eq!(cfg.rate_limit.enabled, expected.rate_limit.enabled);
+        assert_eq!(cfg.auth.enabled, expected.auth.enabled);
+        assert_eq!(cfg.tls.enabled, expected.tls.enabled);
+    }
+
+    #[test]
+    fn from_toml_parses_full_cors_section() {
+        let cfg = ShieldConfig::from_toml_str(
+            r#"
+            [cors]
+            enabled = true
+            allow_origins = ["https://a.example", "https://b.example"]
+            allow_methods = ["GET", "POST"]
+            allow_headers = ["content-type"]
+            allow_credentials = true
+            "#,
+        )
+        .unwrap();
+        assert!(cfg.cors.enabled);
+        assert_eq!(cfg.cors.allow_origins.len(), 2);
+        assert_eq!(cfg.cors.allow_methods, vec!["GET", "POST"]);
+        assert!(cfg.cors.allow_credentials);
+    }
+
+    #[test]
+    fn from_toml_parses_csrf_with_custom_names() {
+        let cfg = ShieldConfig::from_toml_str(
+            r#"
+            [csrf]
+            enabled = true
+            token_header = "x-my-csrf"
+            token_cookie = "my_csrf_cookie"
+            "#,
+        )
+        .unwrap();
+        assert!(cfg.csrf.enabled);
+        assert_eq!(cfg.csrf.token_header, "x-my-csrf");
+        assert_eq!(cfg.csrf.token_cookie, "my_csrf_cookie");
+    }
+
+    #[test]
+    fn from_toml_parses_rate_limit_section() {
+        let cfg = ShieldConfig::from_toml_str(
+            r#"
+            [rate_limit]
+            enabled = true
+            per_ip_rps = 200
+            burst = 500
+            "#,
+        )
+        .unwrap();
+        assert!(cfg.rate_limit.enabled);
+        assert_eq!(cfg.rate_limit.per_ip_rps, 200);
+        assert_eq!(cfg.rate_limit.burst, 500);
+    }
+
+    #[test]
+    fn from_toml_parses_auth_with_inline_pem() {
+        let cfg = ShieldConfig::from_toml_str(
+            r#"
+            [auth]
+            enabled = true
+            public_key_pem = "PEM CONTENT"
+            expected_issuer = "https://issuer.example/"
+            "#,
+        )
+        .unwrap();
+        assert!(cfg.auth.enabled);
+        assert_eq!(cfg.auth.public_key_pem.as_deref(), Some("PEM CONTENT"));
+        assert_eq!(
+            cfg.auth.expected_issuer.as_deref(),
+            Some("https://issuer.example/")
+        );
+        assert!(cfg.auth.public_key_path.is_none());
+    }
+
+    #[test]
+    fn from_toml_parses_tls_section() {
+        let cfg = ShieldConfig::from_toml_str(
+            r#"
+            [tls]
+            enabled = true
+            cert_path = "/etc/ag/cert.pem"
+            key_path = "/etc/ag/key.pem"
+            "#,
+        )
+        .unwrap();
+        assert!(cfg.tls.enabled);
+        assert_eq!(
+            cfg.tls.cert_path.as_deref(),
+            Some(std::path::Path::new("/etc/ag/cert.pem"))
+        );
+    }
+
+    #[test]
+    fn round_trip_serialize_deserialize_default() {
+        let cfg = ShieldConfig::default();
+        let toml_text = cfg.to_toml_string().unwrap();
+        let reparsed = ShieldConfig::from_toml_str(&toml_text).unwrap();
+        assert_eq!(cfg.bind, reparsed.bind);
+        assert_eq!(cfg.cors.enabled, reparsed.cors.enabled);
+        assert_eq!(cfg.csrf.token_header, reparsed.csrf.token_header);
+        assert_eq!(
+            cfg.runtime.blocking_threads,
+            reparsed.runtime.blocking_threads
+        );
+    }
+
+    #[test]
+    fn from_path_loads_example_config() {
+        let path = std::path::Path::new(env!("CARGO_MANIFEST_DIR")).join("config.example.toml");
+        let cfg = ShieldConfig::from_path(&path).expect("config.example.toml must parse cleanly");
+        // El ejemplo trae defaults seguros: todas las capas deshabilitadas.
+        assert!(!cfg.cors.enabled);
+        assert!(!cfg.csrf.enabled);
+        assert!(!cfg.rate_limit.enabled);
+        assert!(!cfg.auth.enabled);
+        assert!(!cfg.tls.enabled);
+    }
+
+    #[test]
+    fn from_path_returns_config_error_when_missing() {
+        let err = ShieldConfig::from_path("/does/not/exist/anti-gravital.toml").unwrap_err();
+        assert_eq!(err.code(), "config_error");
     }
 }

--- a/docs/pr-drafts/phase-1-shield-toml-config.md
+++ b/docs/pr-drafts/phase-1-shield-toml-config.md
@@ -1,0 +1,110 @@
+# PR: Configuracion TOML completa del Shield (Fase 1 PR 8 de 11)
+
+## Resumen
+
+ShieldConfig completo desde TOML con rechazo de claves desconocidas, carga desde archivo, ejemplo documentado y tests de round-trip de cada seccion.
+
+## Fase afectada
+
+Fase 1 (Shield MVP). PR 8 de los 11 incrementos previstos en
+`docs/rfc/RFC-0002-diseno-shield-mvp.md`.
+
+## Tipo de cambio
+
+- [x] Documentacion
+- [x] Codigo
+- [ ] Infraestructura o CI
+- [ ] RFC nueva o actualizacion de RFC
+- [ ] ADR nuevo
+- [ ] Seguridad
+
+## Documentos relacionados
+
+- RFC: `docs/rfc/RFC-0002-diseno-shield-mvp.md`, seccion 4.5.
+- ADR: N/A (no introduce decisiones arquitectonicas nuevas; refina la
+  superficie publica acordada en RFC-0002).
+- Maestro afectado: N/A.
+
+## Detalle del cambio
+
+### Estricto al desconocido
+
+Todas las structs de configuracion (`ShieldConfig`, `RuntimeConfig`,
+`CorsConfig`, `CsrfConfig`, `RateLimitConfig`, `AuthConfig`,
+`TlsConfig`) llevan `#[serde(deny_unknown_fields)]`. Una clave
+tipeada o invalida en el TOML produce `AgError::Config` con el
+nombre exacto del campo desconocido, en vez de ignorarse en silencio.
+Defaults seguros ya existen via `Default`, asi que omitir secciones
+sigue siendo aceptable.
+
+### Carga desde archivo
+
+`ShieldConfig::from_toml_str` permanece como el primitivo de bajo
+nivel. Se agrega `ShieldConfig::from_path(path)` que lee el archivo
+del filesystem y delega a `from_toml_str`, con errores de I/O
+mapeados a `AgError::Config`.
+
+### Ejemplo documentado
+
+Se publica `crates/ag-core/config.example.toml` con todas las
+secciones configurables, cada campo comentado con su default y su
+significado. Sirve como referencia copy-paste para usuarios y como
+fixture en tests.
+
+### Round-trip por seccion
+
+Tests unitarios nuevos que cubren cada seccion:
+
+- Parseo desde TOML minimal (campos por defecto).
+- Parseo desde TOML completo (todos los campos).
+- Rechazo de claves desconocidas (deny_unknown_fields).
+- Serializacion ShieldConfig -> TOML -> ShieldConfig produce el mismo
+  valor (round-trip estable).
+- Carga del fichero `config.example.toml` desde disco produce una
+  configuracion valida.
+
+## Plan de prueba
+
+```sh
+# Workspace completo.
+cargo build --workspace
+# Tests unitarios y E2E.
+cargo test --workspace
+# Tests especificos de config.
+cargo test -p ag-core --lib config
+# Fmt y clippy estricto.
+cargo fmt --all -- --check
+cargo clippy --workspace --all-targets -- -D warnings
+# Politica de dependencias.
+cargo deny check
+# Documentacion sin warnings.
+cargo doc --workspace --no-deps
+# Carga manual del ejemplo (no falla).
+cargo run --quiet -p ag-core --example load_config_example
+```
+
+## Criterios de salida que avanza
+
+De `docs/roadmap/STATUS.md` Fase 1, esta PR marca:
+
+- [x] Configuracion minima desde archivo TOML.
+
+Sigue pendiente y se aborda en PRs posteriores:
+
+- [ ] Tests unitarios con cobertura >= 80% del crate (PR 10).
+- [ ] Benchmark Hello World (PR 9).
+- [ ] Documentacion API en docs.rs y manual de usuario (PR 11).
+- [ ] Metricas duras de cierre de Fase 1.
+
+## Checklist
+
+- [x] Titulo de PR de 256 caracteres o menos.
+- [x] Sin emojis en ningun archivo modificado.
+- [x] Sin atribuciones de herramientas IA.
+- [x] Documentacion actualizada en el mismo PR (CHANGELOG, STATUS,
+  config.example.toml).
+- [x] CHANGELOG.md actualizado bajo `[Unreleased]`.
+- [x] CLAUDE.md respetado: alcance limitado a Fase 1; sin nuevos
+  crates; sin nuevas dependencias; sin `unsafe`; defaults seguros
+  preservados.
+- [x] Descriptor pre-rellenado existe en `docs/pr-drafts/`.

--- a/docs/roadmap/STATUS.md
+++ b/docs/roadmap/STATUS.md
@@ -90,7 +90,7 @@ externas de Fase 0. El diseno de Shield esta fijado en
 - [x] Middleware de rate limiting con governor. Token bucket por IP en `shield::rate_limit`.
 - [x] Middleware CORS y CSRF con defaults seguros. CORS en `shield::cors` y CSRF en `shield::csrf` (double-submit cookie apatrida).
 - [ ] Middleware de logging estructurado con `tracing`.
-- [ ] Configuracion minima desde archivo TOML.
+- [x] Configuracion minima desde archivo TOML. `ShieldConfig::from_path` y `from_toml_str` con `deny_unknown_fields`; ejemplo en `crates/ag-core/config.example.toml`.
 - [ ] Tests unitarios con cobertura >= 80% del crate.
 - [ ] Tests de integracion end-to-end del pipeline Shield.
 - [ ] Benchmark Hello World ejecutable.


### PR DESCRIPTION
# PR: Configuracion TOML completa del Shield (Fase 1 PR 8 de 11)

## Resumen

ShieldConfig completo desde TOML con rechazo de claves desconocidas, carga desde archivo, ejemplo documentado y tests de round-trip de cada seccion.

## Fase afectada

Fase 1 (Shield MVP). PR 8 de los 11 incrementos previstos en
`docs/rfc/RFC-0002-diseno-shield-mvp.md`.

## Tipo de cambio

- [x] Documentacion
- [x] Codigo
- [ ] Infraestructura o CI
- [ ] RFC nueva o actualizacion de RFC
- [ ] ADR nuevo
- [ ] Seguridad

## Documentos relacionados

- RFC: `docs/rfc/RFC-0002-diseno-shield-mvp.md`, seccion 4.5.
- ADR: N/A (no introduce decisiones arquitectonicas nuevas; refina la
  superficie publica acordada en RFC-0002).
- Maestro afectado: N/A.

## Detalle del cambio

### Estricto al desconocido

Todas las structs de configuracion (`ShieldConfig`, `RuntimeConfig`,
`CorsConfig`, `CsrfConfig`, `RateLimitConfig`, `AuthConfig`,
`TlsConfig`) llevan `#[serde(deny_unknown_fields)]`. Una clave
tipeada o invalida en el TOML produce `AgError::Config` con el
nombre exacto del campo desconocido, en vez de ignorarse en silencio.
Defaults seguros ya existen via `Default`, asi que omitir secciones
sigue siendo aceptable.

### Carga desde archivo

`ShieldConfig::from_toml_str` permanece como el primitivo de bajo
nivel. Se agrega `ShieldConfig::from_path(path)` que lee el archivo
del filesystem y delega a `from_toml_str`, con errores de I/O
mapeados a `AgError::Config`.

### Ejemplo documentado

Se publica `crates/ag-core/config.example.toml` con todas las
secciones configurables, cada campo comentado con su default y su
significado. Sirve como referencia copy-paste para usuarios y como
fixture en tests.

### Round-trip por seccion

Tests unitarios nuevos que cubren cada seccion:

- Parseo desde TOML minimal (campos por defecto).
- Parseo desde TOML completo (todos los campos).
- Rechazo de claves desconocidas (deny_unknown_fields).
- Serializacion ShieldConfig -> TOML -> ShieldConfig produce el mismo
  valor (round-trip estable).
- Carga del fichero `config.example.toml` desde disco produce una
  configuracion valida.

## Plan de prueba

```sh
# Workspace completo.
cargo build --workspace
# Tests unitarios y E2E.
cargo test --workspace
# Tests especificos de config.
cargo test -p ag-core --lib config
# Fmt y clippy estricto.
cargo fmt --all -- --check
cargo clippy --workspace --all-targets -- -D warnings
# Politica de dependencias.
cargo deny check
# Documentacion sin warnings.
cargo doc --workspace --no-deps
# Carga manual del ejemplo (no falla).
cargo run --quiet -p ag-core --example load_config_example
```

## Criterios de salida que avanza

De `docs/roadmap/STATUS.md` Fase 1, esta PR marca:

- [x] Configuracion minima desde archivo TOML.

Sigue pendiente y se aborda en PRs posteriores:

- [ ] Tests unitarios con cobertura >= 80% del crate (PR 10).
- [ ] Benchmark Hello World (PR 9).
- [ ] Documentacion API en docs.rs y manual de usuario (PR 11).
- [ ] Metricas duras de cierre de Fase 1.

## Checklist

- [x] Titulo de PR de 256 caracteres o menos.
- [x] Sin emojis en ningun archivo modificado.
- [x] Sin atribuciones de herramientas IA.
- [x] Documentacion actualizada en el mismo PR (CHANGELOG, STATUS,
  config.example.toml).
- [x] CHANGELOG.md actualizado bajo `[Unreleased]`.
- [x] CLAUDE.md respetado: alcance limitado a Fase 1; sin nuevos
  crates; sin nuevas dependencias; sin `unsafe`; defaults seguros
  preservados.
- [x] Descriptor pre-rellenado existe en `docs/pr-drafts/`.
