### PR TITLE
ag-core: paths temporales unicos en tests TLS (fix race windows-x64)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,20 @@ primera version etiquetada.
 
 ## [Unreleased]
 
+### Hotfix de Fase 1 (segundo)
+
+Cambiado:
+
+- Generacion de rutas temporales en tests TLS (`tests/shield_full_pipeline.rs`,
+  `tests/shield_tls.rs`, `src/shield/tls.rs::tests`) usa `AtomicUsize`
+  + pid del proceso en lugar de `SystemTime::now().as_nanos()`. El
+  timestamp en Windows tiene resolucion de ~15ms, lo que producia
+  colisiones de archivo entre tests paralelos: dos tests escribian
+  cert/key en el mismo path y uno sobreescribia al otro mid-test.
+  Sintoma: 3 de 6 tests de `shield_full_pipeline` fallaban
+  intermitentemente en `build (windows-x64)`. Verificado con
+  `RUST_TEST_THREADS=16`.
+
 ### Hotfix de Fase 1
 
 Cambiado:

--- a/crates/ag-core/src/shield/tls.rs
+++ b/crates/ag-core/src/shield/tls.rs
@@ -84,14 +84,14 @@ fn load_private_key(path: &Path) -> Result<PrivateKeyDer<'static>, AgError> {
 mod tests {
     use super::*;
     use std::io::Write;
+    use std::sync::atomic::{AtomicUsize, Ordering};
+
+    static TMP_COUNTER: AtomicUsize = AtomicUsize::new(0);
 
     fn tmpfile(contents: &[u8]) -> std::path::PathBuf {
-        let mut path = std::env::temp_dir();
-        let nanos = std::time::SystemTime::now()
-            .duration_since(std::time::UNIX_EPOCH)
-            .unwrap()
-            .as_nanos();
-        path.push(format!("ag-core-tls-{nanos}.pem"));
+        let n = TMP_COUNTER.fetch_add(1, Ordering::Relaxed);
+        let pid = std::process::id();
+        let path = std::env::temp_dir().join(format!("ag-core-tls-{pid}-{n}.pem"));
         let mut f = std::fs::File::create(&path).unwrap();
         f.write_all(contents).unwrap();
         path

--- a/crates/ag-core/tests/shield_full_pipeline.rs
+++ b/crates/ag-core/tests/shield_full_pipeline.rs
@@ -27,7 +27,16 @@ use serde::{Deserialize, Serialize};
 use std::io::Write;
 use std::net::SocketAddr;
 use std::path::PathBuf;
+use std::sync::atomic::{AtomicUsize, Ordering};
 use std::time::{SystemTime, UNIX_EPOCH};
+
+static TMP_COUNTER: AtomicUsize = AtomicUsize::new(0);
+
+fn unique_temp(prefix: &str) -> PathBuf {
+    let n = TMP_COUNTER.fetch_add(1, Ordering::Relaxed);
+    let pid = std::process::id();
+    std::env::temp_dir().join(format!("{prefix}-{pid}-{n}.pem"))
+}
 
 const ALLOWED_ORIGIN: &str = "https://app.example.com";
 const CSRF_TOKEN: &str = "csrf-token-abc";
@@ -93,13 +102,8 @@ fn generate_tls_cert() -> (PathBuf, PathBuf) {
     let cert =
         rcgen::generate_simple_self_signed(vec!["localhost".to_owned(), "127.0.0.1".to_owned()])
             .unwrap();
-    let nanos = SystemTime::now()
-        .duration_since(UNIX_EPOCH)
-        .unwrap()
-        .as_nanos();
-    let dir = std::env::temp_dir();
-    let cert_path = dir.join(format!("ag-fp-cert-{nanos}.pem"));
-    let key_path = dir.join(format!("ag-fp-key-{nanos}.pem"));
+    let cert_path = unique_temp("ag-fp-cert");
+    let key_path = unique_temp("ag-fp-key");
     std::fs::File::create(&cert_path)
         .unwrap()
         .write_all(cert.cert.pem().as_bytes())

--- a/crates/ag-core/tests/shield_tls.rs
+++ b/crates/ag-core/tests/shield_tls.rs
@@ -8,6 +8,15 @@ use axum::routing::get;
 use axum::Router;
 use std::io::Write;
 use std::path::PathBuf;
+use std::sync::atomic::{AtomicUsize, Ordering};
+
+static TMP_COUNTER: AtomicUsize = AtomicUsize::new(0);
+
+fn unique_temp(prefix: &str) -> PathBuf {
+    let n = TMP_COUNTER.fetch_add(1, Ordering::Relaxed);
+    let pid = std::process::id();
+    std::env::temp_dir().join(format!("{prefix}-{pid}-{n}.pem"))
+}
 
 fn generate_cert_pair() -> (PathBuf, PathBuf) {
     let subject_alt_names = vec!["localhost".to_owned(), "127.0.0.1".to_owned()];
@@ -15,13 +24,8 @@ fn generate_cert_pair() -> (PathBuf, PathBuf) {
     let cert_pem = cert.cert.pem();
     let key_pem = cert.key_pair.serialize_pem();
 
-    let nanos = std::time::SystemTime::now()
-        .duration_since(std::time::UNIX_EPOCH)
-        .unwrap()
-        .as_nanos();
-    let dir = std::env::temp_dir();
-    let cert_path = dir.join(format!("ag-tls-cert-{nanos}.pem"));
-    let key_path = dir.join(format!("ag-tls-key-{nanos}.pem"));
+    let cert_path = unique_temp("ag-tls-cert");
+    let key_path = unique_temp("ag-tls-key");
 
     let mut cf = std::fs::File::create(&cert_path).unwrap();
     cf.write_all(cert_pem.as_bytes()).unwrap();

--- a/docs/pr-drafts/hotfix-tls-test-tmp-collisions.md
+++ b/docs/pr-drafts/hotfix-tls-test-tmp-collisions.md
@@ -1,0 +1,108 @@
+# Hotfix: colision de paths temporales entre tests TLS paralelos en Windows
+
+## Resumen
+
+Fix de colision de archivos /tmp en tests TLS por baja resolucion de `SystemTime::as_nanos()` en Windows. Genera paths unicos con pid+counter en lugar de timestamp.
+
+## Fase afectada
+
+Fase 1 (Shield MVP). Segundo hotfix del CI tras la merge del primer
+hotfix (`1f456b7` en main). Macos-arm64 paso a verde, pero windows-x64
+empezo a fallar de forma intermitente en `shield_full_pipeline.rs`.
+
+## Tipo de cambio
+
+- [ ] Documentacion
+- [x] Codigo
+- [x] Infraestructura o CI
+- [ ] RFC nueva o actualizacion de RFC
+- [ ] ADR nuevo
+- [ ] Seguridad
+
+## Documentos relacionados
+
+- RFC: `docs/rfc/RFC-0002-diseno-shield-mvp.md`.
+- ADR: N/A.
+- Maestro afectado: N/A.
+
+## Diagnostico
+
+CI run #20 (commit `1f456b7`) mostro `build (windows-x64)` rojo con
+tres tests fallando en `tests/shield_full_pipeline.rs`. Los tres
+fallidos varian entre corridas, lo que indica race en lugar de bug
+deterministico. Las otras tres plataformas (linux-x86-64, linux-arm64,
+macos-arm64) verde.
+
+Causa raiz: las funciones helper `generate_tls_cert` (en
+`tests/shield_full_pipeline.rs`) y `generate_cert_pair` (en
+`tests/shield_tls.rs`) construyen rutas temporales con
+`SystemTime::now().duration_since(UNIX_EPOCH).as_nanos()`. En Linux y
+macOS la resolucion del reloj es del orden de microsegundos. En
+Windows, la resolucion efectiva de `SystemTime::now()` es de unos 15
+ms, asi que dos tests que corren en paralelo dentro de la misma
+ventana de 15 ms generan exactamente el mismo path.
+
+Cuando A escribe su cert/key y B escribe los suyos en el mismo path,
+B sobreescribe a A. Si A esta en medio de leer el archivo (en
+`build_acceptor`) mientras B escribe, A puede leer contenido
+parcial y fallar el handshake TLS. Tambien provoca mezcla de
+cert/key entre tests, lo que rompe la verificacion.
+
+El mismo patron afecta a `tmpfile` en
+`crates/ag-core/src/shield/tls.rs` (tests internos), aunque alli el
+riesgo es menor porque los tests internos no corren TLS handshakes.
+
+## Fix
+
+Sustituye el uso de `SystemTime` por un counter atomico + pid del
+proceso, garantizando unicidad sin depender de la resolucion del
+reloj:
+
+```rust
+static COUNTER: AtomicUsize = AtomicUsize::new(0);
+
+fn unique_temp(prefix: &str) -> PathBuf {
+    let n = COUNTER.fetch_add(1, Ordering::Relaxed);
+    let pid = std::process::id();
+    std::env::temp_dir().join(format!("{prefix}-{pid}-{n}.pem"))
+}
+```
+
+Aplicado en:
+
+- `crates/ag-core/tests/shield_full_pipeline.rs::generate_tls_cert`.
+- `crates/ag-core/tests/shield_tls.rs::generate_cert_pair`.
+- `crates/ag-core/src/shield/tls.rs::tests::tmpfile`.
+
+## Plan de prueba
+
+```sh
+# Reproducir el flakiness localmente con paralelismo alto en cualquier
+# plataforma (no requiere Windows).
+RUST_TEST_THREADS=16 cargo test -p ag-core --test shield_full_pipeline
+RUST_TEST_THREADS=16 cargo test -p ag-core --test shield_tls
+
+# Suite completa.
+cargo test --workspace
+cargo fmt --all -- --check
+cargo clippy --workspace --all-targets -- -D warnings
+cargo deny check
+```
+
+CI confirma el fix cuando `build (windows-x64)` vuelve a verde.
+
+## Criterios de salida que avanza
+
+No introduce nuevos criterios. Restaura el verde en CI para los
+entregables ya marcados como completos en Fase 1.
+
+## Checklist
+
+- [x] Titulo de PR de 256 caracteres o menos.
+- [x] Sin emojis en ningun archivo modificado.
+- [x] Sin atribuciones de herramientas IA.
+- [x] Documentacion actualizada (CHANGELOG).
+- [x] CHANGELOG.md actualizado bajo `[Unreleased]`.
+- [x] CLAUDE.md respetado: cambio acotado a infraestructura de tests;
+  sin cambios en codigo de produccion; sin nuevas dependencias.
+- [x] Descriptor pre-rellenado existe en `docs/pr-drafts/`.


### PR DESCRIPTION
# Hotfix: colision de paths temporales entre tests TLS paralelos en Windows

## Resumen

Fix de colision de archivos /tmp en tests TLS por baja resolucion de `SystemTime::as_nanos()` en Windows. Genera paths unicos con pid+counter en lugar de timestamp.

## Fase afectada

Fase 1 (Shield MVP). Segundo hotfix del CI tras la merge del primer
hotfix (`1f456b7` en main). Macos-arm64 paso a verde, pero windows-x64
empezo a fallar de forma intermitente en `shield_full_pipeline.rs`.

## Tipo de cambio

- [ ] Documentacion
- [x] Codigo
- [x] Infraestructura o CI
- [ ] RFC nueva o actualizacion de RFC
- [ ] ADR nuevo
- [ ] Seguridad

## Documentos relacionados

- RFC: `docs/rfc/RFC-0002-diseno-shield-mvp.md`.
- ADR: N/A.
- Maestro afectado: N/A.

## Diagnostico

CI run #20 (commit `1f456b7`) mostro `build (windows-x64)` rojo con
tres tests fallando en `tests/shield_full_pipeline.rs`. Los tres
fallidos varian entre corridas, lo que indica race en lugar de bug
deterministico. Las otras tres plataformas (linux-x86-64, linux-arm64,
macos-arm64) verde.

Causa raiz: las funciones helper `generate_tls_cert` (en
`tests/shield_full_pipeline.rs`) y `generate_cert_pair` (en
`tests/shield_tls.rs`) construyen rutas temporales con
`SystemTime::now().duration_since(UNIX_EPOCH).as_nanos()`. En Linux y
macOS la resolucion del reloj es del orden de microsegundos. En
Windows, la resolucion efectiva de `SystemTime::now()` es de unos 15
ms, asi que dos tests que corren en paralelo dentro de la misma
ventana de 15 ms generan exactamente el mismo path.

Cuando A escribe su cert/key y B escribe los suyos en el mismo path,
B sobreescribe a A. Si A esta en medio de leer el archivo (en
`build_acceptor`) mientras B escribe, A puede leer contenido
parcial y fallar el handshake TLS. Tambien provoca mezcla de
cert/key entre tests, lo que rompe la verificacion.

El mismo patron afecta a `tmpfile` en
`crates/ag-core/src/shield/tls.rs` (tests internos), aunque alli el
riesgo es menor porque los tests internos no corren TLS handshakes.

## Fix

Sustituye el uso de `SystemTime` por un counter atomico + pid del
proceso, garantizando unicidad sin depender de la resolucion del
reloj:

```rust
static COUNTER: AtomicUsize = AtomicUsize::new(0);

fn unique_temp(prefix: &str) -> PathBuf {
    let n = COUNTER.fetch_add(1, Ordering::Relaxed);
    let pid = std::process::id();
    std::env::temp_dir().join(format!("{prefix}-{pid}-{n}.pem"))
}
```

Aplicado en:

- `crates/ag-core/tests/shield_full_pipeline.rs::generate_tls_cert`.
- `crates/ag-core/tests/shield_tls.rs::generate_cert_pair`.
- `crates/ag-core/src/shield/tls.rs::tests::tmpfile`.

## Plan de prueba

```sh
# Reproducir el flakiness localmente con paralelismo alto en cualquier
# plataforma (no requiere Windows).
RUST_TEST_THREADS=16 cargo test -p ag-core --test shield_full_pipeline
RUST_TEST_THREADS=16 cargo test -p ag-core --test shield_tls

# Suite completa.
cargo test --workspace
cargo fmt --all -- --check
cargo clippy --workspace --all-targets -- -D warnings
cargo deny check
```

CI confirma el fix cuando `build (windows-x64)` vuelve a verde.

## Criterios de salida que avanza

No introduce nuevos criterios. Restaura el verde en CI para los
entregables ya marcados como completos en Fase 1.

## Checklist

- [x] Titulo de PR de 256 caracteres o menos.
- [x] Sin emojis en ningun archivo modificado.
- [x] Sin atribuciones de herramientas IA.
- [x] Documentacion actualizada (CHANGELOG).
- [x] CHANGELOG.md actualizado bajo `[Unreleased]`.
- [x] CLAUDE.md respetado: cambio acotado a infraestructura de tests;
  sin cambios en codigo de produccion; sin nuevas dependencias.
- [x] Descriptor pre-rellenado existe en `docs/pr-drafts/`.
