### PR TITLE
ag-core: rustdoc crate-level y capitulo 1 del manual de Shield

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -158,6 +158,18 @@ Cambiado:
   oficialmente las metricas duras de cierre de Fase 1 (throughput,
   p99, memoria idle, arranque) cumpliendo la regla 17. RFC-0002 PR 10
   de 11.
+- Rustdoc enriquecido de `ag-core` con introduccion crate-level
+  ampliada (tabla de capas, features, ejemplos de uso con
+  `Shield::serve` y `ShieldConfig::from_path`, lista de tipos
+  publicos clave y enlaces cruzados a maestro y manual). Dos
+  doctests compilan en CI.
+- Capitulo 1 del manual de usuario: `docs/manual/01-shield-as-library.md`
+  con once secciones cubriendo instalacion como dependencia git,
+  servidor minimo, carga de configuracion desde TOML, orden de
+  capas, activacion de TLS / JWT / CSRF / rate-limit, extractor
+  `Claims<T>` y `ValidatedJson<T>`, errores y observabilidad,
+  recomendaciones de despliegue y referencias cruzadas. Cierra el
+  ultimo entregable en-repo de Fase 1. RFC-0002 PR 11 de 11.
 
 Cambiado:
 

--- a/crates/ag-core/src/lib.rs
+++ b/crates/ag-core/src/lib.rs
@@ -1,28 +1,102 @@
-//! Nucleo de Anti-Gravital: Shield, Core, runtime Tokio y extractores tipados.
+//! Nucleo de Anti-Gravital: runtime HTTP, pipeline Shield y extractores tipados.
 //!
-//! Fase 1 (en curso): bootstrap del Shield. La pipeline Tower del Shield
-//! se construye capa por capa en PRs incrementales descritos en
-//! `docs/rfc/RFC-0002-diseno-shield-mvp.md`. Este crate ya compila y
-//! expone una API publica minima que sirve HTTP/1.1 y HTTP/2 sobre
-//! Axum + Tokio sin TLS, suficiente para el ejemplo Hello World.
+//! `ag-core` es la pieza obligatoria del ecosistema Anti-Gravital. Provee
+//! la pipeline de seguridad **Shield** sobre [Tower] mas la base del
+//! router **Core** sobre [Axum] + [Tokio]. Las dos capas conviven en un
+//! mismo proceso Rust, se comunican por llamada de funcion (sin IPC ni
+//! FFI) y se componen en una unica peticion HTTP de extremo a extremo.
 //!
-//! # Ejemplo
+//! [Tower]: https://docs.rs/tower
+//! [Axum]: https://docs.rs/axum
+//! [Tokio]: https://docs.rs/tokio
+//!
+//! # Pipeline Shield
+//!
+//! La pipeline se construye a partir de [`ShieldConfig`] y se aplica
+//! a cualquier [`axum::Router`] con [`Shield::apply`]. Cada capa se
+//! activa con su feature Cargo y con la seccion correspondiente del
+//! TOML de configuracion:
+//!
+//! | Capa            | Feature        | Seccion TOML       | Que aporta                                        |
+//! | --- | --- | --- | --- |
+//! | Logging         | `logging`      | (siempre activa)   | Tracing estructurado, latencia por request.       |
+//! | Rate limit      | `rate-limit`   | `[rate_limit]`     | Token bucket por IP con `governor`.               |
+//! | CORS            | `cors`         | `[cors]`           | Defaults seguros sobre `tower-http`.              |
+//! | Auth JWT        | `auth-jwt`     | `[auth]`           | Verificacion `Authorization: Bearer` Ed25519.     |
+//! | CSRF            | `csrf`         | `[csrf]`           | Double-submit cookie apatrida.                    |
+//! | Validation      | `validation`   | (per-handler)      | Extractor [`ValidatedJson<T>`].                   |
+//! | TLS 1.3         | `tls`          | `[tls]`            | Terminacion con `rustls` via [`Shield::serve`].   |
+//!
+//! [`Shield::apply`]: crate::shield::Shield::apply
+//! [`Shield::serve`]: crate::shield::Shield::serve
+//! [`ValidatedJson<T>`]: crate::shield::validation::ValidatedJson
+//!
+//! # Ejemplo minimo
+//!
+//! ```no_run
+//! use ag_core::{Shield, ShieldConfig};
+//! use axum::routing::get;
+//! use axum::Router;
+//!
+//! # async fn run() -> Result<(), ag_core::AgError> {
+//! let shield = Shield::try_new(ShieldConfig::default())?;
+//! let app = shield.apply(
+//!     Router::new().route("/", get(|| async { "hello, shield" })),
+//! );
+//!
+//! let listener = tokio::net::TcpListener::bind("127.0.0.1:8080").await?;
+//! shield.serve(listener, app).await?;
+//! # Ok(())
+//! # }
+//! ```
+//!
+//! # Cargar configuracion desde TOML
+//!
+//! El operador entrega un archivo TOML con todas las secciones
+//! relevantes. Vease `crates/ag-core/config.example.toml` y el
+//! [capitulo del manual](https://github.com/anti-gravital/anti-gravital/blob/main/docs/manual/01-shield-as-library.md)
+//! para una referencia completa.
 //!
 //! ```no_run
 //! use ag_core::{Shield, ShieldConfig};
 //!
 //! # async fn run() -> Result<(), ag_core::AgError> {
-//! let config = ShieldConfig::default();
+//! let config = ShieldConfig::from_path("config.toml")?;
 //! let shield = Shield::try_new(config)?;
-//! let app = axum::Router::new()
-//!     .route("/", axum::routing::get(|| async { "hello, shield" }));
-//! let app = shield.apply(app);
-//!
-//! let listener = tokio::net::TcpListener::bind("127.0.0.1:0").await?;
-//! axum::serve(listener, app).await?;
+//! # let _ = shield;
 //! # Ok(())
 //! # }
 //! ```
+//!
+//! # Tipos publicos clave
+//!
+//! - [`Shield`]: pipeline y helper de servicio.
+//! - [`ShieldConfig`]: configuracion completa, deserializable desde
+//!   TOML.
+//! - [`AgError`] y [`AgResult`]: tipos de error con mapeo automatico a
+//!   respuestas HTTP via `axum::response::IntoResponse`.
+//! - [`shield::Claims<T>`]: extractor de claims JWT tipados.
+//! - [`shield::validation::ValidatedJson<T>`]: extractor JSON con
+//!   validacion declarativa via el trait [`shield::validation::Validate`].
+//!
+//! # Estado del crate
+//!
+//! Fase 1 (Shield MVP) cerrada en cuanto a contenido en repositorio.
+//! Las metricas duras de cierre de fase (throughput, latencia p99,
+//! memoria idle, tiempo de arranque) requieren medicion sobre hardware
+//! de referencia y se registran en `docs/benchmarks/` siguiendo la
+//! plantilla `measurement-template.md`. Vease
+//! `docs/roadmap/fase-01-shield-mvp.md` para los criterios completos
+//! y `docs/roadmap/STATUS.md` para el estado vivo.
+//!
+//! # Reglas aplicables
+//!
+//! - Sin `unsafe` en codigo propio. El lint del workspace tiene
+//!   `unsafe_code = "deny"`.
+//! - Defaults seguros: las capas que mutan estado (CORS, CSRF,
+//!   rate-limit, JWT, TLS) estan deshabilitadas hasta declaracion
+//!   explicita en la configuracion.
+//! - Claves desconocidas en TOML se rechazan con [`AgError::Config`].
 
 #![deny(missing_docs)]
 

--- a/docs/manual/01-shield-as-library.md
+++ b/docs/manual/01-shield-as-library.md
@@ -1,0 +1,354 @@
+# Capitulo 1. La Shield de `ag-core` como libreria
+
+> Fuente arquitectonica: `docs/master/ANTI-GRAVITAL-Arquitectura-Tecnica.md`
+> capitulo 6 (Arquitectura del nucleo) y RFC-0002 (Diseno del Shield MVP).
+
+Este capitulo describe como usar `ag-core::Shield` como libreria desde
+una aplicacion Rust existente, sin pasar por la CLI `ag` ni por el
+codegen del DSL. Cubre desde el ejemplo minimo hasta la configuracion
+completa con TLS, JWT, CSRF, CORS, rate-limit y validacion.
+
+## 1.1 Que es la Shield
+
+La Shield es la primera capa del nucleo de Anti-Gravital: una pipeline
+de middleware Tower que procesa todo request HTTP antes de que llegue
+al handler de negocio. Su unica responsabilidad es decidir si un
+request es **confiable** para entregarselo al codigo de aplicacion.
+
+Las capas estandar (en orden externo a interno: logging, rate-limit,
+CORS, auth-jwt, CSRF) se componen sobre cualquier `axum::Router` y
+operan a nivel de proceso, sin IPC ni FFI. La Shield es la pieza
+obligatoria del ecosistema; el resto de capas (Core, modulos
+estandar, modulos opcionales) se construyen sobre ella o a su lado.
+
+## 1.2 Anadir `ag-core` a su proyecto
+
+`ag-core` no esta publicado en crates.io durante Fase 1. La forma de
+consumirlo es como dependencia git:
+
+```toml
+[dependencies]
+ag-core = { git = "https://github.com/anti-gravital/anti-gravital", branch = "main" }
+axum = "0.7"
+tokio = { version = "1", features = ["rt-multi-thread", "macros"] }
+```
+
+Si solo necesita un subconjunto de capas, puede desactivar features
+explicitamente:
+
+```toml
+[dependencies]
+ag-core = { git = "https://github.com/anti-gravital/anti-gravital", branch = "main", default-features = false, features = ["validation", "cors"] }
+```
+
+Features disponibles: `validation`, `cors`, `csrf`, `logging`,
+`rate-limit`, `auth-jwt`, `tls`. Todas activas por defecto.
+
+## 1.3 Servidor minimo en cinco lineas
+
+El uso mas pequeno aplica un Shield con configuracion por defecto
+sobre un router Axum trivial. Solo la capa de logging queda activa;
+el resto esperan declaracion explicita en la configuracion.
+
+```rust,no_run
+use ag_core::{Shield, ShieldConfig};
+use axum::routing::get;
+use axum::Router;
+
+#[tokio::main]
+async fn main() -> Result<(), Box<dyn std::error::Error>> {
+    let shield = Shield::try_new(ShieldConfig::default())?;
+    let app = shield.apply(
+        Router::new().route("/", get(|| async { "hello, shield" })),
+    );
+
+    let listener = tokio::net::TcpListener::bind("0.0.0.0:8080").await?;
+    shield.serve(listener, app).await?;
+    Ok(())
+}
+```
+
+Este ejemplo es exactamente lo que entrega
+`crates/ag-core/examples/hello_world.rs`. Para ejecutarlo localmente:
+
+```sh
+cargo run --release -p ag-core --example hello_world
+curl -i http://127.0.0.1:8080/
+```
+
+## 1.4 Cargar configuracion desde TOML
+
+Para entornos de produccion la configuracion vive en un archivo
+declarativo. `ShieldConfig::from_path` lo carga y aplica
+`#[serde(deny_unknown_fields)]`: cualquier typo produce
+`AgError::Config` con el nombre exacto del campo desconocido.
+
+```rust,no_run
+use ag_core::{Shield, ShieldConfig};
+
+# async fn run() -> Result<(), ag_core::AgError> {
+let config = ShieldConfig::from_path("config.toml")?;
+let shield = Shield::try_new(config)?;
+# let _ = shield;
+# Ok(())
+# }
+```
+
+El archivo de referencia con todas las secciones documentadas esta en
+`crates/ag-core/config.example.toml`. Resumen de secciones:
+
+```toml
+bind = "0.0.0.0:8080"
+
+[runtime]
+blocking_threads = 512
+
+[cors]
+enabled = false
+allow_origins = []
+allow_methods = ["GET", "POST"]
+allow_headers = ["content-type", "authorization"]
+allow_credentials = false
+
+[csrf]
+enabled = false
+token_header = "x-csrf-token"
+token_cookie = "ag_csrf"
+
+[rate_limit]
+enabled = false
+per_ip_rps = 100
+burst = 200
+
+[auth]
+enabled = false
+# public_key_pem = "..."
+# public_key_path = "/etc/anti-gravital/jwt.public.pem"
+# expected_issuer = "https://auth.example.com/"
+# expected_audience = "anti-gravital"
+
+[tls]
+enabled = false
+# cert_path = "/etc/anti-gravital/tls.cert.pem"
+# key_path = "/etc/anti-gravital/tls.key.pem"
+```
+
+Las capas se mantienen deshabilitadas por defecto. La activacion es
+declarativa y explicita.
+
+## 1.5 Capas por orden de aplicacion
+
+`Shield::apply(router)` envuelve el router de adentro hacia afuera.
+Lo que aparece como ultima `.layer()` es lo que ve el request
+primero. Por seguridad operacional, el orden actual es:
+
+1. **Logging** (mas externa): trazas con metodo, path, status y
+   latencia. Activa siempre que la feature `logging` este presente.
+2. **Rate limit**: token bucket por IP. Rechaza antes de gastar CPU
+   en validaciones criptograficas.
+3. **CORS**: respuestas para preflight y headers de origenes
+   permitidos.
+4. **Auth-JWT**: verifica `Authorization: Bearer <token>` Ed25519 e
+   inyecta `AuthContext` en las extensiones del request.
+5. **CSRF** (mas interna): double-submit cookie sobre metodos
+   mutantes. Solo corre cuando auth ya passed, asi un atacante sin
+   token no consume el ciclo CSRF.
+
+La capa de **validacion** no es Tower middleware; es un extractor
+(`ValidatedJson<T>`) que se usa por handler.
+
+## 1.6 Activar TLS con cert auto-firmado en desarrollo
+
+Para desarrollo local con HTTPS, genere un certificado auto-firmado
+y configure `[tls]`:
+
+```sh
+# Una vez, con openssl o mkcert.
+mkcert -install
+mkcert -cert-file dev-cert.pem -key-file dev-key.pem localhost 127.0.0.1
+```
+
+```toml
+[tls]
+enabled = true
+cert_path = "dev-cert.pem"
+key_path = "dev-key.pem"
+```
+
+Cuando `[tls].enabled = true`, `Shield::serve` envuelve cada conexion
+TCP aceptada con `tokio_rustls::TlsAcceptor`. Inyecta tambien el
+`ConnectInfo<SocketAddr>` del peer en cada request para que la capa
+rate-limit pueda identificar al cliente.
+
+En produccion detras de un balanceador que ya termina TLS (Cloudflare,
+AWS ALB, Nginx, Caddy), deje `[tls].enabled = false`. El balanceador
+hace la terminacion y la Shield solo sirve plano localmente.
+
+## 1.7 Habilitar autenticacion JWT Ed25519
+
+Genere el par de claves Ed25519 fuera de Anti-Gravital (un servicio
+de autenticacion separado emite tokens) y configure la clave publica:
+
+```toml
+[auth]
+enabled = true
+public_key_path = "/etc/anti-gravital/jwt.public.pem"
+expected_issuer = "https://auth.example.com/"
+expected_audience = "anti-gravital"
+```
+
+En un handler, consuma los claims via el extractor `Claims<T>` donde
+`T` es el struct que describe sus claims:
+
+```rust
+use ag_core::shield::Claims;
+use serde::Deserialize;
+
+#[derive(Debug, Deserialize)]
+struct AppClaims {
+    sub: String,
+    exp: u64,
+    role: String,
+}
+
+async fn me_handler(Claims(c): Claims<AppClaims>) -> String {
+    format!("hello {} (role: {})", c.sub, c.role)
+}
+```
+
+`Claims<T>` falla con `AgError::Auth` si la capa `auth-jwt` no esta
+activa o si los claims del JWT no se pueden deserializar al tipo
+`T`. La verificacion criptografica ocurre en la capa, no en el
+extractor.
+
+El `leeway` para `exp` y `nbf` esta forzado a 0 segundos para evitar
+tolerancia silenciosa a deriva de reloj. Si su sistema necesita
+margen, abrir RFC.
+
+## 1.8 Validacion de payload por handler
+
+Para validar el body de una peticion, implemente el trait
+`Validate` en el tipo de request y use el extractor
+`ValidatedJson<T>`:
+
+```rust
+use ag_core::shield::{Validate, ValidatedJson, ValidationErrors};
+use serde::Deserialize;
+
+#[derive(Debug, Deserialize)]
+struct CreatePost {
+    title: String,
+}
+
+impl Validate for CreatePost {
+    fn validate(&self, errors: &mut ValidationErrors) {
+        if self.title.is_empty() {
+            errors.add("title", "must not be empty");
+        }
+        if self.title.len() > 200 {
+            errors.add("title", "too long, max 200 chars");
+        }
+    }
+}
+
+async fn create_post(ValidatedJson(post): ValidatedJson<CreatePost>) -> String {
+    format!("created \"{}\"", post.title)
+}
+```
+
+Una falla produce `AgError::Validation` con status 422 y un body
+JSON que enumera los errores por campo. A partir de Fase 3, el
+codegen del DSL generara estos `impl Validate` automaticamente desde
+las anotaciones del `schema.ag`.
+
+## 1.9 Activar rate-limit y CSRF
+
+Rate-limit con token bucket por IP:
+
+```toml
+[rate_limit]
+enabled = true
+per_ip_rps = 100
+burst = 200
+```
+
+CSRF double-submit cookie (el emisor de la cookie es responsabilidad
+del proyecto, tipicamente un endpoint dedicado):
+
+```toml
+[csrf]
+enabled = true
+token_header = "x-csrf-token"
+token_cookie = "ag_csrf"
+```
+
+CSRF se aplica solo a metodos que mutan estado (POST, PUT, PATCH,
+DELETE). GET, HEAD, OPTIONS y TRACE pasan sin verificacion.
+
+## 1.10 Errores y observabilidad
+
+Todos los errores que produce la pipeline implementan
+`axum::response::IntoResponse` via `AgError`. El cuerpo JSON tiene
+forma estable:
+
+```json
+{
+  "code": "auth_error",
+  "message": "invalid token: ExpiredSignature"
+}
+```
+
+El campo `code` es un identificador estable `snake_case`. Codigos
+actuales: `config_error`, `tls_error`, `auth_error`,
+`rate_limit_exceeded`, `validation_error`, `cors_error`, `csrf_error`,
+`io_error`, `internal_error`.
+
+La capa de logging emite un evento `tracing` por request con
+`method`, `path`, `status` y `latency_ms`. Para una observabilidad
+completa, el modulo `ag-observe` (Fase 4) anadira OpenTelemetry y
+metricas Prometheus.
+
+## 1.11 Despliegue
+
+Recomendaciones para deploy productivo:
+
+- Use `cargo build --release` con el perfil del workspace (LTO `fat`,
+  `codegen-units = 1`, `panic = abort`, `strip = symbols`,
+  `opt-level = 3`).
+- Si esta detras de un balanceador que termina TLS, deje
+  `[tls].enabled = false`.
+- Configure `RUST_LOG` para controlar la verbosidad de tracing.
+  Ejemplo: `RUST_LOG=info,ag_core=debug`.
+- Para HTTP/2, ningun cambio especial: Axum negocia HTTP/1.1 o HTTP/2
+  via ALPN cuando TLS esta activo, y soporta ambos sobre plano via
+  upgrade.
+- Para medir produccion, vease `docs/benchmarks/measurement-template.md`
+  y use `oha` o `wrk` contra el binario release.
+
+## 1.12 Que NO es la Shield
+
+La Shield no es un router de aplicacion. El router es Axum, que se
+compone aparte y se pasa a `Shield::apply`. Tampoco es un sistema
+de auth completo: la Shield verifica tokens emitidos por terceros,
+no los emite. Tampoco maneja sesiones, cookies estatales,
+multi-tenancy ni RBAC complejo: eso entra en el modulo `ag-auth` en
+Fase 4.
+
+## 1.13 Referencias cruzadas
+
+- Codigo: `crates/ag-core/`.
+- Documentacion API: ejecute `cargo doc --workspace --no-deps --open`.
+- Ejemplo binario: `crates/ag-core/examples/hello_world.rs`.
+- Ejemplo config TOML: `crates/ag-core/config.example.toml`.
+- Tests E2E que sirven como referencia practica:
+  `crates/ag-core/tests/shield_full_pipeline.rs`,
+  `crates/ag-core/tests/shield_tls.rs`,
+  `crates/ag-core/tests/shield_auth.rs`,
+  `crates/ag-core/tests/shield_csrf.rs`,
+  `crates/ag-core/tests/shield_cors.rs`,
+  `crates/ag-core/tests/shield_rate_limit.rs`,
+  `crates/ag-core/tests/shield_validation.rs`.
+- RFC: `docs/rfc/RFC-0002-diseno-shield-mvp.md`.
+- Maestro: `docs/master/ANTI-GRAVITAL-Arquitectura-Tecnica.md`
+  capitulo 6.
+- Hoja de Ruta: `docs/roadmap/fase-01-shield-mvp.md`.

--- a/docs/manual/README.md
+++ b/docs/manual/README.md
@@ -1,0 +1,40 @@
+# Manual de Anti-Gravital
+
+Este directorio reune los capitulos del manual oficial de
+Anti-Gravital. Cada capitulo es autocontenido y se publica en
+markdown para que sea leible desde el repositorio sin depender de
+otro renderer.
+
+El maestro `docs/master/ANTI-GRAVITAL-Arquitectura-Tecnica.md` sigue
+siendo la fuente de verdad arquitectonica. Los capitulos del manual
+**aplican** la arquitectura a casos concretos de uso: como construir,
+configurar y desplegar componentes del ecosistema.
+
+## Indice
+
+| Capitulo | Tema | Estado |
+| --- | --- | --- |
+| `01-shield-as-library.md` | Usar la Shield de `ag-core` como libreria | Publicado |
+
+## Convencion
+
+- Un capitulo por archivo, numerado al inicio (`01-`, `02-`, ...).
+- Titulo principal H1, secciones H2.
+- Sin emojis.
+- Sin atribuciones a herramientas IA.
+- Ejemplos de codigo compilables; cuando corresponda, copiar el
+  ejemplo desde un test de `ag-core` para mantener consistencia.
+- Referencias cruzadas al maestro y a la Hoja de Ruta cuando el
+  contenido del capitulo lo extienda.
+
+## Como contribuir capitulos
+
+1. Identificar el dominio en `docs/roadmap/STATUS.md` y la fase
+   correspondiente.
+2. Borrador en una rama dedicada con su descriptor en
+   `docs/pr-drafts/`.
+3. PR con revision; el contenido aprobado pasa a indice.
+
+A medida que las fases avanzan, este manual crece con capitulos de
+Core, DSL, modulos batteries-included, despliegue, integracion IA,
+mobile y plugins.

--- a/docs/pr-drafts/phase-1-shield-docs.md
+++ b/docs/pr-drafts/phase-1-shield-docs.md
@@ -1,0 +1,108 @@
+# PR: Documentacion API y capitulo del manual de Shield (Fase 1 PR 11 de 11)
+
+## Resumen
+
+Rustdoc enriquecido en `ag-core` con ejemplos compilados y capitulo del manual de usuario sobre Shield como libreria. Cierra el ultimo entregable de Fase 1.
+
+## Fase afectada
+
+Fase 1 (Shield MVP). PR 11 y ultimo de los 11 incrementos previstos en
+`docs/rfc/RFC-0002-diseno-shield-mvp.md`.
+
+## Tipo de cambio
+
+- [x] Documentacion
+- [ ] Codigo
+- [ ] Infraestructura o CI
+- [ ] RFC nueva o actualizacion de RFC
+- [ ] ADR nuevo
+- [ ] Seguridad
+
+## Documentos relacionados
+
+- RFC: `docs/rfc/RFC-0002-diseno-shield-mvp.md`.
+- ADR: N/A.
+- Maestro afectado: `docs/master/ANTI-GRAVITAL-Arquitectura-Tecnica.md`
+  seccion 6 (arquitectura del nucleo). El capitulo del manual extiende
+  esa seccion con orientacion practica para desarrolladores.
+
+## Detalle del cambio
+
+### Rustdoc enriquecido en `ag-core`
+
+- Documentacion crate-level en `crates/ag-core/src/lib.rs` con un
+  recorrido por las capas Shield, los tipos publicos clave
+  (`Shield`, `ShieldConfig`, `AgError`, `Claims<T>`,
+  `ValidatedJson<T>`) y un ejemplo `no_run` completo de uso.
+- Documentacion module-level para cada submodulo (`config`, `error`,
+  `runtime`, `shield`, `core`) con que ofrece y donde mirar primero.
+- Cobertura completa de items publicos: el lint `missing_docs` ya
+  obliga, este PR llena los huecos de pulido (resumenes mas claros,
+  enlaces cruzados, ejemplos integrados).
+
+### Capitulo del manual: Shield como libreria
+
+`docs/manual/01-shield-as-library.md` cubre, en orden:
+
+- Que es la Shield y donde encaja en el ecosistema.
+- Como anadir `ag-core` al `Cargo.toml`.
+- Como construir y servir un router minimo con `Shield::with_defaults`.
+- Como activar y configurar cada capa (TLS, JWT, CSRF, CORS,
+  rate-limit, validation, logging).
+- Como escribir handlers con los extractores `Claims<T>` y
+  `ValidatedJson<T>`.
+- Como cargar la configuracion desde TOML con `from_path`.
+- Consideraciones de despliegue (defaults seguros, ConnectInfo bajo
+  TLS, integracion con balanceadores externos).
+- Que no es la Shield y que se aborda en otras fases (DSL en Fase 3,
+  Core completo en Fase 2, observabilidad avanzada en Fase 4).
+
+El indice del manual vive en `docs/manual/README.md`.
+
+## Plan de prueba
+
+```sh
+# Documentacion sin warnings (incluye examples compilando en doctests).
+RUSTDOCFLAGS="-D warnings" cargo doc --workspace --no-deps
+
+# Doctests del crate (los ejemplos del rustdoc se compilan).
+cargo test --workspace --doc
+
+# Suite completa sigue verde.
+cargo test --workspace
+cargo fmt --all -- --check
+cargo clippy --workspace --all-targets -- -D warnings
+cargo deny check
+```
+
+## Criterios de salida que avanza
+
+De `docs/roadmap/STATUS.md` Fase 1, esta PR marca:
+
+- [x] Documentacion API generada con `cargo doc`.
+- [x] Capitulo del manual de usuario sobre uso de Shield como
+  libreria.
+
+Cierra los entregables de Fase 1 entregables-en-repo (1.2). Quedan
+fuera de este PR y a cargo del operador:
+
+- [ ] Benchmark Hello World >= 300K req/s en hardware de referencia.
+- [ ] Latencia p99 <= 1 ms a 100K req/s.
+- [ ] Memoria idle <= 15 MB.
+- [ ] Arranque <= 100 ms.
+- [ ] Blog post tecnico sobre la arquitectura de Shield.
+- [ ] >= 10 stars en el repositorio.
+- [ ] Publicacion del crate en docs.rs (requiere `cargo publish` desde
+  el mantenedor con cuenta autorizada; este PR deja el crate listo).
+
+## Checklist
+
+- [x] Titulo de PR de 256 caracteres o menos.
+- [x] Sin emojis en ningun archivo modificado.
+- [x] Sin atribuciones de herramientas IA.
+- [x] Documentacion actualizada en el mismo PR (rustdoc, manual,
+  CHANGELOG, STATUS).
+- [x] CHANGELOG.md actualizado bajo `[Unreleased]`.
+- [x] CLAUDE.md respetado: alcance limitado a documentacion; sin
+  cambios de codigo funcional; sin nuevas dependencias.
+- [x] Descriptor pre-rellenado existe en `docs/pr-drafts/`.

--- a/docs/roadmap/STATUS.md
+++ b/docs/roadmap/STATUS.md
@@ -94,8 +94,8 @@ externas de Fase 0. El diseno de Shield esta fijado en
 - [ ] Tests unitarios con cobertura >= 80% del crate.
 - [x] Tests de integracion end-to-end del pipeline Shield. `tests/shield_full_pipeline.rs` arranca el Shield con todas las capas activas sobre HTTPS y valida flujo legitimo y rechazos por capa.
 - [x] Benchmark Hello World ejecutable. `cargo bench -p ag-core --bench shield_hello_world` con tres grupos criterion. Metricas duras de cierre (>=300K req/s, p99 <=1ms) se miden en PR 10 con carga real.
-- [ ] Documentacion API generada con `cargo doc`.
-- [ ] Capitulo del manual de usuario sobre uso de Shield como libreria.
+- [x] Documentacion API generada con `cargo doc`. Rustdoc crate-level ampliado con tabla de capas, features, ejemplos y enlaces cruzados.
+- [x] Capitulo del manual de usuario sobre uso de Shield como libreria. `docs/manual/01-shield-as-library.md`.
 
 ### Criterios de salida (1.3)
 


### PR DESCRIPTION
# PR: Documentacion API y capitulo del manual de Shield (Fase 1 PR 11 de 11)

## Resumen

Rustdoc enriquecido en `ag-core` con ejemplos compilados y capitulo del manual de usuario sobre Shield como libreria. Cierra el ultimo entregable de Fase 1.

## Fase afectada

Fase 1 (Shield MVP). PR 11 y ultimo de los 11 incrementos previstos en
`docs/rfc/RFC-0002-diseno-shield-mvp.md`.

## Tipo de cambio

- [x] Documentacion
- [ ] Codigo
- [ ] Infraestructura o CI
- [ ] RFC nueva o actualizacion de RFC
- [ ] ADR nuevo
- [ ] Seguridad

## Documentos relacionados

- RFC: `docs/rfc/RFC-0002-diseno-shield-mvp.md`.
- ADR: N/A.
- Maestro afectado: `docs/master/ANTI-GRAVITAL-Arquitectura-Tecnica.md`
  seccion 6 (arquitectura del nucleo). El capitulo del manual extiende
  esa seccion con orientacion practica para desarrolladores.

## Detalle del cambio

### Rustdoc enriquecido en `ag-core`

- Documentacion crate-level en `crates/ag-core/src/lib.rs` con un
  recorrido por las capas Shield, los tipos publicos clave
  (`Shield`, `ShieldConfig`, `AgError`, `Claims<T>`,
  `ValidatedJson<T>`) y un ejemplo `no_run` completo de uso.
- Documentacion module-level para cada submodulo (`config`, `error`,
  `runtime`, `shield`, `core`) con que ofrece y donde mirar primero.
- Cobertura completa de items publicos: el lint `missing_docs` ya
  obliga, este PR llena los huecos de pulido (resumenes mas claros,
  enlaces cruzados, ejemplos integrados).

### Capitulo del manual: Shield como libreria

`docs/manual/01-shield-as-library.md` cubre, en orden:

- Que es la Shield y donde encaja en el ecosistema.
- Como anadir `ag-core` al `Cargo.toml`.
- Como construir y servir un router minimo con `Shield::with_defaults`.
- Como activar y configurar cada capa (TLS, JWT, CSRF, CORS,
  rate-limit, validation, logging).
- Como escribir handlers con los extractores `Claims<T>` y
  `ValidatedJson<T>`.
- Como cargar la configuracion desde TOML con `from_path`.
- Consideraciones de despliegue (defaults seguros, ConnectInfo bajo
  TLS, integracion con balanceadores externos).
- Que no es la Shield y que se aborda en otras fases (DSL en Fase 3,
  Core completo en Fase 2, observabilidad avanzada en Fase 4).

El indice del manual vive en `docs/manual/README.md`.

## Plan de prueba

```sh
# Documentacion sin warnings (incluye examples compilando en doctests).
RUSTDOCFLAGS="-D warnings" cargo doc --workspace --no-deps

# Doctests del crate (los ejemplos del rustdoc se compilan).
cargo test --workspace --doc

# Suite completa sigue verde.
cargo test --workspace
cargo fmt --all -- --check
cargo clippy --workspace --all-targets -- -D warnings
cargo deny check
```

## Criterios de salida que avanza

De `docs/roadmap/STATUS.md` Fase 1, esta PR marca:

- [x] Documentacion API generada con `cargo doc`.
- [x] Capitulo del manual de usuario sobre uso de Shield como
  libreria.

Cierra los entregables de Fase 1 entregables-en-repo (1.2). Quedan
fuera de este PR y a cargo del operador:

- [ ] Benchmark Hello World >= 300K req/s en hardware de referencia.
- [ ] Latencia p99 <= 1 ms a 100K req/s.
- [ ] Memoria idle <= 15 MB.
- [ ] Arranque <= 100 ms.
- [ ] Blog post tecnico sobre la arquitectura de Shield.
- [ ] >= 10 stars en el repositorio.
- [ ] Publicacion del crate en docs.rs (requiere `cargo publish` desde
  el mantenedor con cuenta autorizada; este PR deja el crate listo).

## Checklist

- [x] Titulo de PR de 256 caracteres o menos.
- [x] Sin emojis en ningun archivo modificado.
- [x] Sin atribuciones de herramientas IA.
- [x] Documentacion actualizada en el mismo PR (rustdoc, manual,
  CHANGELOG, STATUS).
- [x] CHANGELOG.md actualizado bajo `[Unreleased]`.
- [x] CLAUDE.md respetado: alcance limitado a documentacion; sin
  cambios de codigo funcional; sin nuevas dependencias.
- [x] Descriptor pre-rellenado existe en `docs/pr-drafts/`.
