### PR TITLE
fase 2: Core MVP, ag-data (sqlx), ag-cli (new/dev/build), todo-api example

- ag-core/core: extractores State/Path/Query/ValidatedBody/Claims, modulo response con PlainText y BodyStream
- ag-core/error: AgError expandido con NotFound (404), BadRequest (400), Conflict (409), Database (500)
- ag-data: pool PostgreSQL via sqlx, DataConfig, connect(), run_migrations(), DataError->AgError
- ag-cli: comandos new/dev/build con 3 templates embebidos (rest/realtime/fullstack)
- examples/todo-api: CRUD completo 5 endpoints, migraciones, Dockerfile FROM scratch
- docs/manual/02-primera-api.md: guia de usuario Fase 2
- workspace: sqlx 0.8 y clap 4 en dependencias compartidas

### DIFF
--- a/.cargo/audit.toml
+++ b/.cargo/audit.toml
@@ -1,0 +1,11 @@
+# Configuracion de cargo-audit para Anti-Gravital.
+# Ignorar advisories sin parche disponible en dependencias transitivas.
+
+[advisories]
+ignore = [
+    # RUSTSEC-2023-0071: Marvin Attack (timing oracle en RSA decryption).
+    # Afecta `rsa` 0.9.x, arrastrado transitivamente por sqlx (auth postgres).
+    # No existe version parcheada del crate rsa. Se revisa en cada actualizacion
+    # de sqlx. Issue de seguimiento: https://github.com/RustCrypto/RSA/issues/19
+    "RUSTSEC-2023-0071",
+]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -17,6 +17,12 @@ version = "0.0.0"
 [[package]]
 name = "ag-cli"
 version = "0.0.0"
+dependencies = [
+ "clap",
+ "serde",
+ "thiserror 1.0.69",
+ "toml",
+]
 
 [[package]]
 name = "ag-cloud"
@@ -58,6 +64,14 @@ dependencies = [
 [[package]]
 name = "ag-data"
 version = "0.0.0"
+dependencies = [
+ "ag-core",
+ "serde",
+ "sqlx",
+ "thiserror 1.0.69",
+ "tokio",
+ "tracing",
+]
 
 [[package]]
 name = "ag-dsl"
@@ -101,16 +115,66 @@ dependencies = [
 ]
 
 [[package]]
+name = "allocator-api2"
+version = "0.2.21"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "683d7910e743518b0e34f1186f92494becacb047c7b6bf616c96772180fef923"
+
+[[package]]
 name = "anes"
 version = "0.1.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4b46cbb362ab8752921c97e041f5e366ee6297bd428a31275b9fcf1e380f7299"
 
 [[package]]
+name = "anstream"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "824a212faf96e9acacdbd09febd34438f8f711fb84e09a8916013cd7815ca28d"
+dependencies = [
+ "anstyle",
+ "anstyle-parse",
+ "anstyle-query",
+ "anstyle-wincon",
+ "colorchoice",
+ "is_terminal_polyfill",
+ "utf8parse",
+]
+
+[[package]]
 name = "anstyle"
 version = "1.0.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "940b3a0ca603d1eade50a4846a2afffd5ef57a9feac2c0e2ec2e14f9ead76000"
+
+[[package]]
+name = "anstyle-parse"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "52ce7f38b242319f7cabaa6813055467063ecdc9d355bbb4ce0c68908cd8130e"
+dependencies = [
+ "utf8parse",
+]
+
+[[package]]
+name = "anstyle-query"
+version = "1.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "40c48f72fd53cd289104fc64099abca73db4166ad86ea0b4341abe65af83dadc"
+dependencies = [
+ "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "anstyle-wincon"
+version = "3.0.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "291e6a250ff86cd4a820112fb8898808a366d8f9f58ce16d1f538353ad55747d"
+dependencies = [
+ "anstyle",
+ "once_cell_polyfill",
+ "windows-sys 0.61.2",
+]
 
 [[package]]
 name = "anyhow"
@@ -127,6 +191,15 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn",
+]
+
+[[package]]
+name = "atoi"
+version = "2.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f28d99ec8bfea296261ca1af174f24225171fea9664ba9003cbebee704810528"
+dependencies = [
+ "num-traits",
 ]
 
 [[package]]
@@ -166,6 +239,7 @@ dependencies = [
  "serde",
  "serde_json",
  "serde_path_to_error",
+ "serde_urlencoded",
  "sync_wrapper",
  "tokio",
  "tower",
@@ -210,6 +284,9 @@ name = "bitflags"
 version = "2.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c4512299f36f043ab09a583e57bceb5a5aab7a73db1805848e8fef3c9e8c78b3"
+dependencies = [
+ "serde_core",
+]
 
 [[package]]
 name = "block-buffer"
@@ -225,6 +302,12 @@ name = "bumpalo"
 version = "3.20.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5d20789868f4b01b2f2caec9f5c4e0213b41e3e5702a50157d699ae31ced2fcb"
+
+[[package]]
+name = "byteorder"
+version = "1.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1fd0f2584146f6f2ef48085050886acf353beff7305ebd1ae69500e27c67f64b"
 
 [[package]]
 name = "bytes"
@@ -294,6 +377,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1ddb117e43bbf7dacf0a4190fef4d345b9bad68dfc649cb349e7d17d28428e51"
 dependencies = [
  "clap_builder",
+ "clap_derive",
 ]
 
 [[package]]
@@ -302,8 +386,22 @@ version = "4.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "714a53001bf66416adb0e2ef5ac857140e7dc3a0c48fb28b2f10762fc4b5069f"
 dependencies = [
+ "anstream",
  "anstyle",
  "clap_lex",
+ "strsim",
+]
+
+[[package]]
+name = "clap_derive"
+version = "4.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f2ce8604710f6733aa641a2b3731eaa1e8b3d9973d5e3565da11800813f997a9"
+dependencies = [
+ "heck",
+ "proc-macro2",
+ "quote",
+ "syn",
 ]
 
 [[package]]
@@ -311,6 +409,21 @@ name = "clap_lex"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c8d4a3bb8b1e0c1050499d1815f5ab16d04f0959b233085fb31653fbfc9d98f9"
+
+[[package]]
+name = "colorchoice"
+version = "1.0.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1d07550c9036bf2ae0c684c4297d503f838287c83c53686d05370d0e139ae570"
+
+[[package]]
+name = "concurrent-queue"
+version = "2.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4ca0197aee26d1ae37445ee532fefce43251d24cc7c166799f4d46817f1d3973"
+dependencies = [
+ "crossbeam-utils",
+]
 
 [[package]]
 name = "const-oid"
@@ -326,6 +439,21 @@ checksum = "59ed5838eebb26a2bb2e58f6d5b5316989ae9d08bab10e0e6d103e656d1b0280"
 dependencies = [
  "libc",
 ]
+
+[[package]]
+name = "crc"
+version = "3.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5eb8a2a1cd12ab0d987a5d5e825195d372001a4094a0376319d5a0ad71c1ba0d"
+dependencies = [
+ "crc-catalog",
+]
+
+[[package]]
+name = "crc-catalog"
+version = "2.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "217698eaf96b4a3f0bc4f3662aaa55bdf913cd54d7204591faa790070c6d0853"
 
 [[package]]
 name = "criterion"
@@ -359,6 +487,15 @@ checksum = "6b50826342786a51a89e2da3a28f1c32b06e387201bc2d19791f622c673706b1"
 dependencies = [
  "cast",
  "itertools",
+]
+
+[[package]]
+name = "crossbeam-queue"
+version = "0.3.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0f58bbc28f91df819d0aa2a2c00cd19754769c2fad90579b3592b1c9ba7a3115"
+dependencies = [
+ "crossbeam-utils",
 ]
 
 [[package]]
@@ -451,7 +588,9 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9ed9a281f7bc9b7576e61468ba615a66a5c8cfdff42420a70aa82701a3b1e292"
 dependencies = [
  "block-buffer",
+ "const-oid",
  "crypto-common",
+ "subtle",
 ]
 
 [[package]]
@@ -464,6 +603,12 @@ dependencies = [
  "quote",
  "syn",
 ]
+
+[[package]]
+name = "dotenvy"
+version = "0.15.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1aaf95b3e5c8f23aa320147307562d361db0ae0d51242340f558153b4eb2439b"
 
 [[package]]
 name = "ed25519"
@@ -494,6 +639,9 @@ name = "either"
 version = "1.15.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "48c757948c5ede0e46177b7add2e67155f70e33c07fea8284df6576da70b3719"
+dependencies = [
+ "serde",
+]
 
 [[package]]
 name = "equivalent"
@@ -512,6 +660,28 @@ dependencies = [
 ]
 
 [[package]]
+name = "etcetera"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "136d1b5283a1ab77bd9257427ffd09d8667ced0570b6f938942bc7568ed5b943"
+dependencies = [
+ "cfg-if",
+ "home",
+ "windows-sys 0.48.0",
+]
+
+[[package]]
+name = "event-listener"
+version = "5.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e13b66accf52311f30a0db42147dadea9850cb48cd070028831ae5f5d4b856ab"
+dependencies = [
+ "concurrent-queue",
+ "parking",
+ "pin-project-lite",
+]
+
+[[package]]
 name = "fiat-crypto"
 version = "0.2.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -522,6 +692,17 @@ name = "find-msvc-tools"
 version = "0.1.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5baebc0774151f905a1a2cc41989300b1e6fbb29aff0ceffa1064fdd3088d582"
+
+[[package]]
+name = "flume"
+version = "0.11.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "da0e4dd2a88388a1f4ccc7c9ce104604dab68d9f408dc34cd45823d5a9069095"
+dependencies = [
+ "futures-core",
+ "futures-sink",
+ "spin",
+]
 
 [[package]]
 name = "fnv"
@@ -551,6 +732,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "07bbe89c50d7a535e539b8c17bc0b49bdb77747034daa8087407d655f3f7cc1d"
 dependencies = [
  "futures-core",
+ "futures-sink",
 ]
 
 [[package]]
@@ -558,6 +740,34 @@ name = "futures-core"
 version = "0.3.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7e3450815272ef58cec6d564423f6e755e25379b217b0bc688e295ba24df6b1d"
+
+[[package]]
+name = "futures-executor"
+version = "0.3.32"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "baf29c38818342a3b26b5b923639e7b1f4a61fc5e76102d4b1981c6dc7a7579d"
+dependencies = [
+ "futures-core",
+ "futures-task",
+ "futures-util",
+]
+
+[[package]]
+name = "futures-intrusive"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1d930c203dd0b6ff06e0201a4a2fe9149b43c684fd4420555b26d21b1a02956f"
+dependencies = [
+ "futures-core",
+ "lock_api",
+ "parking_lot",
+]
+
+[[package]]
+name = "futures-io"
+version = "0.3.32"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cecba35d7ad927e23624b22ad55235f2239cfa44fd10428eecbeba6d6a717718"
 
 [[package]]
 name = "futures-sink"
@@ -584,8 +794,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "389ca41296e6190b48053de0321d02a77f32f8a5d2461dd38762c0593805c6d6"
 dependencies = [
  "futures-core",
+ "futures-io",
  "futures-sink",
  "futures-task",
+ "memchr",
  "pin-project-lite",
  "slab",
 ]
@@ -703,6 +915,8 @@ version = "0.15.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9229cfe53dfd69f0609a49f65461bd93001ea1ef889cd5529dd176593f5338a1"
 dependencies = [
+ "allocator-api2",
+ "equivalent",
  "foldhash",
 ]
 
@@ -711,6 +925,15 @@ name = "hashbrown"
 version = "0.17.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ed5909b6e89a2db4456e54cd5f673791d7eca6732202bbf2a9cc504fe2f9b84a"
+
+[[package]]
+name = "hashlink"
+version = "0.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7382cf6263419f2d8df38c55d7da83da5c18aef87fc7a7fc1fb1e344edfe14c1"
+dependencies = [
+ "hashbrown 0.15.5",
+]
 
 [[package]]
 name = "heck"
@@ -723,6 +946,39 @@ name = "hermit-abi"
 version = "0.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fc0fef456e4baa96da950455cd02c081ca953b141298e41db3fc7e36b1da849c"
+
+[[package]]
+name = "hex"
+version = "0.4.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7f24254aa9a54b5c858eaee2f5bccdb46aaf0e486a595ed5fd8f86ba55232a70"
+
+[[package]]
+name = "hkdf"
+version = "0.12.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7b5f8eb2ad728638ea2c7d47a21db23b7b58a72ed6a38256b8a1849f15fbbdf7"
+dependencies = [
+ "hmac",
+]
+
+[[package]]
+name = "hmac"
+version = "0.12.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6c49c37c09c17a53d937dfbb742eb3a961d65a994e6bcdcf37e7399d0cc8ab5e"
+dependencies = [
+ "digest",
+]
+
+[[package]]
+name = "home"
+version = "0.5.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cc627f471c528ff0c4a49e1d5e60450c8f6461dd6d10ba9dcd3a61d3dff7728d"
+dependencies = [
+ "windows-sys 0.61.2",
+]
 
 [[package]]
 name = "http"
@@ -804,7 +1060,7 @@ dependencies = [
  "tokio",
  "tokio-rustls",
  "tower-service",
- "webpki-roots",
+ "webpki-roots 1.0.7",
 ]
 
 [[package]]
@@ -969,6 +1225,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "is_terminal_polyfill"
+version = "1.70.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a6cb138bb79a146c1bd460005623e142ef0181e3d0219cb493e02f7d08a35695"
+
+[[package]]
 name = "itertools"
 version = "0.10.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1015,6 +1277,9 @@ name = "lazy_static"
 version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bbd2bcb4c963f2ddae06a2efc7e9f3591312473c50c6685e1f298068316e66fe"
+dependencies = [
+ "spin",
+]
 
 [[package]]
 name = "leb128fmt"
@@ -1027,6 +1292,34 @@ name = "libc"
 version = "0.2.186"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "68ab91017fe16c622486840e4c83c9a37afeff978bd239b5293d61ece587de66"
+
+[[package]]
+name = "libm"
+version = "0.2.16"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b6d2cec3eae94f9f509c767b45932f1ada8350c4bdb85af2fcab4a3c14807981"
+
+[[package]]
+name = "libredox"
+version = "0.1.16"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e02f3bb43d335493c96bf3fd3a321600bf6bd07ed34bc64118e9293bdffea46c"
+dependencies = [
+ "bitflags",
+ "libc",
+ "plain",
+ "redox_syscall 0.7.5",
+]
+
+[[package]]
+name = "libsqlite3-sys"
+version = "0.30.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2e99fb7a497b1e3339bc746195567ed8d3e24945ecd636e3619d20b9de9e9149"
+dependencies = [
+ "pkg-config",
+ "vcpkg",
+]
 
 [[package]]
 name = "litemap"
@@ -1069,6 +1362,16 @@ name = "matchit"
 version = "0.7.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0e7465ac9959cc2b1404e8e2367b43684a6d13790fe23056cc8c6c5a6b7bcb94"
+
+[[package]]
+name = "md-5"
+version = "0.10.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d89e7ee0cfbedfc4da3340218492196241d89eefb6dab27de5df917a6d2e78cf"
+dependencies = [
+ "cfg-if",
+ "digest",
+]
 
 [[package]]
 name = "memchr"
@@ -1125,6 +1428,22 @@ dependencies = [
 ]
 
 [[package]]
+name = "num-bigint-dig"
+version = "0.8.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e661dda6640fad38e827a6d4a310ff4763082116fe217f279885c97f511bb0b7"
+dependencies = [
+ "lazy_static",
+ "libm",
+ "num-integer",
+ "num-iter",
+ "num-traits",
+ "rand 0.8.6",
+ "smallvec",
+ "zeroize",
+]
+
+[[package]]
 name = "num-conv"
 version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1140,12 +1459,24 @@ dependencies = [
 ]
 
 [[package]]
+name = "num-iter"
+version = "0.1.45"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1429034a0490724d0075ebb2bc9e875d6503c3cf69e235a8941aa757d83ef5bf"
+dependencies = [
+ "autocfg",
+ "num-integer",
+ "num-traits",
+]
+
+[[package]]
 name = "num-traits"
 version = "0.2.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "071dfc062690e90b734c0b2273ce72ad0ffa95f0c74596bc250dcfd960262841"
 dependencies = [
  "autocfg",
+ "libm",
 ]
 
 [[package]]
@@ -1155,10 +1486,22 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9f7c3e4beb33f85d45ae3e3a1792185706c8e16d043238c593331cc7cd313b50"
 
 [[package]]
+name = "once_cell_polyfill"
+version = "1.70.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "384b8ab6d37215f3c5301a95a4accb5d64aa607f1fcb26a11b5303878451b4fe"
+
+[[package]]
 name = "oorandom"
 version = "11.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d6790f58c7ff633d8771f42965289203411a5e5c68388703c06e14f24770b41e"
+
+[[package]]
+name = "parking"
+version = "2.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f38d5652c16fde515bb1ecef450ab0f6a219d619a7274976324d5e377f7dceba"
 
 [[package]]
 name = "parking_lot"
@@ -1178,7 +1521,7 @@ checksum = "2621685985a2ebf1c516881c026032ac7deafcda1a2c9b7850dc81e3dfcb64c1"
 dependencies = [
  "cfg-if",
  "libc",
- "redox_syscall",
+ "redox_syscall 0.5.18",
  "smallvec",
  "windows-link",
 ]
@@ -1215,6 +1558,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a89322df9ebe1c1578d689c92318e070967d1042b512afbe49518723f4e6d5cd"
 
 [[package]]
+name = "pkcs1"
+version = "0.7.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c8ffb9f10fa047879315e6625af03c164b16962a5368d724ed16323b68ace47f"
+dependencies = [
+ "der",
+ "pkcs8",
+ "spki",
+]
+
+[[package]]
 name = "pkcs8"
 version = "0.10.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1223,6 +1577,18 @@ dependencies = [
  "der",
  "spki",
 ]
+
+[[package]]
+name = "pkg-config"
+version = "0.3.33"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "19f132c84eca552bf34cab8ec81f1c1dcc229b811638f9d283dceabe58c5569e"
+
+[[package]]
+name = "plain"
+version = "0.2.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b4596b6d070b27117e987119b4dac604f3c58cfb0b191112e24771b2faeac1a6"
 
 [[package]]
 name = "portable-atomic"
@@ -1455,6 +1821,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "redox_syscall"
+version = "0.7.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4666a1a60d8412eab19d94f6d13dcc9cea0a5ef4fdf6a5db306537413c661b1b"
+dependencies = [
+ "bitflags",
+]
+
+[[package]]
 name = "regex"
 version = "1.12.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1518,7 +1893,7 @@ dependencies = [
  "wasm-bindgen",
  "wasm-bindgen-futures",
  "web-sys",
- "webpki-roots",
+ "webpki-roots 1.0.7",
 ]
 
 [[package]]
@@ -1533,6 +1908,26 @@ dependencies = [
  "libc",
  "untrusted",
  "windows-sys 0.52.0",
+]
+
+[[package]]
+name = "rsa"
+version = "0.9.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b8573f03f5883dcaebdfcf4725caa1ecb9c15b2ef50c43a07b816e06799bb12d"
+dependencies = [
+ "const-oid",
+ "digest",
+ "num-bigint-dig",
+ "num-integer",
+ "num-traits",
+ "pkcs1",
+ "pkcs8",
+ "rand_core 0.6.4",
+ "signature",
+ "spki",
+ "subtle",
+ "zeroize",
 ]
 
 [[package]]
@@ -1694,6 +2089,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "sha1"
+version = "0.10.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e3bf829a2d51ab4a5ddf1352d8470c140cadc8301b2ae1789db023f01cedd6ba"
+dependencies = [
+ "cfg-if",
+ "cpufeatures",
+ "digest",
+]
+
+[[package]]
 name = "sha2"
 version = "0.10.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1735,6 +2141,7 @@ version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "77549399552de45a898a580c1b41d445bf730df867cc44e6c0233bbc4b8329de"
 dependencies = [
+ "digest",
  "rand_core 0.6.4",
 ]
 
@@ -1761,6 +2168,9 @@ name = "smallvec"
 version = "1.15.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "67b1b7a3b5fe4f1376887184045fcf45c69e92af734b7aaddc05fb777b6fbd03"
+dependencies = [
+ "serde",
+]
 
 [[package]]
 name = "socket2"
@@ -1770,6 +2180,15 @@ checksum = "3a766e1110788c36f4fa1c2b71b387a7815aa65f88ce0229841826633d93723e"
 dependencies = [
  "libc",
  "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "spin"
+version = "0.9.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6980e8d7511241f8acf4aebddbb1ff938df5eebe98691418c4468d0b72a96a67"
+dependencies = [
+ "lock_api",
 ]
 
 [[package]]
@@ -1792,10 +2211,213 @@ dependencies = [
 ]
 
 [[package]]
+name = "sqlx"
+version = "0.8.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1fefb893899429669dcdd979aff487bd78f4064e5e7907e4269081e0ef7d97dc"
+dependencies = [
+ "sqlx-core",
+ "sqlx-macros",
+ "sqlx-mysql",
+ "sqlx-postgres",
+ "sqlx-sqlite",
+]
+
+[[package]]
+name = "sqlx-core"
+version = "0.8.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ee6798b1838b6a0f69c007c133b8df5866302197e404e8b6ee8ed3e3a5e68dc6"
+dependencies = [
+ "base64",
+ "bytes",
+ "crc",
+ "crossbeam-queue",
+ "either",
+ "event-listener",
+ "futures-core",
+ "futures-intrusive",
+ "futures-io",
+ "futures-util",
+ "hashbrown 0.15.5",
+ "hashlink",
+ "indexmap",
+ "log",
+ "memchr",
+ "once_cell",
+ "percent-encoding",
+ "rustls",
+ "serde",
+ "serde_json",
+ "sha2",
+ "smallvec",
+ "thiserror 2.0.18",
+ "tokio",
+ "tokio-stream",
+ "tracing",
+ "url",
+ "webpki-roots 0.26.11",
+]
+
+[[package]]
+name = "sqlx-macros"
+version = "0.8.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a2d452988ccaacfbf5e0bdbc348fb91d7c8af5bee192173ac3636b5fb6e6715d"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "sqlx-core",
+ "sqlx-macros-core",
+ "syn",
+]
+
+[[package]]
+name = "sqlx-macros-core"
+version = "0.8.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "19a9c1841124ac5a61741f96e1d9e2ec77424bf323962dd894bdb93f37d5219b"
+dependencies = [
+ "dotenvy",
+ "either",
+ "heck",
+ "hex",
+ "once_cell",
+ "proc-macro2",
+ "quote",
+ "serde",
+ "serde_json",
+ "sha2",
+ "sqlx-core",
+ "sqlx-postgres",
+ "syn",
+ "tokio",
+ "url",
+]
+
+[[package]]
+name = "sqlx-mysql"
+version = "0.8.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "aa003f0038df784eb8fecbbac13affe3da23b45194bd57dba231c8f48199c526"
+dependencies = [
+ "atoi",
+ "base64",
+ "bitflags",
+ "byteorder",
+ "bytes",
+ "crc",
+ "digest",
+ "dotenvy",
+ "either",
+ "futures-channel",
+ "futures-core",
+ "futures-io",
+ "futures-util",
+ "generic-array",
+ "hex",
+ "hkdf",
+ "hmac",
+ "itoa",
+ "log",
+ "md-5",
+ "memchr",
+ "once_cell",
+ "percent-encoding",
+ "rand 0.8.6",
+ "rsa",
+ "sha1",
+ "sha2",
+ "smallvec",
+ "sqlx-core",
+ "stringprep",
+ "thiserror 2.0.18",
+ "tracing",
+ "whoami",
+]
+
+[[package]]
+name = "sqlx-postgres"
+version = "0.8.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "db58fcd5a53cf07c184b154801ff91347e4c30d17a3562a635ff028ad5deda46"
+dependencies = [
+ "atoi",
+ "base64",
+ "bitflags",
+ "byteorder",
+ "crc",
+ "dotenvy",
+ "etcetera",
+ "futures-channel",
+ "futures-core",
+ "futures-util",
+ "hex",
+ "hkdf",
+ "hmac",
+ "home",
+ "itoa",
+ "log",
+ "md-5",
+ "memchr",
+ "once_cell",
+ "rand 0.8.6",
+ "serde",
+ "serde_json",
+ "sha2",
+ "smallvec",
+ "sqlx-core",
+ "stringprep",
+ "thiserror 2.0.18",
+ "tracing",
+ "whoami",
+]
+
+[[package]]
+name = "sqlx-sqlite"
+version = "0.8.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c2d12fe70b2c1b4401038055f90f151b78208de1f9f89a7dbfd41587a10c3eea"
+dependencies = [
+ "atoi",
+ "flume",
+ "futures-channel",
+ "futures-core",
+ "futures-executor",
+ "futures-intrusive",
+ "futures-util",
+ "libsqlite3-sys",
+ "log",
+ "percent-encoding",
+ "serde_urlencoded",
+ "sqlx-core",
+ "thiserror 2.0.18",
+ "tracing",
+ "url",
+]
+
+[[package]]
 name = "stable_deref_trait"
 version = "1.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6ce2be8dc25455e1f91df71bfa12ad37d7af1092ae736f3a6cd0e37bc7810596"
+
+[[package]]
+name = "stringprep"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7b4df3d392d81bd458a8a621b8bffbd2302a12ffe288a9d931670948749463b1"
+dependencies = [
+ "unicode-bidi",
+ "unicode-normalization",
+ "unicode-properties",
+]
+
+[[package]]
+name = "strsim"
+version = "0.11.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7da8b5736845d9f2fcb837ea5d9e2628564b3b043a70948a3f0b778838c5fb4f"
 
 [[package]]
 name = "subtle"
@@ -1948,6 +2570,22 @@ name = "tinyvec_macros"
 version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1f3ccbac311fea05f86f61904b462b55fb3df8837a366dfc601a0161d0532f20"
+
+[[package]]
+name = "todo-api"
+version = "0.0.0"
+dependencies = [
+ "ag-core",
+ "ag-data",
+ "axum",
+ "criterion",
+ "serde",
+ "serde_json",
+ "sqlx",
+ "tokio",
+ "tracing",
+ "tracing-subscriber",
+]
 
 [[package]]
 name = "tokio"
@@ -2115,6 +2753,7 @@ version = "0.1.44"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "63e71662fa4b2a2c3a26f570f037eb95bb1f85397f3cd8076caed2f026a6d100"
 dependencies = [
+ "log",
  "pin-project-lite",
  "tracing-attributes",
  "tracing-core",
@@ -2196,10 +2835,31 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "40ce102ab67701b8526c123c1bab5cbe42d7040ccfd0f64af1a385808d2f43de"
 
 [[package]]
+name = "unicode-bidi"
+version = "0.3.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5c1cb5db39152898a79168971543b1cb5020dff7fe43c8dc468b0885f5e29df5"
+
+[[package]]
 name = "unicode-ident"
 version = "1.0.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e6e4313cd5fcd3dad5cafa179702e2b244f760991f45397d14d4ebf38247da75"
+
+[[package]]
+name = "unicode-normalization"
+version = "0.1.25"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5fd4f6878c9cb28d874b009da9e8d183b5abc80117c40bbd187a1fde336be6e8"
+dependencies = [
+ "tinyvec",
+]
+
+[[package]]
+name = "unicode-properties"
+version = "0.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7df058c713841ad818f1dc5d3fd88063241cc61f49f5fbea4b951e8cf5a8d71d"
 
 [[package]]
 name = "unicode-xid"
@@ -2232,6 +2892,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b6c140620e7ffbb22c2dee59cafe6084a59b5ffc27a8859a5f0d494b5d52b6be"
 
 [[package]]
+name = "utf8parse"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "06abde3611657adf66d383f00b093d7faecc7fa57071cce2578660c9f1010821"
+
+[[package]]
 name = "uuid"
 version = "1.23.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2247,6 +2913,12 @@ name = "valuable"
 version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ba73ea9cf16a25df0c8caa16c51acb937d5712a8429db78a3ee29d5dcacd3a65"
+
+[[package]]
+name = "vcpkg"
+version = "0.2.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "accd4ea62f7bb7a82fe23066fb0957d48ef677f6eeb8215f372f52e48bb32426"
 
 [[package]]
 name = "version_check"
@@ -2296,6 +2968,12 @@ checksum = "5428f8bf88ea5ddc08faddef2ac4a67e390b88186c703ce6dbd955e1c145aca5"
 dependencies = [
  "wit-bindgen 0.51.0",
 ]
+
+[[package]]
+name = "wasite"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b8dad83b4f25e74f184f64c43b150b91efe7647395b42289f38e50566d82855b"
 
 [[package]]
 name = "wasm-bindgen"
@@ -2408,11 +3086,30 @@ dependencies = [
 
 [[package]]
 name = "webpki-roots"
+version = "0.26.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "521bc38abb08001b01866da9f51eb7c5d647a19260e00054a8c7fd5f9e57f7a9"
+dependencies = [
+ "webpki-roots 1.0.7",
+]
+
+[[package]]
+name = "webpki-roots"
 version = "1.0.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "52f5ee44c96cf55f1b349600768e3ece3a8f26010c05265ab73f945bb1a2eb9d"
 dependencies = [
  "rustls-pki-types",
+]
+
+[[package]]
+name = "whoami"
+version = "1.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5d4a4db5077702ca3015d3d02d74974948aba2ad9e12ab7df718ee64ccd7e97d"
+dependencies = [
+ "libredox",
+ "wasite",
 ]
 
 [[package]]
@@ -2454,6 +3151,15 @@ checksum = "f0805222e57f7521d6a62e36fa9163bc891acd422f971defe97d64e70d0a4fe5"
 
 [[package]]
 name = "windows-sys"
+version = "0.48.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "677d2418bec65e3338edb076e806bc1ec15693c5d0104683f2efe857f61056a9"
+dependencies = [
+ "windows-targets 0.48.5",
+]
+
+[[package]]
+name = "windows-sys"
 version = "0.52.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "282be5f36a8ce781fad8c8ae18fa3f9beff57ec1b52cb3de0789201425d9a33d"
@@ -2477,6 +3183,21 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ae137229bcbd6cdf0f7b80a31df61766145077ddf49416a728b02cb3921ff3fc"
 dependencies = [
  "windows-link",
+]
+
+[[package]]
+name = "windows-targets"
+version = "0.48.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9a2fa6e2155d7247be68c096456083145c183cbbbc2764150dda45a87197940c"
+dependencies = [
+ "windows_aarch64_gnullvm 0.48.5",
+ "windows_aarch64_msvc 0.48.5",
+ "windows_i686_gnu 0.48.5",
+ "windows_i686_msvc 0.48.5",
+ "windows_x86_64_gnu 0.48.5",
+ "windows_x86_64_gnullvm 0.48.5",
+ "windows_x86_64_msvc 0.48.5",
 ]
 
 [[package]]
@@ -2514,6 +3235,12 @@ dependencies = [
 
 [[package]]
 name = "windows_aarch64_gnullvm"
+version = "0.48.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2b38e32f0abccf9987a4e3079dfb67dcd799fb61361e53e2882c3cbaf0d905d8"
+
+[[package]]
+name = "windows_aarch64_gnullvm"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "32a4622180e7a0ec044bb555404c800bc9fd9ec262ec147edd5989ccd0c02cd3"
@@ -2526,6 +3253,12 @@ checksum = "a9d8416fa8b42f5c947f8482c43e7d89e73a173cead56d044f6a56104a6d1b53"
 
 [[package]]
 name = "windows_aarch64_msvc"
+version = "0.48.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dc35310971f3b2dbbf3f0690a219f40e2d9afcf64f9ab7cc1be722937c26b4bc"
+
+[[package]]
+name = "windows_aarch64_msvc"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "09ec2a7bb152e2252b53fa7803150007879548bc709c039df7627cabbd05d469"
@@ -2535,6 +3268,12 @@ name = "windows_aarch64_msvc"
 version = "0.53.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b9d782e804c2f632e395708e99a94275910eb9100b2114651e04744e9b125006"
+
+[[package]]
+name = "windows_i686_gnu"
+version = "0.48.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a75915e7def60c94dcef72200b9a8e58e5091744960da64ec734a6c6e9b3743e"
 
 [[package]]
 name = "windows_i686_gnu"
@@ -2562,6 +3301,12 @@ checksum = "fa7359d10048f68ab8b09fa71c3daccfb0e9b559aed648a8f95469c27057180c"
 
 [[package]]
 name = "windows_i686_msvc"
+version = "0.48.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8f55c233f70c4b27f66c523580f78f1004e8b5a8b659e05a4eb49d4166cca406"
+
+[[package]]
+name = "windows_i686_msvc"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "240948bc05c5e7c6dabba28bf89d89ffce3e303022809e73deaefe4f6ec56c66"
@@ -2571,6 +3316,12 @@ name = "windows_i686_msvc"
 version = "0.53.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1e7ac75179f18232fe9c285163565a57ef8d3c89254a30685b57d83a38d326c2"
+
+[[package]]
+name = "windows_x86_64_gnu"
+version = "0.48.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "53d40abd2583d23e4718fddf1ebec84dbff8381c07cae67ff7768bbf19c6718e"
 
 [[package]]
 name = "windows_x86_64_gnu"
@@ -2586,6 +3337,12 @@ checksum = "9c3842cdd74a865a8066ab39c8a7a473c0778a3f29370b5fd6b4b9aa7df4a499"
 
 [[package]]
 name = "windows_x86_64_gnullvm"
+version = "0.48.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0b7b52767868a23d5bab768e390dc5f5c55825b6d30b86c844ff2dc7414044cc"
+
+[[package]]
+name = "windows_x86_64_gnullvm"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "24d5b23dc417412679681396f2b49f3de8c1473deb516bd34410872eff51ed0d"
@@ -2595,6 +3352,12 @@ name = "windows_x86_64_gnullvm"
 version = "0.53.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0ffa179e2d07eee8ad8f57493436566c7cc30ac536a3379fdf008f47f6bb7ae1"
+
+[[package]]
+name = "windows_x86_64_msvc"
+version = "0.48.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ed94fce61571a4006852b7389a063ab983c02eb1bb37b47f8272ce92d06d9538"
 
 [[package]]
 name = "windows_x86_64_msvc"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -636,9 +636,9 @@ dependencies = [
 
 [[package]]
 name = "either"
-version = "1.15.0"
+version = "1.16.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "48c757948c5ede0e46177b7add2e67155f70e33c07fea8284df6576da70b3719"
+checksum = "91622ff5e7162018101f2fea40d6ebf4a78bbe5a49736a2020649edf9693679e"
 dependencies = [
  "serde",
 ]
@@ -783,9 +783,9 @@ checksum = "037711b3d59c33004d3856fbdc83b99d4ff37a24768fa1be9ce3538a1cde4393"
 
 [[package]]
 name = "futures-timer"
-version = "3.0.3"
+version = "3.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f288b0a4f20f9a56b5d1da57e2227c661b7b16168e2f72365f57b63326e29b24"
+checksum = "af43fadb8a98512d547e37b4e92e0ced13e205c061b87b4623eff01d918d6968"
 
 [[package]]
 name = "futures-util"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,6 +16,7 @@ members = [
     "crates/ag-mobile",
     "crates/ag-migrate",
     "crates/ag-wasm-host",
+    "examples/todo-api",
 ]
 
 [workspace.package]
@@ -34,11 +35,16 @@ publish = false
 
 # Dependencias compartidas del workspace.
 # Cada nueva dependencia exige RFC; el set inicial corresponde a RFC-0002
-# (diseno del Shield MVP). Los crates internos las referencian con
-# `dep = { workspace = true }`.
+# (diseno del Shield MVP). Las adiciones de Fase 2 (sqlx, clap) estan
+# justificadas en la Hoja de Ruta §2.2. Los crates internos las
+# referencian con `dep = { workspace = true }`.
 [workspace.dependencies]
-axum = { version = "0.7", default-features = false, features = ["http1", "http2", "tokio", "json", "matched-path"] }
+ag-core = { path = "crates/ag-core" }
+ag-data = { path = "crates/ag-data" }
+axum = { version = "0.7", default-features = false, features = ["http1", "http2", "tokio", "json", "matched-path", "query"] }
 bytes = "1"
+clap = { version = "4", features = ["derive"] }
+sqlx = { version = "0.8", default-features = false, features = ["runtime-tokio-rustls", "postgres", "migrate", "macros"] }
 governor = "0.7"
 http = "1"
 jsonwebtoken = { version = "9", default-features = false, features = ["use_pem"] }

--- a/crates/ag-cli/Cargo.toml
+++ b/crates/ag-cli/Cargo.toml
@@ -14,5 +14,15 @@ keywords.workspace = true
 categories.workspace = true
 publish = false
 
+[[bin]]
+name = "ag"
+path = "src/main.rs"
+
 [lints]
 workspace = true
+
+[dependencies]
+clap = { workspace = true }
+serde = { workspace = true }
+thiserror = { workspace = true }
+toml = { workspace = true }

--- a/crates/ag-cli/src/main.rs
+++ b/crates/ag-cli/src/main.rs
@@ -1,9 +1,286 @@
 //! Binario unificado `ag` del ecosistema Anti-Gravital.
 //!
-//! Estado: Fase 0 (Fundaciones y Gobernanza). El binario `ag` aun no
-//! contiene comandos operativos. La implementacion incremental comienza
-//! en Fase 2 con `ag new`, `ag dev` y `ag build`.
+//! Implementa los comandos de Fase 2:
+//!
+//! - `ag new <nombre> [--template rest|realtime|fullstack]`
+//! - `ag dev [--bind host:port]`
+//! - `ag build [--target triple]`
+
+use clap::{Parser, Subcommand};
+use std::fs;
+use std::path::Path;
+use std::process;
+
+const VERSION: &str = env!("CARGO_PKG_VERSION");
+
+// Templates embebidos en el binario al compilar. Las rutas son relativas
+// al directorio raiz del workspace (crates/ag-cli/src/../../../templates/).
+
+const REST_CARGO_TOML: &str = include_str!("../../../templates/rest/Cargo.toml.tmpl");
+const REST_MAIN_RS: &str = include_str!("../../../templates/rest/src/main.rs.tmpl");
+const REST_CONFIG_TOML: &str = include_str!("../../../templates/rest/config.toml.tmpl");
+
+const REALTIME_CARGO_TOML: &str = include_str!("../../../templates/realtime/Cargo.toml.tmpl");
+const REALTIME_MAIN_RS: &str = include_str!("../../../templates/realtime/src/main.rs.tmpl");
+const REALTIME_CONFIG_TOML: &str = include_str!("../../../templates/realtime/config.toml.tmpl");
+
+const FULLSTACK_CARGO_TOML: &str = include_str!("../../../templates/fullstack/Cargo.toml.tmpl");
+const FULLSTACK_MAIN_RS: &str = include_str!("../../../templates/fullstack/src/main.rs.tmpl");
+const FULLSTACK_CONFIG_TOML: &str = include_str!("../../../templates/fullstack/config.toml.tmpl");
+const FULLSTACK_MIGRATION: &str =
+    include_str!("../../../templates/fullstack/migrations/0001_init.sql.tmpl");
+
+#[derive(Parser)]
+#[command(
+    name = "ag",
+    version = VERSION,
+    about = "Anti-Gravital CLI - crea y gestiona proyectos AG",
+    long_about = None,
+)]
+struct Cli {
+    #[command(subcommand)]
+    command: Commands,
+}
+
+#[derive(Subcommand)]
+enum Commands {
+    /// Crea un nuevo proyecto Anti-Gravital.
+    ///
+    /// Genera la estructura de archivos a partir del template elegido
+    /// y sustituye el nombre del proyecto en todos los archivos.
+    New {
+        /// Nombre del nuevo proyecto (también se usa como nombre de directorio).
+        name: String,
+
+        /// Template de partida.
+        #[arg(long, short = 't', default_value = "rest",
+              value_parser = ["rest", "realtime", "fullstack"])]
+        template: String,
+    },
+
+    /// Arranca el servidor en modo desarrollo con hot reload.
+    ///
+    /// Requiere `cargo-watch` instalado (`cargo install cargo-watch`).
+    /// Si no esta disponible, ejecuta `cargo run` sin recarga automatica.
+    Dev {
+        /// Direccion de escucha del servidor.
+        #[arg(long, default_value = "0.0.0.0:8080")]
+        bind: String,
+    },
+
+    /// Compila el proyecto en modo release.
+    Build {
+        /// Triple de compilacion cruzada (ej: `x86_64-unknown-linux-musl`).
+        #[arg(long)]
+        target: Option<String>,
+    },
+}
 
 fn main() {
-    // Placeholder de Fase 0: deliberadamente vacio.
+    let cli = Cli::parse();
+    let result = match cli.command {
+        Commands::New { name, template } => cmd_new(&name, &template),
+        Commands::Dev { bind } => cmd_dev(&bind),
+        Commands::Build { target } => cmd_build(target.as_deref()),
+    };
+    if let Err(msg) = result {
+        eprintln!("error: {msg}");
+        process::exit(1);
+    }
+}
+
+fn cmd_new(name: &str, template: &str) -> Result<(), String> {
+    validate_project_name(name)?;
+
+    let project_dir = Path::new(name);
+    if project_dir.exists() {
+        return Err(format!("el directorio '{name}' ya existe"));
+    }
+
+    println!("Creando proyecto '{name}' con template '{template}'...");
+
+    match template {
+        "rest" => scaffold_rest(name, project_dir),
+        "realtime" => scaffold_realtime(name, project_dir),
+        "fullstack" => scaffold_fullstack(name, project_dir),
+        _ => Err(format!("template desconocido: {template}")),
+    }?;
+
+    println!();
+    println!("Proyecto '{name}' creado.");
+    println!();
+    println!("Proximos pasos:");
+    println!("  cd {name}");
+    println!("  ag dev");
+
+    Ok(())
+}
+
+fn cmd_dev(bind: &str) -> Result<(), String> {
+    println!("Iniciando servidor en modo desarrollo (bind: {bind})...");
+
+    let watch_available = process::Command::new("cargo")
+        .args(["watch", "--version"])
+        .stdout(process::Stdio::null())
+        .stderr(process::Stdio::null())
+        .status()
+        .map(|s| s.success())
+        .unwrap_or(false);
+
+    let status = if watch_available {
+        println!("Usando cargo-watch para hot reload.");
+        process::Command::new("cargo")
+            .env("BIND", bind)
+            .args(["watch", "-x", "run"])
+            .status()
+            .map_err(|e| format!("no se pudo ejecutar cargo watch: {e}"))?
+    } else {
+        println!("cargo-watch no encontrado. Ejecutando sin hot reload.");
+        println!("Para habilitar hot reload: cargo install cargo-watch");
+        process::Command::new("cargo")
+            .env("BIND", bind)
+            .arg("run")
+            .status()
+            .map_err(|e| format!("no se pudo ejecutar cargo run: {e}"))?
+    };
+
+    if !status.success() {
+        return Err("el servidor termino con error".into());
+    }
+    Ok(())
+}
+
+fn cmd_build(target: Option<&str>) -> Result<(), String> {
+    let mut args = vec!["build", "--release"];
+    if let Some(t) = target {
+        args.push("--target");
+        args.push(t);
+    }
+
+    println!("Compilando en modo release...");
+    let status = process::Command::new("cargo")
+        .args(&args)
+        .status()
+        .map_err(|e| format!("no se pudo ejecutar cargo build: {e}"))?;
+
+    if !status.success() {
+        return Err("la compilacion fallo".into());
+    }
+    println!("Compilacion exitosa.");
+    Ok(())
+}
+
+fn validate_project_name(name: &str) -> Result<(), String> {
+    if name.is_empty() {
+        return Err("el nombre del proyecto no puede estar vacio".into());
+    }
+    if !name
+        .chars()
+        .all(|c| c.is_alphanumeric() || c == '-' || c == '_')
+    {
+        return Err(format!(
+            "nombre de proyecto invalido '{name}': solo se permiten letras, numeros, guion y guion_bajo"
+        ));
+    }
+    Ok(())
+}
+
+fn apply_template(template: &str, name: &str) -> String {
+    template.replace("{{name}}", name)
+}
+
+fn write_file(path: &Path, content: &str) -> Result<(), String> {
+    if let Some(parent) = path.parent() {
+        fs::create_dir_all(parent)
+            .map_err(|e| format!("no se pudo crear directorio '{}': {e}", parent.display()))?;
+    }
+    fs::write(path, content).map_err(|e| format!("no se pudo escribir '{}': {e}", path.display()))
+}
+
+fn scaffold_rest(name: &str, dir: &Path) -> Result<(), String> {
+    write_file(
+        &dir.join("Cargo.toml"),
+        &apply_template(REST_CARGO_TOML, name),
+    )?;
+    write_file(
+        &dir.join("src/main.rs"),
+        &apply_template(REST_MAIN_RS, name),
+    )?;
+    write_file(
+        &dir.join("config.toml"),
+        &apply_template(REST_CONFIG_TOML, name),
+    )?;
+    Ok(())
+}
+
+fn scaffold_realtime(name: &str, dir: &Path) -> Result<(), String> {
+    write_file(
+        &dir.join("Cargo.toml"),
+        &apply_template(REALTIME_CARGO_TOML, name),
+    )?;
+    write_file(
+        &dir.join("src/main.rs"),
+        &apply_template(REALTIME_MAIN_RS, name),
+    )?;
+    write_file(
+        &dir.join("config.toml"),
+        &apply_template(REALTIME_CONFIG_TOML, name),
+    )?;
+    Ok(())
+}
+
+fn scaffold_fullstack(name: &str, dir: &Path) -> Result<(), String> {
+    write_file(
+        &dir.join("Cargo.toml"),
+        &apply_template(FULLSTACK_CARGO_TOML, name),
+    )?;
+    write_file(
+        &dir.join("src/main.rs"),
+        &apply_template(FULLSTACK_MAIN_RS, name),
+    )?;
+    write_file(
+        &dir.join("config.toml"),
+        &apply_template(FULLSTACK_CONFIG_TOML, name),
+    )?;
+    write_file(
+        &dir.join("migrations/0001_init.sql"),
+        &apply_template(FULLSTACK_MIGRATION, name),
+    )?;
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn validate_name_accepts_valid_names() {
+        assert!(validate_project_name("my-api").is_ok());
+        assert!(validate_project_name("my_service").is_ok());
+        assert!(validate_project_name("todoapi123").is_ok());
+    }
+
+    #[test]
+    fn validate_name_rejects_empty() {
+        assert!(validate_project_name("").is_err());
+    }
+
+    #[test]
+    fn validate_name_rejects_spaces() {
+        assert!(validate_project_name("mi proyecto").is_err());
+    }
+
+    #[test]
+    fn apply_template_substitutes_name() {
+        let tmpl = "name = \"{{name}}\"";
+        let result = apply_template(tmpl, "my-app");
+        assert_eq!(result, "name = \"my-app\"");
+    }
+
+    #[test]
+    fn apply_template_replaces_all_occurrences() {
+        let tmpl = "{{name}} y {{name}}";
+        let result = apply_template(tmpl, "alfa");
+        assert_eq!(result, "alfa y alfa");
+    }
 }

--- a/crates/ag-core/src/core/mod.rs
+++ b/crates/ag-core/src/core/mod.rs
@@ -18,7 +18,7 @@
 //! # Sistema de respuestas
 //!
 //! El modulo [`response`] reexporta los tipos de respuesta de Axum y
-//! agrega [`PlainText`] para respuestas de texto plano.
+//! agrega [`response::PlainText`] para respuestas de texto plano.
 //!
 //! # Estado de la aplicacion
 //!
@@ -52,8 +52,8 @@ pub use crate::shield::Claims;
 ///
 /// Reexporta los tipos de respuesta de Axum y agrega variantes
 /// convenientes para texto plano. Los handlers que devuelven JSON
-/// usan [`Json<T>`] directamente; los que devuelven texto plano
-/// usan [`PlainText`].
+/// usan [`response::Json`] directamente; los que devuelven texto plano
+/// usan [`response::PlainText`].
 pub mod response {
     pub use axum::http::StatusCode;
     pub use axum::response::{IntoResponse, Response};

--- a/crates/ag-core/src/core/mod.rs
+++ b/crates/ag-core/src/core/mod.rs
@@ -1,16 +1,99 @@
-//! Capa Core: router, extractores tipados y estado compartido.
+//! Capa Core: router Axum, extractores tipados y estado compartido.
 //!
-//! Fase 1 deja este modulo como placeholder estable: solo expone el
-//! tipo `AppState` minimo. La implementacion completa (router con
-//! extractores `State<T>`, `ValidatedBody<T>`, `Claims<T>`, `Path<T>`,
-//! `Query<T>`, sistema de respuestas JSON/plaintext/streams) llega en
-//! Fase 2 segun la Hoja de Ruta.
+//! Esta capa recibe los requests que ya pasaron la pipeline Shield y los
+//! despacha a los handlers de logica de negocio. Reexporta los extractores
+//! de Axum y de la Shield para que los handlers no necesiten importar
+//! directamente desde esos modulos.
 //!
-//! La separacion logica Shield/Core descrita en el capitulo 6 del
-//! maestro de arquitectura se respeta desde el bootstrap.
+//! # Extractores disponibles
+//!
+//! | Extractor | Origen | Que extrae |
+//! | --- | --- | --- |
+//! | [`State<T>`] | axum | Estado compartido del router |
+//! | [`Path<T>`] | axum | Segmentos de ruta tipados |
+//! | [`Query<T>`] | axum | Parametros de query string |
+//! | [`ValidatedBody<T>`] | shield | Body JSON deserializado y validado |
+//! | [`Claims<T>`] | shield | Claims JWT verificados |
+//!
+//! # Sistema de respuestas
+//!
+//! El modulo [`response`] reexporta los tipos de respuesta de Axum y
+//! agrega [`PlainText`] para respuestas de texto plano.
+//!
+//! # Estado de la aplicacion
+//!
+//! [`AppState`] es el tipo base de estado compartido. En proyectos reales
+//! el desarrollador define su propio tipo de estado con los clientes de
+//! base de datos, cache y servicios externos:
+//!
+//! ```rust
+//! use ag_core::core::AppState;
+//!
+//! #[derive(Clone)]
+//! struct MiEstado {
+//!     nombre: String,
+//! }
+//! ```
+//!
+//! Ese tipo se pasa a [`axum::Router::with_state`] y se extrae con [`State<T>`].
 
-/// Estado compartido por defecto. Los proyectos lo extienden con sus
-/// clientes a base de datos, caches y servicios externos.
+// Re-exports de extractores de Axum para los handlers del Core.
+pub use axum::extract::{Path, Query, State};
+
+// Re-exports del extractor de body con validacion desde Shield.
+#[cfg(feature = "validation")]
+pub use crate::shield::validation::ValidatedJson as ValidatedBody;
+
+// Re-export del extractor de claims JWT desde Shield.
+#[cfg(feature = "auth-jwt")]
+pub use crate::shield::Claims;
+
+/// Sistema de respuestas del Core.
+///
+/// Reexporta los tipos de respuesta de Axum y agrega variantes
+/// convenientes para texto plano. Los handlers que devuelven JSON
+/// usan [`Json<T>`] directamente; los que devuelven texto plano
+/// usan [`PlainText`].
+pub mod response {
+    pub use axum::http::StatusCode;
+    pub use axum::response::{IntoResponse, Response};
+    pub use axum::Json;
+
+    /// Respuesta de texto plano con `Content-Type: text/plain; charset=utf-8`.
+    ///
+    /// ```rust
+    /// use ag_core::core::response::{IntoResponse, PlainText};
+    ///
+    /// async fn handler() -> impl IntoResponse {
+    ///     PlainText("pong".into())
+    /// }
+    /// ```
+    pub struct PlainText(pub String);
+
+    impl IntoResponse for PlainText {
+        fn into_response(self) -> Response {
+            use axum::http::header;
+            (
+                [(header::CONTENT_TYPE, "text/plain; charset=utf-8")],
+                self.0,
+            )
+                .into_response()
+        }
+    }
+
+    /// Stream de bytes abierto.
+    ///
+    /// Util para respuestas chunked o para SSE basico. Para SSE completo
+    /// con reconexion y event IDs usar `ag-realtime` (Fase 4).
+    pub use axum::body::Body as BodyStream;
+}
+
+/// Estado compartido por defecto.
+///
+/// Tipo placeholder para proyectos que no necesitan estado global.
+/// Los proyectos reales definen su propio estado con los clientes
+/// de base de datos, cache y servicios externos, luego lo registran
+/// con [`axum::Router::with_state`].
 #[derive(Debug, Default, Clone)]
 pub struct AppState;
 
@@ -21,5 +104,26 @@ mod tests {
     #[test]
     fn app_state_default_is_constructible() {
         let _state = AppState;
+    }
+
+    #[test]
+    fn path_query_state_re_exported() {
+        // Verifica que los tipos esten disponibles en el modulo.
+        // La compilacion ya valida la re-exportacion correcta.
+        type _P = Path<String>;
+        type _Q = Query<std::collections::HashMap<String, String>>;
+        type _S = State<()>;
+    }
+
+    #[test]
+    fn plain_text_into_response() {
+        use response::{IntoResponse, PlainText};
+        let resp = PlainText("hola".into()).into_response();
+        let ct = resp
+            .headers()
+            .get(axum::http::header::CONTENT_TYPE)
+            .and_then(|v| v.to_str().ok())
+            .unwrap_or("");
+        assert!(ct.contains("text/plain"));
     }
 }

--- a/crates/ag-core/src/error.rs
+++ b/crates/ag-core/src/error.rs
@@ -45,6 +45,22 @@ pub enum AgError {
     #[error("csrf error: {0}")]
     Csrf(String),
 
+    /// Recurso no encontrado.
+    #[error("not found: {0}")]
+    NotFound(String),
+
+    /// Solicitud incorrecta (parametros invalidos, semantica incorrecta).
+    #[error("bad request: {0}")]
+    BadRequest(String),
+
+    /// Conflicto de estado (duplicado, restriccion de unicidad, etc.).
+    #[error("conflict: {0}")]
+    Conflict(String),
+
+    /// Error de capa de datos (base de datos, migraciones).
+    #[error("database error: {0}")]
+    Database(String),
+
     /// Error de I/O.
     #[error("io error: {0}")]
     Io(#[from] std::io::Error),
@@ -66,6 +82,10 @@ impl AgError {
             Self::Validation(_) => "validation_error",
             Self::Cors(_) => "cors_error",
             Self::Csrf(_) => "csrf_error",
+            Self::NotFound(_) => "not_found",
+            Self::BadRequest(_) => "bad_request",
+            Self::Conflict(_) => "conflict",
+            Self::Database(_) => "database_error",
             Self::Io(_) => "io_error",
             Self::Other(_) => "internal_error",
         }
@@ -80,7 +100,10 @@ impl AgError {
             Self::RateLimit => StatusCode::TOO_MANY_REQUESTS,
             Self::Validation(_) => StatusCode::UNPROCESSABLE_ENTITY,
             Self::Cors(_) | Self::Csrf(_) => StatusCode::FORBIDDEN,
-            Self::Io(_) | Self::Other(_) => StatusCode::INTERNAL_SERVER_ERROR,
+            Self::NotFound(_) => StatusCode::NOT_FOUND,
+            Self::BadRequest(_) => StatusCode::BAD_REQUEST,
+            Self::Conflict(_) => StatusCode::CONFLICT,
+            Self::Database(_) | Self::Io(_) | Self::Other(_) => StatusCode::INTERNAL_SERVER_ERROR,
         }
     }
 }
@@ -123,5 +146,33 @@ mod tests {
     fn auth_maps_to_401() {
         let err = AgError::Auth("missing token".into());
         assert_eq!(err.status(), StatusCode::UNAUTHORIZED);
+    }
+
+    #[test]
+    fn not_found_maps_to_404() {
+        let err = AgError::NotFound("todo 42".into());
+        assert_eq!(err.status(), StatusCode::NOT_FOUND);
+        assert_eq!(err.code(), "not_found");
+    }
+
+    #[test]
+    fn bad_request_maps_to_400() {
+        let err = AgError::BadRequest("invalid id".into());
+        assert_eq!(err.status(), StatusCode::BAD_REQUEST);
+        assert_eq!(err.code(), "bad_request");
+    }
+
+    #[test]
+    fn conflict_maps_to_409() {
+        let err = AgError::Conflict("email already exists".into());
+        assert_eq!(err.status(), StatusCode::CONFLICT);
+        assert_eq!(err.code(), "conflict");
+    }
+
+    #[test]
+    fn database_maps_to_500() {
+        let err = AgError::Database("connection refused".into());
+        assert_eq!(err.status(), StatusCode::INTERNAL_SERVER_ERROR);
+        assert_eq!(err.code(), "database_error");
     }
 }

--- a/crates/ag-core/src/lib.rs
+++ b/crates/ag-core/src/lib.rs
@@ -107,5 +107,6 @@ pub mod runtime;
 pub mod shield;
 
 pub use crate::config::ShieldConfig;
+pub use crate::core::AppState;
 pub use crate::error::{AgError, AgResult};
 pub use crate::shield::Shield;

--- a/crates/ag-data/Cargo.toml
+++ b/crates/ag-data/Cargo.toml
@@ -16,3 +16,11 @@ publish = false
 
 [lints]
 workspace = true
+
+[dependencies]
+ag-core = { workspace = true }
+serde = { workspace = true }
+sqlx = { workspace = true }
+thiserror = { workspace = true }
+tokio = { workspace = true }
+tracing = { workspace = true }

--- a/crates/ag-data/src/lib.rs
+++ b/crates/ag-data/src/lib.rs
@@ -1,5 +1,211 @@
-//! Capa de datos con sqlx, ORM tipado generado por el DSL y migraciones embebidas.
+//! Capa de datos de Anti-Gravital.
 //!
-//! Estado: Fase 0 (Fundaciones y Gobernanza). Este crate aun no contiene
-//! codigo funcional. La implementacion se entrega en la fase declarada
-//! en el README del crate y en la Hoja de Ruta del proyecto.
+//! Provee el pool de conexiones PostgreSQL, la configuracion declarativa
+//! y el helper para ejecutar migraciones embebidas. En Fase 3+ el DSL
+//! genera query builders tipados que usan este pool como backend.
+//!
+//! # Ejemplo minimo
+//!
+//! ```no_run
+//! use ag_data::{DataConfig, connect};
+//!
+//! # async fn run() -> Result<(), Box<dyn std::error::Error>> {
+//! let config = DataConfig {
+//!     url: "postgresql://localhost/mi_app".into(),
+//!     ..DataConfig::default()
+//! };
+//!
+//! let pool = connect(&config).await?;
+//! # let _ = pool;
+//! # Ok(())
+//! # }
+//! ```
+//!
+//! # Migraciones
+//!
+//! Las migraciones se embeben en el binario con el macro `sqlx::migrate!`
+//! y se aplican en el arranque con [`run_migrations`]:
+//!
+//! ```ignore
+//! use ag_data::{DataConfig, DbPool, connect, run_migrations};
+//!
+//! # async fn run() -> Result<(), Box<dyn std::error::Error>> {
+//! # let pool = connect(&DataConfig::default()).await?;
+//! // El macro lee los archivos SQL del crate consumidor, no de ag-data.
+//! // La ruta es relativa al Cargo.toml del proyecto que llama a migrate!.
+//! static MIGRATOR: sqlx::migrate::Migrator = sqlx::migrate!("./migrations");
+//! run_migrations(&pool, &MIGRATOR).await?;
+//! # Ok(())
+//! # }
+//! ```
+
+use std::time::Duration;
+
+use sqlx::postgres::PgPoolOptions;
+use thiserror::Error;
+
+/// Pool de conexiones PostgreSQL compartido entre handlers.
+///
+/// Es un alias de [`sqlx::PgPool`], que ya implementa [`Clone`] con
+/// costo O(1) (comparte el pool interno por `Arc`).
+pub type DbPool = sqlx::PgPool;
+
+/// Error de la capa de datos.
+#[derive(Debug, Error)]
+pub enum DataError {
+    /// Error originado en sqlx (conexion, query, protocolo).
+    #[error("sqlx error: {0}")]
+    Sqlx(#[from] sqlx::Error),
+
+    /// Error durante la ejecucion de migraciones.
+    #[error("migration error: {0}")]
+    Migration(#[from] sqlx::migrate::MigrateError),
+}
+
+impl From<DataError> for ag_core::AgError {
+    fn from(err: DataError) -> Self {
+        ag_core::AgError::Database(err.to_string())
+    }
+}
+
+/// Configuracion del pool de conexiones.
+#[derive(Debug, Clone, serde::Deserialize)]
+pub struct DataConfig {
+    /// URL de conexion PostgreSQL.
+    ///
+    /// Formato: `postgresql://usuario:contrasena@host:puerto/basedatos`
+    pub url: String,
+
+    /// Maximo de conexiones simultaneas en el pool.
+    #[serde(default = "DataConfig::default_max_connections")]
+    pub max_connections: u32,
+
+    /// Segundos maximos para adquirir una conexion del pool.
+    #[serde(default = "DataConfig::default_acquire_timeout_secs")]
+    pub acquire_timeout_secs: u64,
+}
+
+impl DataConfig {
+    fn default_max_connections() -> u32 {
+        10
+    }
+    fn default_acquire_timeout_secs() -> u64 {
+        30
+    }
+}
+
+impl Default for DataConfig {
+    fn default() -> Self {
+        Self {
+            url: "postgresql://localhost/app".into(),
+            max_connections: Self::default_max_connections(),
+            acquire_timeout_secs: Self::default_acquire_timeout_secs(),
+        }
+    }
+}
+
+/// Conecta a PostgreSQL y devuelve un pool listo para usar.
+///
+/// Aplica la configuracion del pool declarada en [`DataConfig`].
+/// El pool se inicializa de forma lazy: las conexiones reales se
+/// abren cuando se necesitan, hasta el maximo declarado.
+///
+/// # Errores
+///
+/// Devuelve [`DataError::Sqlx`] si la URL es invalida o si no se
+/// puede establecer la conexion inicial de prueba.
+pub async fn connect(config: &DataConfig) -> Result<DbPool, DataError> {
+    tracing::debug!(url = %sanitize_url(&config.url), "conectando al pool PostgreSQL");
+
+    let pool = PgPoolOptions::new()
+        .max_connections(config.max_connections)
+        .acquire_timeout(Duration::from_secs(config.acquire_timeout_secs))
+        .connect(&config.url)
+        .await?;
+
+    tracing::info!(
+        max_connections = config.max_connections,
+        "pool PostgreSQL listo"
+    );
+    Ok(pool)
+}
+
+/// Ejecuta las migraciones embebidas contra el pool.
+///
+/// El `migrator` se construye con el macro `sqlx::migrate!("./migrations")`
+/// en el crate que contiene los archivos SQL. Este helper aplica todas
+/// las migraciones pendientes en orden y es idempotente.
+///
+/// # Errores
+///
+/// Devuelve [`DataError::Migration`] si una migracion falla.
+pub async fn run_migrations(
+    pool: &DbPool,
+    migrator: &sqlx::migrate::Migrator,
+) -> Result<(), DataError> {
+    tracing::info!("aplicando migraciones pendientes");
+    migrator.run(pool).await?;
+    tracing::info!("migraciones completadas");
+    Ok(())
+}
+
+/// Elimina credenciales de la URL para logging seguro.
+fn sanitize_url(url: &str) -> String {
+    // Oculta usuario:contrasena@ para no filtrar credenciales en logs.
+    if let Some(at) = url.find('@') {
+        if let Some(proto) = url.find("://") {
+            return format!("{}://<redacted>@{}", &url[..proto], &url[at + 1..]);
+        }
+    }
+    url.to_string()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn data_config_default_is_sensible() {
+        let cfg = DataConfig::default();
+        assert_eq!(cfg.max_connections, 10);
+        assert_eq!(cfg.acquire_timeout_secs, 30);
+        assert!(cfg.url.starts_with("postgresql://"));
+    }
+
+    #[test]
+    fn sanitize_url_removes_credentials() {
+        let url = "postgresql://user:secret@localhost:5432/db";
+        let safe = sanitize_url(url);
+        assert!(!safe.contains("secret"));
+        assert!(safe.contains("localhost:5432/db"));
+    }
+
+    #[test]
+    fn sanitize_url_without_credentials_is_unchanged() {
+        let url = "postgresql://localhost/db";
+        let safe = sanitize_url(url);
+        assert_eq!(safe, url);
+    }
+
+    #[test]
+    fn data_error_converts_to_ag_error() {
+        use ag_core::AgError;
+        let data_err = DataError::Sqlx(sqlx::Error::RowNotFound);
+        let ag_err = AgError::from(data_err);
+        assert_eq!(ag_err.code(), "database_error");
+    }
+
+    #[tokio::test]
+    #[ignore = "requiere DATABASE_URL con PostgreSQL accesible"]
+    async fn connect_to_real_db() {
+        let url =
+            std::env::var("DATABASE_URL").expect("DATABASE_URL debe estar definida para este test");
+        let config = DataConfig {
+            url,
+            ..DataConfig::default()
+        };
+        let pool = connect(&config).await.expect("conexion fallida");
+        let row: (i64,) = sqlx::query_as("SELECT 1").fetch_one(&pool).await.unwrap();
+        assert_eq!(row.0, 1);
+    }
+}

--- a/deny.toml
+++ b/deny.toml
@@ -10,7 +10,9 @@ no-default-features = false
 db-path = "~/.cargo/advisory-db"
 db-urls = ["https://github.com/rustsec/advisory-db"]
 yanked = "warn"
-ignore = []
+# RUSTSEC-2023-0071: Marvin Attack en `rsa` 0.9.x (transitivo via sqlx).
+# Sin parche disponible. Se revisa con cada actualizacion de sqlx.
+ignore = ["RUSTSEC-2023-0071"]
 
 [licenses]
 confidence-threshold = 0.93
@@ -25,6 +27,7 @@ allow = [
     "BSD-2-Clause",
     "BSD-3-Clause",
     "ISC",
+    "MPL-2.0",
     "Unicode-3.0",
     "Unicode-DFS-2016",
     "Zlib",

--- a/docs/manual/02-primera-api.md
+++ b/docs/manual/02-primera-api.md
@@ -1,0 +1,251 @@
+# Tu primera API con Anti-Gravital
+
+> Fase 2 — The Core MVP y roundtrip completo  
+> Documento del manual: `docs/manual/02-primera-api.md`  
+> Anterior: [01-shield-as-library.md](./01-shield-as-library.md)
+
+---
+
+## Objetivo
+
+Al finalizar este capitulo tendras una API REST completamente funcional
+que hace CRUD contra PostgreSQL, empaquetada en un binario estatico
+deployable desde `FROM scratch`.
+
+El flujo completo es:
+
+```
+Request → Shield (auth, rate-limit, CORS) → Core (router, handlers) → PostgreSQL
+```
+
+Todo en un proceso Rust, sin IPC, sin sidecar, sin magic.
+
+---
+
+## Prerequisitos
+
+- Rust 1.79+ instalado (`rustup update stable`)
+- PostgreSQL local o remoto accesible
+- `ag` CLI compilado (`cargo install --path crates/ag-cli` desde el
+  repositorio)
+
+---
+
+## 1. Crear el proyecto
+
+```sh
+ag new mi-api --template rest
+cd mi-api
+```
+
+Esto genera:
+
+```
+mi-api/
+├── Cargo.toml
+├── config.toml
+└── src/
+    └── main.rs
+```
+
+Para una API con base de datos desde el inicio:
+
+```sh
+ag new mi-api --template fullstack
+```
+
+El template `fullstack` agrega `ag-data`, sqlx y un directorio
+`migrations/` preconfigurado.
+
+---
+
+## 2. Arrancar en desarrollo
+
+```sh
+export DATABASE_URL="postgresql://postgres:postgres@localhost/mi_api"
+ag dev
+```
+
+El comando `ag dev` detecta si `cargo-watch` esta instalado y activa
+hot reload automaticamente. Si no esta instalado:
+
+```sh
+cargo install cargo-watch
+```
+
+La API queda disponible en `http://localhost:8080`.
+
+---
+
+## 3. Estructura de un handler tipico
+
+```rust
+use ag_core::{AgError, AgResult};
+use ag_core::core::{State, Path, Query};
+use axum::Json;
+
+// Estado compartido: definido una vez, clonado por referencia Arc.
+#[derive(Clone)]
+struct AppState {
+    db: ag_data::DbPool,
+}
+
+// Handler: recibe extractores tipados, devuelve Result<_, AgError>.
+// La conversion a respuesta HTTP es automatica.
+async fn get_user(
+    State(state): State<AppState>,
+    Path(id): Path<i64>,
+) -> Result<Json<User>, AgError> {
+    let user = sqlx::query_as::<_, User>("SELECT id, name FROM users WHERE id = $1")
+        .bind(id)
+        .fetch_optional(&state.db)
+        .await
+        .map_err(|e| AgError::Database(e.to_string()))?
+        .ok_or_else(|| AgError::NotFound(format!("user {id}")))?;
+
+    Ok(Json(user))
+}
+```
+
+Los extractores disponibles desde `ag_core::core`:
+
+| Extractor | Que extrae |
+| --- | --- |
+| `State<T>` | Estado compartido del router |
+| `Path<T>` | Segmentos de ruta tipados (`/users/{id}`) |
+| `Query<T>` | Parametros de query string (`?page=1`) |
+| `ValidatedBody<T>` | Body JSON con validacion declarativa |
+| `Claims<T>` | Claims JWT verificados por Shield |
+
+---
+
+## 4. Conectar a PostgreSQL
+
+```rust
+use ag_data::{DataConfig, connect, run_migrations};
+
+let config = DataConfig {
+    url: std::env::var("DATABASE_URL").expect("DATABASE_URL no definida"),
+    max_connections: 10,
+    ..DataConfig::default()
+};
+
+let pool = connect(&config).await?;
+
+// El macro embebe los archivos SQL en el binario al compilar.
+static MIGRATOR: sqlx::migrate::Migrator = sqlx::migrate!("./migrations");
+run_migrations(&pool, &MIGRATOR).await?;
+```
+
+Las migraciones son archivos `.sql` en el directorio `migrations/`,
+numerados en orden: `0001_create_users.sql`, `0002_add_index.sql`, etc.
+Son idempotentes: se aplican solo si no han sido aplicadas antes.
+
+---
+
+## 5. Registrar el router con Shield
+
+```rust
+use ag_core::{Shield, ShieldConfig};
+use axum::{Router, routing::{get, post}};
+
+let shield = Shield::with_defaults();
+
+let router = Router::new()
+    .route("/users", get(list_users).post(create_user))
+    .route("/users/{id}", get(get_user).put(update_user).delete(delete_user))
+    .with_state(AppState { db: pool });
+
+// Shield aplica: logging, rate-limit, CORS, CSRF, auth-JWT.
+let app = shield.apply(router);
+
+let listener = tokio::net::TcpListener::bind("0.0.0.0:8080").await?;
+shield.serve(listener, app).await?;
+```
+
+---
+
+## 6. Sistema de errores
+
+`AgError` convierte automaticamente a respuestas HTTP estructuradas:
+
+| Variante | HTTP | Codigo JSON |
+| --- | --- | --- |
+| `NotFound(msg)` | 404 | `not_found` |
+| `BadRequest(msg)` | 400 | `bad_request` |
+| `Conflict(msg)` | 409 | `conflict` |
+| `Validation(msg)` | 422 | `validation_error` |
+| `Auth(msg)` | 401 | `auth_error` |
+| `Database(msg)` | 500 | `database_error` |
+
+Ejemplo de respuesta de error:
+
+```json
+{
+  "code": "not_found",
+  "message": "not found: user 42"
+}
+```
+
+---
+
+## 7. Compilar para produccion
+
+```sh
+ag build
+```
+
+El binario resultante en `target/release/` es autocontenido.
+Para una imagen Docker minima:
+
+```sh
+# Ver examples/todo-api/Dockerfile para el Dockerfile completo
+docker build -t mi-api .
+docker run -e DATABASE_URL=postgresql://... -p 8080:8080 mi-api
+```
+
+El Dockerfile usa compilacion MUSL y `FROM scratch`, produciendo una
+imagen de menos de 20 MB.
+
+---
+
+## 8. Ejemplo completo: todo-api
+
+El ejemplo `examples/todo-api/` del repositorio implementa un CRUD
+completo con los cinco endpoints:
+
+```sh
+# Listar tareas
+curl http://localhost:8080/todos
+
+# Crear tarea
+curl -X POST http://localhost:8080/todos \
+  -H "Content-Type: application/json" \
+  -d '{"title": "Leer la documentacion"}'
+
+# Obtener tarea
+curl http://localhost:8080/todos/1
+
+# Actualizar tarea
+curl -X PUT http://localhost:8080/todos/1 \
+  -H "Content-Type: application/json" \
+  -d '{"done": true}'
+
+# Eliminar tarea
+curl -X DELETE http://localhost:8080/todos/1
+```
+
+Arrancar el ejemplo:
+
+```sh
+export DATABASE_URL="postgresql://postgres:postgres@localhost/todos"
+cargo run -p todo-api
+```
+
+---
+
+## Que sigue
+
+La Fase 3 introduce el Anti-DSL: defines tus modelos y endpoints en
+`schema.ag` y el compilador genera todo el codigo de esta guia
+automaticamente. Ver `docs/roadmap/fase-03-anti-dsl-alpha.md`.

--- a/docs/pr-drafts/claude-phase-2-development-7OWE3.md
+++ b/docs/pr-drafts/claude-phase-2-development-7OWE3.md
@@ -1,0 +1,119 @@
+# Fase 2: The Core MVP y roundtrip completo
+
+## Resumen
+
+Implementacion de los entregables de Fase 2 segun la Hoja de Ruta §2.2:
+modulo core en ag-core con extractores tipados y sistema de respuestas;
+ag-data con pool PostgreSQL y migraciones embebidas; ag-cli operativo con
+tres templates; ejemplo todo-api con CRUD completo y Dockerfile FROM scratch.
+
+## Fase afectada
+
+Fase 2 — The Core MVP y roundtrip completo.
+
+## Tipo de cambio
+
+- Implementacion de funcionalidad nueva (core, data, cli, ejemplo).
+- Expansion de sistema de errores existente (AgError).
+- Adicion de dependencias de workspace (sqlx, clap).
+
+## Documentos relacionados
+
+- `docs/roadmap/fase-02-core-mvp.md` — definicion de los entregables.
+- `docs/master/ANTI-GRAVITAL-Hoja-de-Ruta.md` — criterios de salida de Fase 2.
+- `docs/master/ANTI-GRAVITAL-Arquitectura-Tecnica.md` capitulo 6 — diseno Shield/Core.
+- `docs/manual/02-primera-api.md` — guia de usuario creada en esta PR.
+- `docs/roadmap/STATUS.md` — actualizado con progreso de Fase 2.
+
+## Cambios principales
+
+### ag-core
+
+- `src/core/mod.rs`: modulo Core completo con reexports de extractores
+  (`State`, `Path`, `Query`), alias `ValidatedBody`, reexport `Claims`
+  y modulo `response` con `PlainText` y `BodyStream`.
+- `src/error.rs`: expandido con `NotFound` (404), `BadRequest` (400),
+  `Conflict` (409) y `Database` (500).
+- `src/lib.rs`: reexporta `AppState` en el nivel superior.
+
+### ag-data (nuevo contenido funcional)
+
+- `Cargo.toml`: dependencias sqlx (0.8, postgres, migrate, macros,
+  runtime-tokio-rustls), ag-core, serde, thiserror, tokio, tracing.
+- `src/lib.rs`: `DbPool`, `DataConfig`, `DataError`, `connect()`,
+  `run_migrations()`, conversion `DataError -> AgError`, `sanitize_url`.
+- `migrations/`: directorio placeholder para tests del crate.
+
+### ag-cli (nuevo contenido funcional)
+
+- `Cargo.toml`: dependencias clap (4, derive), serde, thiserror, toml.
+  Declara el binario `ag`.
+- `src/main.rs`: comandos `new`, `dev`, `build` con subcomandos clap;
+  tres templates embebidos via `include_str!`; scaffold de proyectos con
+  sustitucion de `{{name}}`; deteccion de cargo-watch para hot reload.
+
+### templates/
+
+- `templates/rest/`: Cargo.toml.tmpl, src/main.rs.tmpl, config.toml.tmpl.
+- `templates/realtime/`: igual con handler WebSocket de ejemplo.
+- `templates/fullstack/`: igual con ag-data, sqlx y migrations/.
+
+### examples/todo-api/ (nuevo)
+
+- `Cargo.toml`: workspace member; dependencias ag-core, ag-data, axum,
+  sqlx, tokio, tracing, tracing-subscriber. Declara bench `crud`.
+- `src/main.rs`: arranque con Shield + router + pool PostgreSQL.
+- `src/models.rs`: structs `Todo`, `CreateTodo`, `UpdateTodo`.
+- `src/handlers.rs`: cinco handlers CRUD tipados con AgError.
+- `migrations/0001_create_todos.sql`: tabla `todos`.
+- `benches/crud.rs`: placeholder de benchmark CRUD+DB con instrucciones
+  para medicion en hardware de referencia.
+- `Dockerfile`: compilacion MUSL + FROM scratch; imagen <= 20 MB.
+
+### Workspace
+
+- `Cargo.toml`: agrega `examples/todo-api` a los miembros; agrega
+  `sqlx` (0.8) y `clap` (4) a `workspace.dependencies`; habilita la
+  feature `query` de axum; agrega path-references `ag-core` y `ag-data`.
+
+## Plan de prueba
+
+- [x] `cargo build --workspace` limpio (sin errores, sin warnings).
+- [x] `cargo test --workspace` verde (tests de DB ignorados por defecto).
+- [x] `cargo clippy --workspace --all-targets -- -D warnings` limpio.
+- [x] `cargo fmt --check` limpio.
+- [ ] `cargo test --workspace -- --ignored` verde contra PostgreSQL real.
+- [ ] `cargo run -p todo-api` arranca y sirve los cinco endpoints.
+- [ ] `docker build` produce imagen funcional < 20 MB (requiere MUSL).
+
+## Criterios de salida que avanza
+
+Hoja de Ruta Fase 2, seccion 2.2 (entregables):
+
+- [x] Crate `ag-core` con modulo `core` operativo.
+- [x] Router Axum integrado con la Shield.
+- [x] Extractores tipados.
+- [x] Sistema de errores AgError extendido.
+- [x] Sistema de respuestas JSON / plaintext / streams.
+- [x] Crate `ag-data` con pool PostgreSQL.
+- [x] Sistema de migraciones embebido.
+- [x] Example app `todo-api` con CRUD completo.
+- [/] Benchmark CRUD + DB (placeholder; medicion real pendiente).
+- [x] Crate `ag-cli` con comandos `new`, `dev`, `build`.
+- [x] Tres templates: `rest`, `realtime`, `fullstack`.
+
+## Checklist final CLAUDE.md
+
+- [x] Pertenece a la fase correcta (Fase 2).
+- [x] Respeta la documentacion y el alcance.
+- [x] No rompe arquitectura ni modularidad.
+- [x] No anade complejidad innecesaria ni features fuera de scope.
+- [x] No crea dependencias circulares.
+- [x] Compila (`cargo build --workspace`).
+- [x] Pasa tests (`cargo test --workspace`).
+- [x] Pasa fmt (`cargo fmt --check`).
+- [x] Pasa clippy (`cargo clippy --workspace --all-targets -- -D warnings`).
+- [x] Tiene documentacion (`docs/manual/02-primera-api.md`).
+- [/] Tiene benchmarks (placeholder en `examples/todo-api/benches/crud.rs`).
+- [x] Tiene manejo de errores correcto (`AgError` con conversion HTTP).
+- [x] Mantiene coherencia con Anti-Gravital v4.0.

--- a/docs/roadmap/STATUS.md
+++ b/docs/roadmap/STATUS.md
@@ -112,7 +112,55 @@ externas de Fase 0. El diseno de Shield esta fijado en
 
 ## Fase 2 - The Core MVP
 
-Estado: Pendiente. Vease `docs/roadmap/fase-02-core-mvp.md`.
+Estado: En curso. Implementacion inicial completa en repositorio.
+
+### Criterios de entrada (2.1)
+
+- [x] Fase 1 completada con todos sus criterios de salida marcados.
+  (Excepcion: criterios externos de Fase 0/1 siguen pendientes; la
+  implementacion avanza bajo la misma excepcion documentada en RFC-0001.)
+- [x] El crate `ag-data` ha sido iniciado con sqlx como dependencia.
+
+### Entregables (2.2)
+
+- [x] Crate `ag-core` con modulo `core` operativo. Reexporta `State<T>`,
+  `Path<T>`, `Query<T>`, `ValidatedBody<T>`, `Claims<T>` y el modulo
+  `response` con `Json`, `PlainText` y `BodyStream`.
+- [x] Router Axum integrado con la Shield. `Shield::apply(router)` acepta
+  cualquier `Router<()>` con estado ya registrado via `with_state`.
+- [x] Extractores: `State<T>`, `ValidatedBody<T>`, `Claims<T>`, `Path<T>`,
+  `Query<T>` disponibles desde `ag_core::core`.
+- [x] Sistema de errores `AgError` expandido: `NotFound` (404),
+  `BadRequest` (400), `Conflict` (409), `Database` (500).
+- [x] Sistema de respuestas: JSON (`axum::Json`), plaintext (`PlainText`),
+  streams (`BodyStream = axum::body::Body`).
+- [x] Crate `ag-data` con pool PostgreSQL via sqlx. `DataConfig`,
+  `DbPool`, `connect()`, `run_migrations()`, conversion `DataError ->
+  AgError`.
+- [x] Sistema de migraciones embebido con `sqlx::migrate!` demostrado
+  en `examples/todo-api/`.
+- [x] Example app `todo-api` en `examples/` con CRUD completo: cinco
+  handlers GET/POST/PUT/DELETE contra PostgreSQL real.
+- [/] Benchmark CRUD + DB ejecutable. El archivo `benches/crud.rs` existe
+  en `examples/todo-api/`. Las metricas duras (>= 40K req/s, p99 <= 5ms)
+  requieren hardware de referencia con PostgreSQL y se registran en
+  `docs/benchmarks/` segun la plantilla.
+- [x] Crate `ag-cli` con comandos `new`, `dev`, `build`.
+- [x] Tres templates: `rest`, `realtime`, `fullstack` embebidos en el
+  binario `ag` via `include_str!`.
+
+### Criterios de salida (2.3)
+
+- [ ] Benchmark CRUD + PostgreSQL >= 40K req/s en hardware de referencia.
+- [ ] Latencia p99 del CRUD <= 5 ms.
+- [ ] La app `todo-api` corre exitosamente con `ag new` + `ag dev`.
+- [ ] La app `todo-api` se despliega como binario unico (`FROM scratch`
+  Docker). Dockerfile preparado en `examples/todo-api/Dockerfile`.
+- [ ] El binario release del `todo-api` ocupa <= 20 MB.
+- [ ] Documentacion: "Tu primera API con Anti-Gravital" publicada.
+  Disponible en `docs/manual/02-primera-api.md`.
+- [ ] Al menos 50 stars en el repositorio.
+- [ ] Al menos tres contribuidores externos con PRs merged.
 
 ## Fase 3 - Anti-DSL alpha
 

--- a/examples/todo-api/Cargo.toml
+++ b/examples/todo-api/Cargo.toml
@@ -1,0 +1,33 @@
+[package]
+name = "todo-api"
+version.workspace = true
+edition.workspace = true
+rust-version.workspace = true
+license.workspace = true
+publish = false
+description = "Ejemplo CRUD completo: API de tareas con ag-core y ag-data"
+
+[[bin]]
+name = "todo-api"
+path = "src/main.rs"
+
+[lints]
+workspace = true
+
+[dependencies]
+ag-core = { workspace = true }
+ag-data = { workspace = true }
+axum = { workspace = true }
+serde = { workspace = true }
+serde_json = { workspace = true }
+sqlx = { workspace = true }
+tokio = { workspace = true }
+tracing = { workspace = true }
+tracing-subscriber = { workspace = true }
+
+[dev-dependencies]
+criterion = { workspace = true }
+
+[[bench]]
+name = "crud"
+harness = false

--- a/examples/todo-api/Dockerfile
+++ b/examples/todo-api/Dockerfile
@@ -1,0 +1,37 @@
+# syntax=docker/dockerfile:1
+#
+# Imagen de produccion de todo-api.
+# Construye un binario estatico con MUSL y lo empaqueta en FROM scratch.
+#
+# Uso:
+#   docker build -t todo-api .
+#   docker run -e DATABASE_URL=postgresql://... -p 8080:8080 todo-api
+
+FROM rust:1.79-slim AS builder
+
+# Instala las herramientas necesarias para compilacion estatica con MUSL.
+RUN apt-get update && apt-get install -y --no-install-recommends \
+        musl-tools \
+    && rm -rf /var/lib/apt/lists/*
+
+RUN rustup target add x86_64-unknown-linux-musl
+
+WORKDIR /build
+
+# Copia el workspace completo para aprovechar la cache de capas Docker.
+COPY Cargo.toml Cargo.lock rust-toolchain.toml ./
+COPY crates/ ./crates/
+COPY examples/todo-api/ ./examples/todo-api/
+COPY templates/ ./templates/
+
+RUN cargo build --release --target x86_64-unknown-linux-musl -p todo-api
+
+FROM scratch
+
+COPY --from=builder \
+    /build/target/x86_64-unknown-linux-musl/release/todo-api \
+    /todo-api
+
+EXPOSE 8080
+
+ENTRYPOINT ["/todo-api"]

--- a/examples/todo-api/benches/crud.rs
+++ b/examples/todo-api/benches/crud.rs
@@ -1,0 +1,42 @@
+//! Benchmark CRUD + PostgreSQL de la todo-api.
+#![allow(missing_docs)]
+//!
+//! Requiere una base de datos PostgreSQL accesible via DATABASE_URL.
+//! Si la variable no esta definida, el benchmark se salta con un aviso.
+//!
+//! Ejecutar:
+//! ```sh
+//! export DATABASE_URL="postgresql://postgres:postgres@localhost/todos_bench"
+//! cargo bench -p todo-api --bench crud
+//! ```
+
+use criterion::{criterion_group, criterion_main, Criterion};
+
+fn bench_placeholder(c: &mut Criterion) {
+    // El benchmark real requiere un runtime Tokio y una conexion PostgreSQL.
+    // Se implementa aqui como placeholder que documenta la intencion;
+    // la medicion definitiva se registra en docs/benchmarks/ siguiendo
+    // la plantilla measurement-template.md con hardware de referencia.
+    //
+    // Objetivo de Fase 2: >= 40 K req/s en CRUD simple, p99 <= 5 ms.
+
+    if std::env::var("DATABASE_URL").is_err() {
+        eprintln!(
+            "[crud bench] DATABASE_URL no definida; benchmark omitido. \
+             Define DATABASE_URL para ejecutar con una base de datos real."
+        );
+        return;
+    }
+
+    c.bench_function("todo_crud_placeholder", |b| {
+        b.iter(|| {
+            // Sustituir por operaciones reales contra el pool cuando
+            // DATABASE_URL este disponible. Ver docs/benchmarks/ para
+            // la metodologia y la plantilla de medicion.
+            std::hint::black_box(42u64)
+        });
+    });
+}
+
+criterion_group!(benches, bench_placeholder);
+criterion_main!(benches);

--- a/examples/todo-api/migrations/0001_create_todos.sql
+++ b/examples/todo-api/migrations/0001_create_todos.sql
@@ -1,0 +1,7 @@
+-- Migracion inicial: tabla de tareas.
+CREATE TABLE IF NOT EXISTS todos (
+    id        BIGSERIAL    PRIMARY KEY,
+    title     TEXT         NOT NULL,
+    done      BOOLEAN      NOT NULL DEFAULT FALSE,
+    created_at TIMESTAMPTZ NOT NULL DEFAULT NOW()
+);

--- a/examples/todo-api/src/handlers.rs
+++ b/examples/todo-api/src/handlers.rs
@@ -1,0 +1,120 @@
+//! Handlers HTTP de la todo-api.
+//!
+//! Cada handler recibe los extractores necesarios y devuelve
+//! `Result<_, AgError>` para que la conversion a respuesta HTTP sea
+//! automatica via `IntoResponse`.
+
+use axum::{
+    extract::{Path, State},
+    http::StatusCode,
+    Json,
+};
+use serde::Serialize;
+
+use ag_core::AgError;
+
+use crate::{
+    models::{CreateTodo, Todo, UpdateTodo},
+    AppState,
+};
+
+#[derive(Serialize)]
+pub(crate) struct HealthResponse {
+    status: &'static str,
+    service: &'static str,
+}
+
+pub(crate) async fn health() -> Json<HealthResponse> {
+    Json(HealthResponse {
+        status: "ok",
+        service: "todo-api",
+    })
+}
+
+pub(crate) async fn list_todos(State(state): State<AppState>) -> Result<Json<Vec<Todo>>, AgError> {
+    let todos = sqlx::query_as::<_, Todo>("SELECT id, title, done FROM todos ORDER BY id")
+        .fetch_all(&state.db)
+        .await
+        .map_err(|e| AgError::Database(e.to_string()))?;
+
+    Ok(Json(todos))
+}
+
+pub(crate) async fn get_todo(
+    State(state): State<AppState>,
+    Path(id): Path<i64>,
+) -> Result<Json<Todo>, AgError> {
+    let todo = sqlx::query_as::<_, Todo>("SELECT id, title, done FROM todos WHERE id = $1")
+        .bind(id)
+        .fetch_optional(&state.db)
+        .await
+        .map_err(|e| AgError::Database(e.to_string()))?
+        .ok_or_else(|| AgError::NotFound(format!("todo {id}")))?;
+
+    Ok(Json(todo))
+}
+
+pub(crate) async fn create_todo(
+    State(state): State<AppState>,
+    Json(req): Json<CreateTodo>,
+) -> Result<(StatusCode, Json<Todo>), AgError> {
+    if req.title.trim().is_empty() {
+        return Err(AgError::BadRequest("el titulo no puede estar vacio".into()));
+    }
+
+    let todo = sqlx::query_as::<_, Todo>(
+        "INSERT INTO todos (title) VALUES ($1) RETURNING id, title, done",
+    )
+    .bind(&req.title)
+    .fetch_one(&state.db)
+    .await
+    .map_err(|e| AgError::Database(e.to_string()))?;
+
+    Ok((StatusCode::CREATED, Json(todo)))
+}
+
+pub(crate) async fn update_todo(
+    State(state): State<AppState>,
+    Path(id): Path<i64>,
+    Json(req): Json<UpdateTodo>,
+) -> Result<Json<Todo>, AgError> {
+    // Verifica que exista antes de actualizar.
+    let existing = sqlx::query_as::<_, Todo>("SELECT id, title, done FROM todos WHERE id = $1")
+        .bind(id)
+        .fetch_optional(&state.db)
+        .await
+        .map_err(|e| AgError::Database(e.to_string()))?
+        .ok_or_else(|| AgError::NotFound(format!("todo {id}")))?;
+
+    let new_title = req.title.unwrap_or(existing.title);
+    let new_done = req.done.unwrap_or(existing.done);
+
+    let updated = sqlx::query_as::<_, Todo>(
+        "UPDATE todos SET title = $1, done = $2 WHERE id = $3 RETURNING id, title, done",
+    )
+    .bind(&new_title)
+    .bind(new_done)
+    .bind(id)
+    .fetch_one(&state.db)
+    .await
+    .map_err(|e| AgError::Database(e.to_string()))?;
+
+    Ok(Json(updated))
+}
+
+pub(crate) async fn delete_todo(
+    State(state): State<AppState>,
+    Path(id): Path<i64>,
+) -> Result<StatusCode, AgError> {
+    let result = sqlx::query("DELETE FROM todos WHERE id = $1")
+        .bind(id)
+        .execute(&state.db)
+        .await
+        .map_err(|e| AgError::Database(e.to_string()))?;
+
+    if result.rows_affected() == 0 {
+        return Err(AgError::NotFound(format!("todo {id}")));
+    }
+
+    Ok(StatusCode::NO_CONTENT)
+}

--- a/examples/todo-api/src/main.rs
+++ b/examples/todo-api/src/main.rs
@@ -1,0 +1,79 @@
+//! Todo API: ejemplo de CRUD completo con ag-core y ag-data.
+//!
+//! Demuestra el roundtrip Request -> Shield -> Core -> Handler -> Respuesta
+//! con conexion real a PostgreSQL. Ejecutar con:
+//!
+//! ```sh
+//! export DATABASE_URL="postgresql://usuario:clave@localhost/todos"
+//! cargo run -p todo-api
+//! ```
+//!
+//! Endpoints disponibles:
+//!
+//! | Metodo | Ruta         | Descripcion              |
+//! | ------ | ------------ | ------------------------ |
+//! | GET    | /todos       | Lista todas las tareas   |
+//! | POST   | /todos       | Crea una tarea nueva     |
+//! | GET    | /todos/:id   | Obtiene una tarea        |
+//! | PUT    | /todos/:id   | Actualiza una tarea      |
+//! | DELETE | /todos/:id   | Elimina una tarea        |
+//! | GET    | /health      | Verificacion de estado   |
+
+#![allow(missing_docs)]
+
+mod handlers;
+mod models;
+
+use ag_core::Shield;
+use ag_data::{DataConfig, DbPool};
+use axum::{routing::get, Router};
+use handlers::{create_todo, delete_todo, get_todo, health, list_todos, update_todo};
+
+#[derive(Clone)]
+pub(crate) struct AppState {
+    pub(crate) db: DbPool,
+}
+
+#[tokio::main]
+async fn main() -> Result<(), Box<dyn std::error::Error>> {
+    tracing_subscriber::fmt()
+        .with_env_filter(
+            tracing_subscriber::EnvFilter::try_from_default_env()
+                .unwrap_or_else(|_| "info,sqlx=warn".into()),
+        )
+        .init();
+
+    let db_url = std::env::var("DATABASE_URL")
+        .unwrap_or_else(|_| "postgresql://postgres:postgres@localhost/todos".into());
+
+    tracing::info!("conectando a la base de datos");
+    let config = DataConfig {
+        url: db_url,
+        ..DataConfig::default()
+    };
+    let pool = ag_data::connect(&config).await?;
+
+    static MIGRATOR: sqlx::migrate::Migrator = sqlx::migrate!("./migrations");
+    ag_data::run_migrations(&pool, &MIGRATOR).await?;
+
+    let state = AppState { db: pool };
+
+    let shield = Shield::with_defaults();
+    let router = Router::new()
+        .route("/health", get(health))
+        .route("/todos", get(list_todos).post(create_todo))
+        .route(
+            "/todos/{id}",
+            get(get_todo).put(update_todo).delete(delete_todo),
+        )
+        .with_state(state);
+
+    let app = shield.apply(router);
+
+    let bind = std::env::var("BIND").unwrap_or_else(|_| "0.0.0.0:8080".into());
+    let listener = tokio::net::TcpListener::bind(&bind).await?;
+    tracing::info!(addr = %bind, "servidor iniciado");
+
+    shield.serve(listener, app).await?;
+    Ok(())
+}

--- a/examples/todo-api/src/models.rs
+++ b/examples/todo-api/src/models.rs
@@ -1,0 +1,24 @@
+//! Modelos de datos de la todo-api.
+
+use serde::{Deserialize, Serialize};
+
+/// Tarea almacenada en la base de datos.
+#[derive(Debug, Clone, Serialize, sqlx::FromRow)]
+pub struct Todo {
+    pub id: i64,
+    pub title: String,
+    pub done: bool,
+}
+
+/// Payload para crear una tarea nueva.
+#[derive(Debug, Deserialize)]
+pub struct CreateTodo {
+    pub title: String,
+}
+
+/// Payload para actualizar una tarea existente.
+#[derive(Debug, Deserialize)]
+pub struct UpdateTodo {
+    pub title: Option<String>,
+    pub done: Option<bool>,
+}

--- a/templates/fullstack/Cargo.toml.tmpl
+++ b/templates/fullstack/Cargo.toml.tmpl
@@ -1,0 +1,17 @@
+[package]
+name = "{{name}}"
+version = "0.1.0"
+edition = "2021"
+
+[[bin]]
+name = "{{name}}"
+path = "src/main.rs"
+
+[dependencies]
+ag-core = { git = "https://github.com/anti-gravital/anti-gravital" }
+ag-data = { git = "https://github.com/anti-gravital/anti-gravital" }
+axum = { version = "0.7", default-features = false, features = ["http1", "http2", "tokio", "json", "matched-path"] }
+serde = { version = "1", features = ["derive"] }
+sqlx = { version = "0.8", default-features = false, features = ["runtime-tokio-rustls", "postgres", "migrate", "macros"] }
+tokio = { version = "1", features = ["rt-multi-thread", "macros", "net"] }
+tracing-subscriber = { version = "0.3", features = ["env-filter", "fmt"] }

--- a/templates/fullstack/config.toml.tmpl
+++ b/templates/fullstack/config.toml.tmpl
@@ -1,0 +1,10 @@
+# Configuracion de Shield para {{name}} (template fullstack).
+
+[bind]
+host = "0.0.0.0"
+port = 8080
+
+# Habilita rate limiting para proteger los endpoints publicos.
+# [rate_limit]
+# enabled = true
+# requests_per_second = 100

--- a/templates/fullstack/migrations/0001_init.sql.tmpl
+++ b/templates/fullstack/migrations/0001_init.sql.tmpl
@@ -1,0 +1,9 @@
+-- Migracion inicial para {{name}}.
+-- Agrega tus tablas aqui.
+
+-- Ejemplo: tabla de usuarios basica
+-- CREATE TABLE IF NOT EXISTS users (
+--     id BIGSERIAL PRIMARY KEY,
+--     email TEXT NOT NULL UNIQUE,
+--     created_at TIMESTAMPTZ NOT NULL DEFAULT NOW()
+-- );

--- a/templates/fullstack/src/main.rs.tmpl
+++ b/templates/fullstack/src/main.rs.tmpl
@@ -1,0 +1,60 @@
+use ag_core::{Shield, ShieldConfig};
+use ag_data::{DataConfig, DbPool};
+use axum::{
+    extract::State,
+    routing::get,
+    Json, Router,
+};
+use serde::Serialize;
+
+#[derive(Clone)]
+struct AppState {
+    db: DbPool,
+}
+
+#[tokio::main]
+async fn main() -> Result<(), Box<dyn std::error::Error>> {
+    tracing_subscriber::fmt()
+        .with_env_filter(
+            tracing_subscriber::EnvFilter::try_from_default_env()
+                .unwrap_or_else(|_| "info".into()),
+        )
+        .init();
+
+    let db_url = std::env::var("DATABASE_URL")
+        .unwrap_or_else(|_| "postgresql://localhost/{{name}}".into());
+
+    let config = DataConfig {
+        url: db_url,
+        ..DataConfig::default()
+    };
+    let pool = ag_data::connect(&config).await?;
+
+    static MIGRATOR: sqlx::migrate::Migrator = sqlx::migrate!("./migrations");
+    ag_data::run_migrations(&pool, &MIGRATOR).await?;
+
+    let state = AppState { db: pool };
+    let shield = Shield::with_defaults();
+    let router = Router::new()
+        .route("/health", get(health_handler))
+        .with_state(state);
+
+    let app = shield.apply(router);
+    let listener = tokio::net::TcpListener::bind("0.0.0.0:8080").await?;
+    tracing::info!("escuchando en http://0.0.0.0:8080");
+    shield.serve(listener, app).await?;
+    Ok(())
+}
+
+#[derive(Serialize)]
+struct Health {
+    status: &'static str,
+    service: &'static str,
+}
+
+async fn health_handler(State(_state): State<AppState>) -> Json<Health> {
+    Json(Health {
+        status: "ok",
+        service: "{{name}}",
+    })
+}

--- a/templates/realtime/Cargo.toml.tmpl
+++ b/templates/realtime/Cargo.toml.tmpl
@@ -1,0 +1,15 @@
+[package]
+name = "{{name}}"
+version = "0.1.0"
+edition = "2021"
+
+[[bin]]
+name = "{{name}}"
+path = "src/main.rs"
+
+[dependencies]
+ag-core = { git = "https://github.com/anti-gravital/anti-gravital" }
+axum = { version = "0.7", default-features = false, features = ["http1", "http2", "tokio", "json", "matched-path", "ws"] }
+serde = { version = "1", features = ["derive"] }
+tokio = { version = "1", features = ["rt-multi-thread", "macros", "net", "sync"] }
+tracing-subscriber = { version = "0.3", features = ["env-filter", "fmt"] }

--- a/templates/realtime/config.toml.tmpl
+++ b/templates/realtime/config.toml.tmpl
@@ -1,0 +1,5 @@
+# Configuracion de Shield para {{name}} (template realtime).
+
+[bind]
+host = "0.0.0.0"
+port = 8080

--- a/templates/realtime/src/main.rs.tmpl
+++ b/templates/realtime/src/main.rs.tmpl
@@ -1,0 +1,37 @@
+use ag_core::{Shield, ShieldConfig};
+use axum::{
+    extract::ws::{Message, WebSocket, WebSocketUpgrade},
+    routing::get,
+    Router,
+};
+
+#[tokio::main]
+async fn main() -> Result<(), ag_core::AgError> {
+    tracing_subscriber::fmt()
+        .with_env_filter(
+            tracing_subscriber::EnvFilter::try_from_default_env()
+                .unwrap_or_else(|_| "info".into()),
+        )
+        .init();
+
+    let shield = Shield::with_defaults();
+    let router = Router::new().route("/ws", get(ws_handler));
+    let app = shield.apply(router);
+
+    let listener = tokio::net::TcpListener::bind("0.0.0.0:8080").await?;
+    tracing::info!("WebSocket en ws://0.0.0.0:8080/ws");
+    shield.serve(listener, app).await
+}
+
+async fn ws_handler(upgrade: WebSocketUpgrade) -> impl axum::response::IntoResponse {
+    upgrade.on_upgrade(handle_socket)
+}
+
+async fn handle_socket(mut socket: WebSocket) {
+    while let Some(Ok(msg)) = socket.recv().await {
+        if let Message::Text(text) = msg {
+            tracing::info!(msg = %text, "mensaje recibido");
+            let _ = socket.send(Message::Text(format!("echo: {text}"))).await;
+        }
+    }
+}

--- a/templates/rest/Cargo.toml.tmpl
+++ b/templates/rest/Cargo.toml.tmpl
@@ -1,0 +1,16 @@
+[package]
+name = "{{name}}"
+version = "0.1.0"
+edition = "2021"
+
+[[bin]]
+name = "{{name}}"
+path = "src/main.rs"
+
+[dependencies]
+ag-core = { git = "https://github.com/anti-gravital/anti-gravital" }
+axum = { version = "0.7", default-features = false, features = ["http1", "http2", "tokio", "json", "matched-path"] }
+serde = { version = "1", features = ["derive"] }
+serde_json = "1"
+tokio = { version = "1", features = ["rt-multi-thread", "macros", "net"] }
+tracing-subscriber = { version = "0.3", features = ["env-filter", "fmt"] }

--- a/templates/rest/config.toml.tmpl
+++ b/templates/rest/config.toml.tmpl
@@ -1,0 +1,6 @@
+# Configuracion de Shield para {{name}}.
+# Edita segun las necesidades del proyecto.
+
+[bind]
+host = "0.0.0.0"
+port = 8080

--- a/templates/rest/src/main.rs.tmpl
+++ b/templates/rest/src/main.rs.tmpl
@@ -1,0 +1,24 @@
+use ag_core::{Shield, ShieldConfig};
+use axum::{routing::get, Router};
+
+#[tokio::main]
+async fn main() -> Result<(), ag_core::AgError> {
+    tracing_subscriber::fmt()
+        .with_env_filter(
+            tracing_subscriber::EnvFilter::try_from_default_env()
+                .unwrap_or_else(|_| "info".into()),
+        )
+        .init();
+
+    let shield = Shield::with_defaults();
+    let router = Router::new().route("/", get(root_handler));
+    let app = shield.apply(router);
+
+    let listener = tokio::net::TcpListener::bind("0.0.0.0:8080").await?;
+    tracing::info!("escuchando en http://0.0.0.0:8080");
+    shield.serve(listener, app).await
+}
+
+async fn root_handler() -> &'static str {
+    "{{name}} corriendo con Anti-Gravital"
+}


### PR DESCRIPTION
# Fase 2: The Core MVP y roundtrip completo

## Resumen

Implementacion de los entregables de Fase 2 segun la Hoja de Ruta §2.2:
modulo core en ag-core con extractores tipados y sistema de respuestas;
ag-data con pool PostgreSQL y migraciones embebidas; ag-cli operativo con
tres templates; ejemplo todo-api con CRUD completo y Dockerfile FROM scratch.

## Fase afectada

Fase 2 — The Core MVP y roundtrip completo.

## Tipo de cambio

- Implementacion de funcionalidad nueva (core, data, cli, ejemplo).
- Expansion de sistema de errores existente (AgError).
- Adicion de dependencias de workspace (sqlx, clap).

## Documentos relacionados

- `docs/roadmap/fase-02-core-mvp.md` — definicion de los entregables.
- `docs/master/ANTI-GRAVITAL-Hoja-de-Ruta.md` — criterios de salida de Fase 2.
- `docs/master/ANTI-GRAVITAL-Arquitectura-Tecnica.md` capitulo 6 — diseno Shield/Core.
- `docs/manual/02-primera-api.md` — guia de usuario creada en esta PR.
- `docs/roadmap/STATUS.md` — actualizado con progreso de Fase 2.

## Cambios principales

### ag-core

- `src/core/mod.rs`: modulo Core completo con reexports de extractores
  (`State`, `Path`, `Query`), alias `ValidatedBody`, reexport `Claims`
  y modulo `response` con `PlainText` y `BodyStream`.
- `src/error.rs`: expandido con `NotFound` (404), `BadRequest` (400),
  `Conflict` (409) y `Database` (500).
- `src/lib.rs`: reexporta `AppState` en el nivel superior.

### ag-data (nuevo contenido funcional)

- `Cargo.toml`: dependencias sqlx (0.8, postgres, migrate, macros,
  runtime-tokio-rustls), ag-core, serde, thiserror, tokio, tracing.
- `src/lib.rs`: `DbPool`, `DataConfig`, `DataError`, `connect()`,
  `run_migrations()`, conversion `DataError -> AgError`, `sanitize_url`.
- `migrations/`: directorio placeholder para tests del crate.

### ag-cli (nuevo contenido funcional)

- `Cargo.toml`: dependencias clap (4, derive), serde, thiserror, toml.
  Declara el binario `ag`.
- `src/main.rs`: comandos `new`, `dev`, `build` con subcomandos clap;
  tres templates embebidos via `include_str!`; scaffold de proyectos con
  sustitucion de `{{name}}`; deteccion de cargo-watch para hot reload.

### templates/

- `templates/rest/`: Cargo.toml.tmpl, src/main.rs.tmpl, config.toml.tmpl.
- `templates/realtime/`: igual con handler WebSocket de ejemplo.
- `templates/fullstack/`: igual con ag-data, sqlx y migrations/.

### examples/todo-api/ (nuevo)

- `Cargo.toml`: workspace member; dependencias ag-core, ag-data, axum,
  sqlx, tokio, tracing, tracing-subscriber. Declara bench `crud`.
- `src/main.rs`: arranque con Shield + router + pool PostgreSQL.
- `src/models.rs`: structs `Todo`, `CreateTodo`, `UpdateTodo`.
- `src/handlers.rs`: cinco handlers CRUD tipados con AgError.
- `migrations/0001_create_todos.sql`: tabla `todos`.
- `benches/crud.rs`: placeholder de benchmark CRUD+DB con instrucciones
  para medicion en hardware de referencia.
- `Dockerfile`: compilacion MUSL + FROM scratch; imagen <= 20 MB.

### Workspace

- `Cargo.toml`: agrega `examples/todo-api` a los miembros; agrega
  `sqlx` (0.8) y `clap` (4) a `workspace.dependencies`; habilita la
  feature `query` de axum; agrega path-references `ag-core` y `ag-data`.

## Plan de prueba

- [x] `cargo build --workspace` limpio (sin errores, sin warnings).
- [x] `cargo test --workspace` verde (tests de DB ignorados por defecto).
- [x] `cargo clippy --workspace --all-targets -- -D warnings` limpio.
- [x] `cargo fmt --check` limpio.
- [ ] `cargo test --workspace -- --ignored` verde contra PostgreSQL real.
- [ ] `cargo run -p todo-api` arranca y sirve los cinco endpoints.
- [ ] `docker build` produce imagen funcional < 20 MB (requiere MUSL).

## Criterios de salida que avanza

Hoja de Ruta Fase 2, seccion 2.2 (entregables):

- [x] Crate `ag-core` con modulo `core` operativo.
- [x] Router Axum integrado con la Shield.
- [x] Extractores tipados.
- [x] Sistema de errores AgError extendido.
- [x] Sistema de respuestas JSON / plaintext / streams.
- [x] Crate `ag-data` con pool PostgreSQL.
- [x] Sistema de migraciones embebido.
- [x] Example app `todo-api` con CRUD completo.
- [/] Benchmark CRUD + DB (placeholder; medicion real pendiente).
- [x] Crate `ag-cli` con comandos `new`, `dev`, `build`.
- [x] Tres templates: `rest`, `realtime`, `fullstack`.

## Checklist final CLAUDE.md

- [x] Pertenece a la fase correcta (Fase 2).
- [x] Respeta la documentacion y el alcance.
- [x] No rompe arquitectura ni modularidad.
- [x] No anade complejidad innecesaria ni features fuera de scope.
- [x] No crea dependencias circulares.
- [x] Compila (`cargo build --workspace`).
- [x] Pasa tests (`cargo test --workspace`).
- [x] Pasa fmt (`cargo fmt --check`).
- [x] Pasa clippy (`cargo clippy --workspace --all-targets -- -D warnings`).
- [x] Tiene documentacion (`docs/manual/02-primera-api.md`).
- [/] Tiene benchmarks (placeholder en `examples/todo-api/benches/crud.rs`).
- [x] Tiene manejo de errores correcto (`AgError` con conversion HTTP).
- [x] Mantiene coherencia con Anti-Gravital v4.0.
