### PR TITLE
feat(fase-3): compilador Anti-DSL v0.1 — lexer, parser, semantic, cod…

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -18,6 +18,7 @@ version = "0.0.0"
 name = "ag-cli"
 version = "0.0.0"
 dependencies = [
+ "ag-dsl",
  "clap",
  "serde",
  "thiserror 1.0.69",
@@ -76,6 +77,12 @@ dependencies = [
 [[package]]
 name = "ag-dsl"
 version = "0.0.0"
+dependencies = [
+ "chumsky",
+ "logos",
+ "serde_json",
+ "thiserror 1.0.69",
+]
 
 [[package]]
 name = "ag-migrate"
@@ -104,6 +111,18 @@ version = "0.0.0"
 [[package]]
 name = "ag-wasm-host"
 version = "0.0.0"
+
+[[package]]
+name = "ahash"
+version = "0.8.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5a15f179cd60c4584b8a8c596927aadc462e27f2ca70c04e0071964a73ba7a75"
+dependencies = [
+ "cfg-if",
+ "once_cell",
+ "version_check",
+ "zerocopy",
+]
 
 [[package]]
 name = "aho-corasick"
@@ -181,6 +200,15 @@ name = "anyhow"
 version = "1.0.102"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7f202df86484c868dbad7eaa557ef785d5c66295e41b460ef922eca0723b842c"
+
+[[package]]
+name = "ar_archive_writer"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7eb93bbb63b9c227414f6eb3a0adfddca591a8ce1e9b60661bb08969b87e340b"
+dependencies = [
+ "object",
+]
 
 [[package]]
 name = "async-trait"
@@ -286,6 +314,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2af50177e190e07a26ab74f8b1efbfe2ef87da2116221318cb1c2e82baf7de06"
 
 [[package]]
+name = "beef"
+version = "0.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3a8241f3ebb85c056b509d4327ad0358fbbba6ffb340bf388f26350aeda225b1"
+
+[[package]]
 name = "bitflags"
 version = "2.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -348,6 +382,16 @@ name = "cfg_aliases"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "613afe47fcd5fac7ccf1db93babcb082c5994d996f20b8b159f2ad1658eb5724"
+
+[[package]]
+name = "chumsky"
+version = "0.9.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8eebd66744a15ded14960ab4ccdbfb51ad3b81f51f3f04a80adac98c985396c9"
+dependencies = [
+ "hashbrown 0.14.5",
+ "stacker",
+]
 
 [[package]]
 name = "ciborium"
@@ -983,6 +1027,10 @@ name = "hashbrown"
 version = "0.14.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e5274423e17b7c9fc20b6e7e208532f9b19825d82dfd615708b70edd83df41f1"
+dependencies = [
+ "ahash",
+ "allocator-api2",
+]
 
 [[package]]
 name = "hashbrown"
@@ -1427,6 +1475,39 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5e5032e24019045c762d3c0f28f5b6b8bbf38563a65908389bf7978758920897"
 
 [[package]]
+name = "logos"
+version = "0.14.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7251356ef8cb7aec833ddf598c6cb24d17b689d20b993f9d11a3d764e34e6458"
+dependencies = [
+ "logos-derive",
+]
+
+[[package]]
+name = "logos-codegen"
+version = "0.14.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "59f80069600c0d66734f5ff52cc42f2dabd6b29d205f333d61fd7832e9e9963f"
+dependencies = [
+ "beef",
+ "fnv",
+ "lazy_static",
+ "proc-macro2",
+ "quote",
+ "regex-syntax",
+ "syn",
+]
+
+[[package]]
+name = "logos-derive"
+version = "0.14.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "24fb722b06a9dc12adb0963ed585f19fc61dc5413e6a9be9422ef92c091e731d"
+dependencies = [
+ "logos-codegen",
+]
+
+[[package]]
 name = "lru-slab"
 version = "0.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1561,6 +1642,15 @@ checksum = "071dfc062690e90b734c0b2273ce72ad0ffa95f0c74596bc250dcfd960262841"
 dependencies = [
  "autocfg",
  "libm",
+]
+
+[[package]]
+name = "object"
+version = "0.37.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ff76201f031d8863c38aa7f905eca4f53abbfa15f609db4277d44cd8938f33fe"
+dependencies = [
+ "memchr",
 ]
 
 [[package]]
@@ -1754,6 +1844,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8fd00f0bb2e90d81d1044c2b32617f68fcb9fa3bb7640c23e9c748e53fb30934"
 dependencies = [
  "unicode-ident",
+]
+
+[[package]]
+name = "psm"
+version = "0.1.31"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "645dbe486e346d9b5de3ef16ede18c26e6c70ad97418f4874b8b1889d6e761ea"
+dependencies = [
+ "ar_archive_writer",
+ "cc",
 ]
 
 [[package]]
@@ -2542,6 +2642,19 @@ name = "stable_deref_trait"
 version = "1.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6ce2be8dc25455e1f91df71bfa12ad37d7af1092ae736f3a6cd0e37bc7810596"
+
+[[package]]
+name = "stacker"
+version = "0.1.24"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "640c8cdd92b6b12f5bcb1803ca3bbf5ab96e5e6b6b96b9ab77dabe9e880b3190"
+dependencies = [
+ "cc",
+ "cfg-if",
+ "libc",
+ "psm",
+ "windows-sys 0.61.2",
+]
 
 [[package]]
 name = "stringprep"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -36,15 +36,19 @@ publish = false
 # Dependencias compartidas del workspace.
 # Cada nueva dependencia exige RFC; el set inicial corresponde a RFC-0002
 # (diseno del Shield MVP). Las adiciones de Fase 2 (sqlx, clap) estan
-# justificadas en la Hoja de Ruta §2.2. Los crates internos las
-# referencian con `dep = { workspace = true }`.
+# justificadas en la Hoja de Ruta §2.2. Las adiciones de Fase 3 (logos,
+# chumsky) estan justificadas en RFC-0003 (compilador ag-dsl).
+# Los crates internos las referencian con `dep = { workspace = true }`.
 [workspace.dependencies]
 ag-core = { path = "crates/ag-core", version = "0.0.0" }
 ag-data = { path = "crates/ag-data", version = "0.0.0" }
+ag-dsl = { path = "crates/ag-dsl", version = "0.0.0" }
 axum = { version = "0.7", default-features = false, features = ["http1", "http2", "tokio", "json", "matched-path", "query"] }
 bytes = "1"
 clap = { version = "4", features = ["derive"] }
 sqlx = { version = "0.8", default-features = false, features = ["runtime-tokio-rustls", "postgres", "migrate", "macros"] }
+chumsky = "0.9"
+logos = "0.14"
 governor = "0.7"
 http = "1"
 jsonwebtoken = { version = "10", default-features = false, features = ["use_pem", "rust_crypto"] }

--- a/crates/ag-cli/Cargo.toml
+++ b/crates/ag-cli/Cargo.toml
@@ -22,6 +22,7 @@ path = "src/main.rs"
 workspace = true
 
 [dependencies]
+ag-dsl = { workspace = true }
 clap = { workspace = true }
 serde = { workspace = true }
 thiserror = { workspace = true }

--- a/crates/ag-cli/src/main.rs
+++ b/crates/ag-cli/src/main.rs
@@ -1,14 +1,18 @@
 //! Binario unificado `ag` del ecosistema Anti-Gravital.
 //!
-//! Implementa los comandos de Fase 2:
-//!
+//! Comandos de Fase 2:
 //! - `ag new <nombre> [--template rest|realtime|fullstack]`
 //! - `ag dev [--bind host:port]`
 //! - `ag build [--target triple]`
+//!
+//! Comandos de Fase 3 (DSL):
+//! - `ag generate [--schema schema.ag] [--output ./generated]`
+//! - `ag schema lint [--schema schema.ag]`
+//! - `ag schema diff <ref> [--schema schema.ag]`
 
 use clap::{Parser, Subcommand};
 use std::fs;
-use std::path::Path;
+use std::path::{Path, PathBuf};
 use std::process;
 
 const VERSION: &str = env!("CARGO_PKG_VERSION");
@@ -74,6 +78,46 @@ enum Commands {
         #[arg(long)]
         target: Option<String>,
     },
+
+    /// Genera artefactos (Rust, SQL, TypeScript, OpenAPI) desde schema.ag.
+    ///
+    /// Lee el archivo DSL indicado (por defecto `schema.ag` en el directorio
+    /// actual), compila el schema y escribe los artefactos generados en el
+    /// directorio de salida.
+    Generate {
+        /// Archivo schema DSL de entrada.
+        #[arg(long, default_value = "schema.ag")]
+        schema: PathBuf,
+
+        /// Directorio donde se escriben los artefactos generados.
+        #[arg(long, default_value = "generated")]
+        output: PathBuf,
+    },
+
+    /// Operaciones sobre el schema DSL.
+    Schema {
+        #[command(subcommand)]
+        command: SchemaCommands,
+    },
+}
+
+/// Sub-comandos de `ag schema`.
+#[derive(Subcommand)]
+enum SchemaCommands {
+    /// Verifica el schema y reporta warnings de mejores practicas.
+    Lint {
+        /// Archivo schema DSL.
+        #[arg(long, default_value = "schema.ag")]
+        schema: PathBuf,
+    },
+    /// Muestra cambios breaking vs no-breaking respecto a un archivo de referencia.
+    Diff {
+        /// Archivo de referencia (otro schema.ag, snapshot, etc.).
+        reference: PathBuf,
+        /// Archivo schema actual.
+        #[arg(long, default_value = "schema.ag")]
+        schema: PathBuf,
+    },
 }
 
 fn main() {
@@ -82,6 +126,11 @@ fn main() {
         Commands::New { name, template } => cmd_new(&name, &template),
         Commands::Dev { bind } => cmd_dev(&bind),
         Commands::Build { target } => cmd_build(target.as_deref()),
+        Commands::Generate { schema, output } => cmd_generate(&schema, &output),
+        Commands::Schema { command } => match command {
+            SchemaCommands::Lint { schema } => cmd_schema_lint(&schema),
+            SchemaCommands::Diff { reference, schema } => cmd_schema_diff(&schema, &reference),
+        },
     };
     if let Err(msg) = result {
         eprintln!("error: {msg}");
@@ -247,6 +296,216 @@ fn scaffold_fullstack(name: &str, dir: &Path) -> Result<(), String> {
         &apply_template(FULLSTACK_MIGRATION, name),
     )?;
     Ok(())
+}
+
+// ---- Comandos DSL (Fase 3) ------------------------------------------
+
+fn cmd_generate(schema_path: &Path, output_dir: &Path) -> Result<(), String> {
+    let source = read_schema(schema_path)?;
+
+    let schema = ag_dsl::compile(&source).map_err(|diags| {
+        let mut msg = format!(
+            "{} error(es) en '{}':\n",
+            diags.iter().filter(|d| d.is_error()).count(),
+            schema_path.display()
+        );
+        for d in &diags {
+            msg.push_str(&format!("  {}\n", d.display(&source)));
+        }
+        msg
+    })?;
+
+    let files = ag_dsl::generate(&schema);
+
+    println!(
+        "Generando {} artefactos desde '{}'...",
+        files.len(),
+        schema_path.display()
+    );
+
+    for (rel_path, content) in &files.files {
+        let full_path = output_dir.join(rel_path);
+        write_file(&full_path, content)?;
+        println!("  {}", full_path.display());
+    }
+
+    println!("Generacion completada en '{}'.", output_dir.display());
+    Ok(())
+}
+
+fn cmd_schema_lint(schema_path: &Path) -> Result<(), String> {
+    let source = read_schema(schema_path)?;
+
+    match ag_dsl::compile(&source) {
+        Ok(_schema) => {
+            println!("'{}': sin problemas encontrados.", schema_path.display());
+        }
+        Err(diags) => {
+            let errors: Vec<_> = diags.iter().filter(|d| d.is_error()).collect();
+            let warnings: Vec<_> = diags.iter().filter(|d| !d.is_error()).collect();
+
+            for w in &warnings {
+                println!("warning: {}", w.display(&source));
+            }
+            for e in &errors {
+                eprintln!("error: {}", e.display(&source));
+            }
+
+            if !errors.is_empty() {
+                return Err(format!(
+                    "{} error(es) en '{}'",
+                    errors.len(),
+                    schema_path.display()
+                ));
+            }
+        }
+    }
+    Ok(())
+}
+
+fn cmd_schema_diff(schema_path: &Path, reference_path: &Path) -> Result<(), String> {
+    let current_source = read_schema(schema_path)?;
+    let ref_source = read_schema(reference_path)?;
+
+    let current = ag_dsl::compile(&current_source).map_err(|diags| {
+        format!(
+            "errores en schema actual: {}",
+            diags
+                .iter()
+                .filter(|d| d.is_error())
+                .map(|d| d.message.clone())
+                .collect::<Vec<_>>()
+                .join(", ")
+        )
+    })?;
+
+    let reference = ag_dsl::compile(&ref_source).map_err(|diags| {
+        format!(
+            "errores en schema de referencia: {}",
+            diags
+                .iter()
+                .filter(|d| d.is_error())
+                .map(|d| d.message.clone())
+                .collect::<Vec<_>>()
+                .join(", ")
+        )
+    })?;
+
+    let changes = diff_schemas(&reference, &current);
+
+    if changes.is_empty() {
+        println!(
+            "Sin cambios entre '{}' y '{}'.",
+            reference_path.display(),
+            schema_path.display()
+        );
+        return Ok(());
+    }
+
+    println!(
+        "Cambios entre '{}' y '{}':",
+        reference_path.display(),
+        schema_path.display()
+    );
+    for change in &changes {
+        println!("  {change}");
+    }
+    Ok(())
+}
+
+/// Compara dos schemas y retorna una lista de cambios legibles.
+///
+/// Detecta: modelos añadidos/eliminados, campos añadidos/eliminados/cambiados.
+/// Los cambios breaking (eliminar modelo, eliminar campo, cambiar tipo) se marcan
+/// con `[BREAKING]`. Los cambios no-breaking se marcan con `[additive]`.
+fn diff_schemas(old: &ag_dsl::ast::Schema, new: &ag_dsl::ast::Schema) -> Vec<String> {
+    use std::collections::HashMap;
+
+    let old_models: HashMap<&str, _> = old
+        .models
+        .iter()
+        .map(|m| (m.name.value.as_str(), m))
+        .collect();
+    let new_models: HashMap<&str, _> = new
+        .models
+        .iter()
+        .map(|m| (m.name.value.as_str(), m))
+        .collect();
+
+    let mut changes = Vec::new();
+
+    // Modelos eliminados (breaking)
+    for name in old_models.keys() {
+        if !new_models.contains_key(name) {
+            changes.push(format!("[BREAKING]  modelo '{name}' eliminado"));
+        }
+    }
+
+    // Modelos añadidos (no breaking)
+    for name in new_models.keys() {
+        if !old_models.contains_key(name) {
+            changes.push(format!("[additive]  modelo '{name}' añadido"));
+        }
+    }
+
+    // Campos en modelos comunes
+    for (name, old_model) in &old_models {
+        if let Some(new_model) = new_models.get(name) {
+            let old_fields: HashMap<&str, _> = old_model
+                .fields
+                .iter()
+                .map(|f| (f.name.value.as_str(), f))
+                .collect();
+            let new_fields: HashMap<&str, _> = new_model
+                .fields
+                .iter()
+                .map(|f| (f.name.value.as_str(), f))
+                .collect();
+
+            for fname in old_fields.keys() {
+                if !new_fields.contains_key(fname) {
+                    changes.push(format!("[BREAKING]  '{name}.{fname}' eliminado"));
+                }
+            }
+            for fname in new_fields.keys() {
+                if !old_fields.contains_key(fname) {
+                    changes.push(format!("[additive]  '{name}.{fname}' añadido"));
+                }
+            }
+            for (fname, old_field) in &old_fields {
+                if let Some(new_field) = new_fields.get(fname) {
+                    if old_field.ty.value != new_field.ty.value {
+                        changes.push(format!(
+                            "[BREAKING]  '{name}.{fname}' tipo cambiado: {:?} -> {:?}",
+                            old_field.ty.value, new_field.ty.value
+                        ));
+                    }
+                    if old_field.optional && !new_field.optional {
+                        changes.push(format!(
+                            "[BREAKING]  '{name}.{fname}' cambio de nullable a NOT NULL"
+                        ));
+                    }
+                    if !old_field.optional && new_field.optional {
+                        changes.push(format!(
+                            "[additive]  '{name}.{fname}' cambio de NOT NULL a nullable"
+                        ));
+                    }
+                }
+            }
+        }
+    }
+
+    changes
+}
+
+fn read_schema(path: &Path) -> Result<String, String> {
+    if !path.exists() {
+        return Err(format!(
+            "archivo schema no encontrado: '{}'",
+            path.display()
+        ));
+    }
+    fs::read_to_string(path).map_err(|e| format!("no se pudo leer '{}': {e}", path.display()))
 }
 
 #[cfg(test)]

--- a/crates/ag-dsl/Cargo.toml
+++ b/crates/ag-dsl/Cargo.toml
@@ -9,10 +9,17 @@ repository.workspace = true
 homepage.workspace = true
 documentation.workspace = true
 readme = "README.md"
-description = "Lexer, parser, analisis semantico y codegen del Anti-DSL"
+description = "Compilador del Anti-DSL: lexer, parser, AST, analisis semantico y generadores de codigo"
 keywords.workspace = true
 categories.workspace = true
 publish = false
 
 [lints]
 workspace = true
+
+[dependencies]
+# Fase 3 — RFC-0003: logos (lexer), chumsky (parser), serde_json (OpenAPI)
+logos = { workspace = true }
+chumsky = { workspace = true }
+thiserror = { workspace = true }
+serde_json = { workspace = true }

--- a/crates/ag-dsl/src/ast.rs
+++ b/crates/ag-dsl/src/ast.rs
@@ -1,0 +1,189 @@
+//! Tipos del AST del Anti-DSL.
+//!
+//! Todas las construcciones del lenguaje se representan como nodos del AST.
+//! Los nodos clave llevan informacion de span para reportar errores precisos.
+//! En DSL v0.1 el AST cubre modelos, campos, tipos primitivos y anotaciones
+//! basicas (@primary, @unique, @auto, @auto_update, @default).
+
+use crate::lexer::Span;
+
+/// Rango de bytes en el texto fuente adjunto a un valor.
+#[derive(Debug, Clone, PartialEq)]
+pub struct Spanned<T> {
+    /// Valor del nodo.
+    pub value: T,
+    /// Posicion en el texto fuente (bytes).
+    pub span: Span,
+}
+
+impl<T> Spanned<T> {
+    /// Construye un nodo con su span.
+    pub fn new(value: T, span: Span) -> Self {
+        Self { value, span }
+    }
+}
+
+/// Schema completo: punto de entrada del AST.
+///
+/// En v0.1 contiene configuracion opcional y cero o mas modelos.
+/// Las versiones futuras añadiran endpoints, enums y eventos.
+#[derive(Debug, Clone, Default)]
+pub struct Schema {
+    /// Bloque `config { ... }` opcional.
+    pub config: Option<Config>,
+    /// Definiciones de modelo en orden de aparicion.
+    pub models: Vec<ModelDef>,
+}
+
+/// Bloque `config { ... }`.
+///
+/// Campos reconocidos en v0.1: `project_name` y `database`.
+/// Campos desconocidos se reportan como warnings en el paso semantico.
+#[derive(Debug, Clone, Default)]
+pub struct Config {
+    /// Nombre del proyecto.
+    pub project_name: Option<String>,
+    /// Backend de base de datos: `"postgres"`, `"sqlite"`, etc.
+    pub database: Option<String>,
+}
+
+/// Definicion de modelo: `model Nombre { campos... }`.
+#[derive(Debug, Clone)]
+pub struct ModelDef {
+    /// Nombre del modelo con span para reportar errores.
+    pub name: Spanned<String>,
+    /// Campos del modelo en orden de aparicion.
+    pub fields: Vec<FieldDef>,
+    /// Span del bloque completo (del `model` al `}`).
+    pub span: Span,
+}
+
+/// Definicion de campo dentro de un modelo.
+#[derive(Debug, Clone)]
+pub struct FieldDef {
+    /// Nombre del campo.
+    pub name: Spanned<String>,
+    /// Tipo del campo.
+    pub ty: Spanned<FieldType>,
+    /// Si el campo es opcional (`?` al final del tipo).
+    pub optional: bool,
+    /// Lista de anotaciones en orden de aparicion.
+    pub annotations: Vec<Spanned<Annotation>>,
+}
+
+/// Tipos primitivos soportados en DSL v0.1.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum FieldType {
+    /// `UUID` — identificador unico universal.
+    Uuid,
+    /// `String` — texto sin limite definido (el limite se pone con @max).
+    String,
+    /// `Int` — entero de 64 bits con signo.
+    Int,
+    /// `Float` — punto flotante de 64 bits.
+    Float,
+    /// `Bool` — booleano.
+    Bool,
+    /// `Timestamp` — fecha y hora con zona (UTC por defecto).
+    Timestamp,
+    /// `Decimal` — numero decimal de precision arbitraria (para dinero).
+    Decimal,
+}
+
+impl FieldType {
+    /// Nombre Rust del tipo generado.
+    pub fn rust_type(&self, optional: bool) -> std::string::String {
+        let base = match self {
+            FieldType::Uuid => "uuid::Uuid",
+            FieldType::String => "String",
+            FieldType::Int => "i64",
+            FieldType::Float => "f64",
+            FieldType::Bool => "bool",
+            FieldType::Timestamp => "chrono::DateTime<chrono::Utc>",
+            FieldType::Decimal => "rust_decimal::Decimal",
+        };
+        if optional {
+            format!("Option<{base}>")
+        } else {
+            base.to_owned()
+        }
+    }
+
+    /// Tipo SQL correspondiente.
+    pub fn sql_type(&self) -> &'static str {
+        match self {
+            FieldType::Uuid => "UUID",
+            FieldType::String => "TEXT",
+            FieldType::Int => "BIGINT",
+            FieldType::Float => "DOUBLE PRECISION",
+            FieldType::Bool => "BOOLEAN",
+            FieldType::Timestamp => "TIMESTAMPTZ",
+            FieldType::Decimal => "NUMERIC",
+        }
+    }
+
+    /// Tipo TypeScript correspondiente.
+    pub fn ts_type(&self) -> &'static str {
+        match self {
+            FieldType::Uuid => "string",
+            FieldType::String => "string",
+            FieldType::Int => "number",
+            FieldType::Float => "number",
+            FieldType::Bool => "boolean",
+            FieldType::Timestamp => "string",
+            FieldType::Decimal => "string",
+        }
+    }
+
+    /// Formato OpenAPI del tipo (pares type/format).
+    pub fn openapi_type(&self) -> (&'static str, Option<&'static str>) {
+        match self {
+            FieldType::Uuid => ("string", Some("uuid")),
+            FieldType::String => ("string", None),
+            FieldType::Int => ("integer", Some("int64")),
+            FieldType::Float => ("number", Some("double")),
+            FieldType::Bool => ("boolean", None),
+            FieldType::Timestamp => ("string", Some("date-time")),
+            FieldType::Decimal => ("string", Some("decimal")),
+        }
+    }
+}
+
+/// Anotaciones DSL v0.1.
+#[derive(Debug, Clone, PartialEq)]
+pub enum Annotation {
+    /// `@primary` — clave primaria.
+    Primary,
+    /// `@unique` — restriccion UNIQUE.
+    Unique,
+    /// `@auto` — valor autogenerado (UUID, SERIAL, NOW()).
+    Auto,
+    /// `@auto_update` — actualizado en cada UPDATE.
+    AutoUpdate,
+    /// `@default(valor)` — valor por defecto.
+    Default(DefaultValue),
+}
+
+/// Valor para la anotacion `@default(...)`.
+#[derive(Debug, Clone, PartialEq)]
+pub enum DefaultValue {
+    /// Literal entero: `@default(0)`.
+    Int(i64),
+    /// Literal string: `@default("activo")`.
+    String(std::string::String),
+    /// Literal booleano: `@default(true)`.
+    Bool(bool),
+    /// Identificador (variante de enum u otra referencia): `@default(USER)`.
+    Ident(std::string::String),
+}
+
+impl std::fmt::Display for DefaultValue {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            DefaultValue::Int(n) => write!(f, "{n}"),
+            DefaultValue::String(s) => write!(f, "'{s}'"),
+            DefaultValue::Bool(b) => write!(f, "{b}"),
+            DefaultValue::Ident(s) => write!(f, "'{s}'"),
+        }
+    }
+}

--- a/crates/ag-dsl/src/codegen/mod.rs
+++ b/crates/ag-dsl/src/codegen/mod.rs
@@ -1,0 +1,107 @@
+//! Generadores de codigo del Anti-DSL v0.1.
+//!
+//! Cada sub-modulo es un generador independiente para un target distinto.
+//! La funcion `generate()` invoca todos los generadores y retorna la
+//! coleccion de archivos a escribir en disco.
+
+pub mod openapi_gen;
+pub mod rust_gen;
+pub mod sql_gen;
+pub mod ts_gen;
+
+use std::collections::BTreeMap;
+use std::path::PathBuf;
+
+use crate::ast::Schema;
+
+/// Coleccion de archivos generados, indexada por ruta relativa al proyecto.
+///
+/// Las claves son rutas relativas (p. ej. `src/models.rs`).
+/// Los valores son el contenido del archivo como `String`.
+#[derive(Debug, Default)]
+pub struct GeneratedFiles {
+    /// Archivos generados: ruta -> contenido.
+    pub files: BTreeMap<PathBuf, String>,
+}
+
+impl GeneratedFiles {
+    fn insert(&mut self, path: impl Into<PathBuf>, content: String) {
+        self.files.insert(path.into(), content);
+    }
+
+    /// Numero de archivos generados.
+    pub fn len(&self) -> usize {
+        self.files.len()
+    }
+
+    /// Retorna true si no se genero ningun archivo.
+    pub fn is_empty(&self) -> bool {
+        self.files.is_empty()
+    }
+}
+
+/// Genera todos los artefactos para el schema dado.
+///
+/// Retorna la coleccion de archivos con sus rutas relativas y contenido.
+/// El llamador (ag-cli) es responsable de escribirlos en disco.
+pub fn generate(schema: &Schema) -> GeneratedFiles {
+    let mut files = GeneratedFiles::default();
+
+    files.insert(
+        PathBuf::from("src/models.rs"),
+        rust_gen::generate_models(schema),
+    );
+
+    files.insert(
+        PathBuf::from("migrations/0001_initial.sql"),
+        sql_gen::generate_migration(schema),
+    );
+
+    files.insert(
+        PathBuf::from("clients/typescript/types.ts"),
+        ts_gen::generate_types(schema),
+    );
+
+    files.insert(
+        PathBuf::from("openapi.json"),
+        openapi_gen::generate_openapi(schema),
+    );
+
+    files
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::lexer::tokenize;
+    use crate::parser::parse_tokens;
+
+    fn schema_from(src: &str) -> Schema {
+        let (tokens, _) = tokenize(src);
+        let (ast, _) = parse_tokens(tokens, src.len());
+        ast.expect("valid schema")
+    }
+
+    #[test]
+    fn generates_four_files() {
+        let schema = schema_from(
+            r#"
+model User {
+    id    UUID   @primary @auto
+    email String @unique
+    name  String
+}
+"#,
+        );
+        let files = generate(&schema);
+        assert_eq!(files.len(), 4);
+        assert!(files.files.contains_key(&PathBuf::from("src/models.rs")));
+        assert!(files
+            .files
+            .contains_key(&PathBuf::from("migrations/0001_initial.sql")));
+        assert!(files
+            .files
+            .contains_key(&PathBuf::from("clients/typescript/types.ts")));
+        assert!(files.files.contains_key(&PathBuf::from("openapi.json")));
+    }
+}

--- a/crates/ag-dsl/src/codegen/openapi_gen.rs
+++ b/crates/ag-dsl/src/codegen/openapi_gen.rs
@@ -1,0 +1,194 @@
+//! Generador OpenAPI 3.1 para DSL v0.1.
+//!
+//! Produce el bloque `components/schemas` del documento OpenAPI en formato
+//! JSON. La salida puede convertirse a YAML con herramientas externas.
+//! En DSL v0.2 se añadiran los bloques `paths` y `operations`.
+
+use serde_json::{json, Value};
+
+use crate::ast::{Annotation, FieldDef, ModelDef, Schema};
+
+/// Genera el documento OpenAPI 3.1 con solo `components/schemas`.
+///
+/// Retorna JSON formateado con indentacion de dos espacios.
+pub fn generate_openapi(schema: &Schema) -> String {
+    let mut schemas = serde_json::Map::new();
+
+    for model in &schema.models {
+        let name = &model.name.value;
+        schemas.insert(name.clone(), model_schema(model, false));
+        schemas.insert(format!("Create{name}Request"), model_schema(model, true));
+    }
+
+    let project_name = schema
+        .config
+        .as_ref()
+        .and_then(|c| c.project_name.as_deref())
+        .unwrap_or("anti-gravital-api");
+
+    let doc = json!({
+        "openapi": "3.1.0",
+        "info": {
+            "title": project_name,
+            "version": "0.1.0",
+            "description": "API generada por Anti-Gravital ag-dsl v0.1"
+        },
+        "components": {
+            "schemas": schemas
+        }
+    });
+
+    serde_json::to_string_pretty(&doc).expect("serde_json serialization is infallible")
+}
+
+/// Genera el schema JSON Schema de un modelo.
+///
+/// Si `create_only` es true, omite los campos @auto para el CreateRequest.
+fn model_schema(model: &ModelDef, create_only: bool) -> Value {
+    let mut properties = serde_json::Map::new();
+    let mut required: Vec<Value> = Vec::new();
+
+    for field in &model.fields {
+        // Omitir campos @auto en el schema de creacion
+        if create_only && is_auto_generated(field) {
+            continue;
+        }
+
+        let fname = &field.name.value;
+        let (ts_type, format) = field.ty.value.openapi_type();
+
+        let mut prop = serde_json::Map::new();
+        prop.insert("type".to_owned(), json!(ts_type));
+        if let Some(fmt) = format {
+            prop.insert("format".to_owned(), json!(fmt));
+        }
+        if field.optional {
+            // OpenAPI 3.1 usa nullable via type array
+            prop.insert("type".to_owned(), json!([ts_type, "null"]));
+        }
+
+        properties.insert(fname.clone(), Value::Object(prop));
+
+        if !(field.optional || create_only && is_auto_generated(field)) {
+            required.push(json!(fname));
+        }
+    }
+
+    let mut schema = serde_json::Map::new();
+    schema.insert("type".to_owned(), json!("object"));
+    if !required.is_empty() {
+        schema.insert("required".to_owned(), Value::Array(required));
+    }
+    schema.insert("properties".to_owned(), Value::Object(properties));
+
+    Value::Object(schema)
+}
+
+fn is_auto_generated(field: &FieldDef) -> bool {
+    field
+        .annotations
+        .iter()
+        .any(|a| matches!(a.value, Annotation::Auto | Annotation::AutoUpdate))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::lexer::tokenize;
+    use crate::parser::parse_tokens;
+
+    fn schema_from(src: &str) -> Schema {
+        let (tokens, _) = tokenize(src);
+        let (ast, _) = parse_tokens(tokens, src.len());
+        ast.expect("valid schema")
+    }
+
+    #[test]
+    fn generates_openapi_json() {
+        let schema = schema_from(
+            r#"
+config {
+    project_name "test-api"
+    database "postgres"
+}
+
+model User {
+    id    UUID   @primary @auto
+    email String @unique
+    name  String
+}
+"#,
+        );
+        let json_str = generate_openapi(&schema);
+        let doc: serde_json::Value = serde_json::from_str(&json_str).expect("valid JSON");
+
+        assert_eq!(doc["openapi"], "3.1.0");
+        assert_eq!(doc["info"]["title"], "test-api");
+        assert!(doc["components"]["schemas"]["User"].is_object());
+        assert!(doc["components"]["schemas"]["CreateUserRequest"].is_object());
+    }
+
+    #[test]
+    fn uuid_has_format() {
+        let schema = schema_from(
+            r#"
+model Item {
+    id UUID @primary @auto
+    v  Int
+}
+"#,
+        );
+        let json_str = generate_openapi(&schema);
+        let doc: serde_json::Value = serde_json::from_str(&json_str).unwrap();
+        let id_prop = &doc["components"]["schemas"]["Item"]["properties"]["id"];
+        assert_eq!(id_prop["format"], "uuid");
+    }
+
+    #[test]
+    fn auto_field_excluded_from_create_schema() {
+        let schema = schema_from(
+            r#"
+model Post {
+    id    UUID @primary @auto
+    title String
+}
+"#,
+        );
+        let json_str = generate_openapi(&schema);
+        let doc: serde_json::Value = serde_json::from_str(&json_str).unwrap();
+        let create = &doc["components"]["schemas"]["CreatePostRequest"]["properties"];
+        assert!(
+            create["id"].is_null(),
+            "id should be excluded from CreateRequest"
+        );
+        assert!(create["title"].is_object());
+    }
+
+    #[test]
+    fn required_fields_listed() {
+        let schema = schema_from(
+            r#"
+model Product {
+    id   UUID   @primary @auto
+    name String
+    desc String?
+}
+"#,
+        );
+        let json_str = generate_openapi(&schema);
+        let doc: serde_json::Value = serde_json::from_str(&json_str).unwrap();
+        let required = &doc["components"]["schemas"]["Product"]["required"];
+        let required_list: Vec<&str> = required
+            .as_array()
+            .unwrap()
+            .iter()
+            .map(|v| v.as_str().unwrap())
+            .collect();
+        assert!(required_list.contains(&"id"));
+        assert!(required_list.contains(&"name"));
+        assert!(
+            !required_list.contains(&"desc"),
+            "optional field should not be required"
+        );
+    }
+}

--- a/crates/ag-dsl/src/codegen/rust_gen.rs
+++ b/crates/ag-dsl/src/codegen/rust_gen.rs
@@ -5,7 +5,7 @@
 //!
 //! - `NombreModel` — struct completo (para respuestas y persistencia).
 //! - `CreateNombreRequest` — sin campos @auto (para POST).
-//! - `UpdateNombreRequest` — todos los campos no-@auto como Option<T> (para PUT/PATCH).
+//! - `UpdateNombreRequest` — todos los campos no-@auto como `Option<T>` (para PUT/PATCH).
 
 use crate::ast::{Annotation, FieldDef, FieldType, ModelDef, Schema};
 

--- a/crates/ag-dsl/src/codegen/rust_gen.rs
+++ b/crates/ag-dsl/src/codegen/rust_gen.rs
@@ -1,0 +1,240 @@
+//! Generador Rust para DSL v0.1.
+//!
+//! Produce structs Rust con serde::{Serialize, Deserialize} a partir de
+//! los modelos del schema. Por cada modelo genera:
+//!
+//! - `NombreModel` — struct completo (para respuestas y persistencia).
+//! - `CreateNombreRequest` — sin campos @auto (para POST).
+//! - `UpdateNombreRequest` — todos los campos no-@auto como Option<T> (para PUT/PATCH).
+
+use crate::ast::{Annotation, FieldDef, FieldType, ModelDef, Schema};
+
+/// Genera el contenido del archivo `src/models.rs` para el schema dado.
+pub fn generate_models(schema: &Schema) -> String {
+    let mut out = String::new();
+
+    out.push_str("//! Modelos generados por Anti-Gravital ag-dsl v0.1.\n");
+    out.push_str("//! NO editar manualmente. Regenerar con `ag generate`.\n\n");
+    out.push_str("#![allow(dead_code)]\n\n");
+
+    // Imports base
+    let needs_uuid = schema
+        .models
+        .iter()
+        .any(|m| m.fields.iter().any(|f| f.ty.value == FieldType::Uuid));
+    let needs_chrono = schema
+        .models
+        .iter()
+        .any(|m| m.fields.iter().any(|f| f.ty.value == FieldType::Timestamp));
+    let needs_decimal = schema
+        .models
+        .iter()
+        .any(|m| m.fields.iter().any(|f| f.ty.value == FieldType::Decimal));
+
+    out.push_str("use serde::{Deserialize, Serialize};\n");
+    if needs_uuid {
+        out.push_str("use uuid::Uuid;\n");
+    }
+    if needs_chrono {
+        out.push_str("use chrono::{DateTime, Utc};\n");
+    }
+    if needs_decimal {
+        out.push_str("use rust_decimal::Decimal;\n");
+    }
+    out.push('\n');
+
+    for model in &schema.models {
+        out.push_str(&generate_model_struct(model));
+        out.push('\n');
+        out.push_str(&generate_create_request(model));
+        out.push('\n');
+        out.push_str(&generate_update_request(model));
+        out.push('\n');
+    }
+
+    out
+}
+
+/// Struct completo del modelo (todos los campos).
+fn generate_model_struct(model: &ModelDef) -> String {
+    let name = &model.name.value;
+    let mut out = String::new();
+
+    out.push_str("/// Modelo completo (incluye campos generados automaticamente).\n");
+    out.push_str("#[derive(Debug, Clone, Serialize, Deserialize)]\n");
+    out.push_str(&format!("pub struct {name} {{\n"));
+
+    for field in &model.fields {
+        let rust_ty = rust_field_type(field);
+        let fname = &field.name.value;
+        // UUID usa serde rename cuando el nombre de campo es 'id'
+        if field.ty.value == FieldType::Uuid && fname == "id" {
+            out.push_str("    pub id: Uuid,\n");
+        } else {
+            out.push_str(&format!("    pub {fname}: {rust_ty},\n"));
+        }
+    }
+
+    out.push_str("}\n");
+    out
+}
+
+/// Request de creacion: excluye campos @auto y @auto_update.
+fn generate_create_request(model: &ModelDef) -> String {
+    let name = &model.name.value;
+    let create_fields: Vec<_> = model
+        .fields
+        .iter()
+        .filter(|f| !is_auto_generated(f))
+        .collect();
+
+    if create_fields.is_empty() {
+        // Todos los campos son auto; no tiene sentido un create request.
+        return format!(
+            "/// Todos los campos de '{name}' son autogenerados.\n\
+             /// No se necesita CreateRequest.\n\n"
+        );
+    }
+
+    let mut out = String::new();
+    out.push_str("/// Cuerpo de la peticion POST para crear un nuevo registro.\n");
+    out.push_str("#[derive(Debug, Clone, Serialize, Deserialize)]\n");
+    out.push_str(&format!("pub struct Create{name}Request {{\n"));
+
+    for field in create_fields {
+        let rust_ty = rust_field_type(field);
+        let fname = &field.name.value;
+        out.push_str(&format!("    pub {fname}: {rust_ty},\n"));
+    }
+
+    out.push_str("}\n");
+    out
+}
+
+/// Request de actualizacion: todos los campos no-auto son Option<T>.
+fn generate_update_request(model: &ModelDef) -> String {
+    let name = &model.name.value;
+    let update_fields: Vec<_> = model
+        .fields
+        .iter()
+        .filter(|f| !is_auto_generated(f) && !is_primary(f))
+        .collect();
+
+    if update_fields.is_empty() {
+        return format!("/// '{name}' no tiene campos actualizables.\n\n");
+    }
+
+    let mut out = String::new();
+    out.push_str("/// Cuerpo de la peticion PUT/PATCH para actualizar un registro.\n");
+    out.push_str("/// Los campos son opcionales: solo se actualizan los presentes.\n");
+    out.push_str("#[derive(Debug, Clone, Serialize, Deserialize, Default)]\n");
+    out.push_str(&format!("pub struct Update{name}Request {{\n"));
+
+    for field in update_fields {
+        let base_ty = field.ty.value.rust_type(false);
+        let fname = &field.name.value;
+        out.push_str(&format!("    pub {fname}: Option<{base_ty}>,\n"));
+    }
+
+    out.push_str("}\n");
+    out
+}
+
+/// Retorna el tipo Rust del campo, considerando opcionalidad.
+fn rust_field_type(field: &FieldDef) -> String {
+    // Campos @auto o @auto_update son siempre presentes en la DB,
+    // pero en los structs de respuesta se incluyen como requeridos.
+    field.ty.value.rust_type(field.optional)
+}
+
+/// True si el campo tiene @auto o @auto_update.
+fn is_auto_generated(field: &FieldDef) -> bool {
+    field
+        .annotations
+        .iter()
+        .any(|a| matches!(a.value, Annotation::Auto | Annotation::AutoUpdate))
+}
+
+/// True si el campo tiene @primary.
+fn is_primary(field: &FieldDef) -> bool {
+    field
+        .annotations
+        .iter()
+        .any(|a| a.value == Annotation::Primary)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::lexer::tokenize;
+    use crate::parser::parse_tokens;
+
+    fn schema_from(src: &str) -> Schema {
+        let (tokens, _) = tokenize(src);
+        let (ast, _) = parse_tokens(tokens, src.len());
+        ast.expect("valid schema")
+    }
+
+    #[test]
+    fn generates_valid_struct() {
+        let schema = schema_from(
+            r#"
+model User {
+    id    UUID   @primary @auto
+    email String @unique
+    name  String
+}
+"#,
+        );
+        let out = generate_models(&schema);
+        assert!(out.contains("pub struct User {"));
+        assert!(out.contains("pub struct CreateUserRequest {"));
+        assert!(out.contains("pub struct UpdateUserRequest {"));
+        // El campo id (@auto) no debe estar en CreateRequest
+        assert!(!out.contains("pub struct CreateUserRequest {\n    pub id:"));
+    }
+
+    #[test]
+    fn optional_field_in_update_request() {
+        let schema = schema_from(
+            r#"
+model Post {
+    id      UUID   @primary @auto
+    title   String
+    content String?
+}
+"#,
+        );
+        let out = generate_models(&schema);
+        assert!(out.contains("pub title: Option<String>,"));
+        assert!(out.contains("pub content: Option<String>,"));
+    }
+
+    #[test]
+    fn uuid_import_included() {
+        let schema = schema_from(
+            r#"
+model Item {
+    id UUID @primary @auto
+    v  Int
+}
+"#,
+        );
+        let out = generate_models(&schema);
+        assert!(out.contains("use uuid::Uuid;"));
+    }
+
+    #[test]
+    fn no_uuid_import_when_not_needed() {
+        let schema = schema_from(
+            r#"
+model Counter {
+    id    Int    @primary @auto
+    value Int
+}
+"#,
+        );
+        let out = generate_models(&schema);
+        assert!(!out.contains("use uuid::Uuid;"));
+    }
+}

--- a/crates/ag-dsl/src/codegen/sql_gen.rs
+++ b/crates/ag-dsl/src/codegen/sql_gen.rs
@@ -1,0 +1,250 @@
+//! Generador SQL para DSL v0.1.
+//!
+//! Produce una migracion SQL `CREATE TABLE IF NOT EXISTS` idempotente
+//! para cada modelo del schema. Compatible con PostgreSQL 14+.
+
+use crate::ast::{Annotation, FieldDef, FieldType, ModelDef, Schema};
+
+/// Genera el contenido del archivo de migracion SQL inicial.
+///
+/// El archivo resultante es idempotente: `CREATE TABLE IF NOT EXISTS` y
+/// `CREATE UNIQUE INDEX IF NOT EXISTS` no fallan si la tabla ya existe.
+pub fn generate_migration(schema: &Schema) -> String {
+    let mut out = String::new();
+
+    out.push_str("-- Migracion generada por Anti-Gravital ag-dsl v0.1.\n");
+    out.push_str("-- NO editar manualmente. Regenerar con `ag generate`.\n\n");
+
+    // Extension para gen_random_uuid() si hay campos UUID @auto
+    let needs_uuid_ext = schema.models.iter().any(|m| {
+        m.fields.iter().any(|f| {
+            f.ty.value == FieldType::Uuid
+                && f.annotations.iter().any(|a| a.value == Annotation::Auto)
+        })
+    });
+
+    if needs_uuid_ext {
+        out.push_str("CREATE EXTENSION IF NOT EXISTS \"pgcrypto\";\n\n");
+    }
+
+    for model in &schema.models {
+        out.push_str(&generate_table(model));
+        out.push('\n');
+    }
+
+    out
+}
+
+/// Genera el CREATE TABLE para un modelo.
+fn generate_table(model: &ModelDef) -> String {
+    let table_name = to_snake_case(&model.name.value);
+    let mut out = String::new();
+
+    out.push_str(&format!("CREATE TABLE IF NOT EXISTS \"{table_name}\" (\n"));
+
+    let field_count = model.fields.len();
+    for (i, field) in model.fields.iter().enumerate() {
+        let col = generate_column(field);
+        if i < field_count - 1 {
+            out.push_str(&format!("    {col},\n"));
+        } else {
+            out.push_str(&format!("    {col}\n"));
+        }
+    }
+
+    out.push_str(");\n");
+
+    // Indices UNIQUE separados (mas flexibles que UNIQUE inline).
+    for field in &model.fields {
+        if field
+            .annotations
+            .iter()
+            .any(|a| a.value == Annotation::Unique)
+            && !field
+                .annotations
+                .iter()
+                .any(|a| a.value == Annotation::Primary)
+        {
+            let col_name = to_snake_case(&field.name.value);
+            let idx_name = format!("idx_{table_name}_{col_name}_unique");
+            out.push_str(&format!(
+                "CREATE UNIQUE INDEX IF NOT EXISTS \"{idx_name}\" \
+                 ON \"{table_name}\" (\"{col_name}\");\n"
+            ));
+        }
+    }
+
+    out
+}
+
+/// Genera la definicion de columna SQL para un campo.
+fn generate_column(field: &FieldDef) -> String {
+    let col_name = to_snake_case(&field.name.value);
+    let is_primary = field
+        .annotations
+        .iter()
+        .any(|a| a.value == Annotation::Primary);
+    let is_auto = field
+        .annotations
+        .iter()
+        .any(|a| a.value == Annotation::Auto);
+    let is_auto_update = field
+        .annotations
+        .iter()
+        .any(|a| a.value == Annotation::AutoUpdate);
+    let nullable = field.optional;
+
+    // Tipo SQL base
+    let sql_type = match (&field.ty.value, is_auto) {
+        (FieldType::Int, true) => "BIGSERIAL",
+        (ty, _) => ty.sql_type(),
+    };
+
+    let mut col = format!("\"{col_name}\" {sql_type}");
+
+    // NOT NULL
+    if !nullable && sql_type != "BIGSERIAL" {
+        col.push_str(" NOT NULL");
+    }
+
+    // DEFAULT para campos @auto
+    if is_auto && field.ty.value == FieldType::Uuid {
+        col.push_str(" DEFAULT gen_random_uuid()");
+    } else if is_auto && field.ty.value == FieldType::Timestamp {
+        col.push_str(" DEFAULT NOW()");
+    } else if is_auto_update {
+        // @auto_update se maneja con trigger; no hay DEFAULT SQL directo.
+        // La migracion incluye una nota al respecto.
+        col.push_str(" DEFAULT NOW()");
+    } else {
+        // @default(valor)
+        for ann in &field.annotations {
+            if let Annotation::Default(ref val) = ann.value {
+                col.push_str(&format!(" DEFAULT {val}"));
+                break;
+            }
+        }
+    }
+
+    // PRIMARY KEY
+    if is_primary {
+        col.push_str(" PRIMARY KEY");
+    }
+
+    col
+}
+
+/// Convierte PascalCase o camelCase a snake_case para nombres de tabla/columna.
+fn to_snake_case(s: &str) -> String {
+    let mut result = String::with_capacity(s.len() + 4);
+    for (i, ch) in s.chars().enumerate() {
+        if ch.is_uppercase() && i > 0 {
+            result.push('_');
+        }
+        result.push(ch.to_lowercase().next().unwrap());
+    }
+    result
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::lexer::tokenize;
+    use crate::parser::parse_tokens;
+
+    fn schema_from(src: &str) -> Schema {
+        let (tokens, _) = tokenize(src);
+        let (ast, _) = parse_tokens(tokens, src.len());
+        ast.expect("valid schema")
+    }
+
+    #[test]
+    fn generates_create_table() {
+        let schema = schema_from(
+            r#"
+model User {
+    id    UUID   @primary @auto
+    email String @unique
+    name  String
+}
+"#,
+        );
+        let sql = generate_migration(&schema);
+        assert!(sql.contains("CREATE TABLE IF NOT EXISTS \"user\""));
+        assert!(sql.contains("\"id\" UUID NOT NULL DEFAULT gen_random_uuid() PRIMARY KEY"));
+        assert!(sql.contains("\"email\" TEXT NOT NULL"));
+        assert!(sql.contains("\"name\" TEXT NOT NULL"));
+    }
+
+    #[test]
+    fn unique_field_gets_index() {
+        let schema = schema_from(
+            r#"
+model User {
+    id    UUID   @primary @auto
+    email String @unique
+}
+"#,
+        );
+        let sql = generate_migration(&schema);
+        assert!(sql.contains("CREATE UNIQUE INDEX IF NOT EXISTS \"idx_user_email_unique\""));
+    }
+
+    #[test]
+    fn optional_field_has_no_not_null() {
+        let schema = schema_from(
+            r#"
+model Profile {
+    id  UUID   @primary @auto
+    bio String?
+}
+"#,
+        );
+        let sql = generate_migration(&schema);
+        // El campo bio es nullable: no debe tener NOT NULL
+        let bio_line = sql
+            .lines()
+            .find(|l| l.contains("\"bio\""))
+            .expect("bio column missing");
+        assert!(
+            !bio_line.contains("NOT NULL"),
+            "nullable field should not have NOT NULL: {bio_line}"
+        );
+    }
+
+    #[test]
+    fn int_auto_is_bigserial() {
+        let schema = schema_from(
+            r#"
+model Counter {
+    id    Int @primary @auto
+    value Int
+}
+"#,
+        );
+        let sql = generate_migration(&schema);
+        assert!(sql.contains("\"id\" BIGSERIAL"));
+    }
+
+    #[test]
+    fn uuid_auto_includes_pgcrypto() {
+        let schema = schema_from(
+            r#"
+model Thing {
+    id UUID @primary @auto
+    v  Int
+}
+"#,
+        );
+        let sql = generate_migration(&schema);
+        assert!(sql.contains("CREATE EXTENSION IF NOT EXISTS \"pgcrypto\""));
+    }
+
+    #[test]
+    fn to_snake_case_conversion() {
+        assert_eq!(to_snake_case("User"), "user");
+        assert_eq!(to_snake_case("BlogPost"), "blog_post");
+        assert_eq!(to_snake_case("HTTPRequest"), "h_t_t_p_request");
+        assert_eq!(to_snake_case("id"), "id");
+    }
+}

--- a/crates/ag-dsl/src/codegen/ts_gen.rs
+++ b/crates/ag-dsl/src/codegen/ts_gen.rs
@@ -1,0 +1,184 @@
+//! Generador TypeScript para DSL v0.1.
+//!
+//! Produce interfaces TypeScript con tipos precisos para cada modelo.
+//! Los campos @auto se incluyen como requeridos en la interfaz completa
+//! y se excluyen en la interfaz de creacion.
+
+use crate::ast::{Annotation, FieldDef, ModelDef, Schema};
+
+/// Genera el contenido del archivo `clients/typescript/types.ts`.
+pub fn generate_types(schema: &Schema) -> String {
+    let mut out = String::new();
+
+    out.push_str("// Tipos generados por Anti-Gravital ag-dsl v0.1.\n");
+    out.push_str("// NO editar manualmente. Regenerar con `ag generate`.\n\n");
+
+    for model in &schema.models {
+        out.push_str(&generate_model_interface(model));
+        out.push('\n');
+        out.push_str(&generate_create_interface(model));
+        out.push('\n');
+        out.push_str(&generate_update_interface(model));
+        out.push('\n');
+    }
+
+    out
+}
+
+/// Interfaz completa del modelo.
+fn generate_model_interface(model: &ModelDef) -> String {
+    let name = &model.name.value;
+    let mut out = String::new();
+
+    out.push_str("/** Modelo completo incluyendo campos autogenerados. */\n");
+    out.push_str(&format!("export interface {name} {{\n"));
+
+    for field in &model.fields {
+        let ts_ty = ts_field_type(field);
+        let fname = &field.name.value;
+        let optional_marker = if field.optional { "?" } else { "" };
+        out.push_str(&format!("  {fname}{optional_marker}: {ts_ty};\n"));
+    }
+
+    out.push_str("}\n");
+    out
+}
+
+/// Interfaz de creacion: excluye campos @auto.
+fn generate_create_interface(model: &ModelDef) -> String {
+    let name = &model.name.value;
+    let create_fields: Vec<_> = model
+        .fields
+        .iter()
+        .filter(|f| !is_auto_generated(f))
+        .collect();
+
+    if create_fields.is_empty() {
+        return format!(
+            "// Todos los campos de '{name}' son autogenerados; no hay Create interface.\n\n"
+        );
+    }
+
+    let mut out = String::new();
+    out.push_str("/** Cuerpo de la peticion POST para crear un nuevo registro. */\n");
+    out.push_str(&format!("export interface Create{name}Request {{\n"));
+
+    for field in create_fields {
+        let ts_ty = ts_field_type(field);
+        let fname = &field.name.value;
+        let optional_marker = if field.optional { "?" } else { "" };
+        out.push_str(&format!("  {fname}{optional_marker}: {ts_ty};\n"));
+    }
+
+    out.push_str("}\n");
+    out
+}
+
+/// Interfaz de actualizacion: todos los campos no-auto son opcionales.
+fn generate_update_interface(model: &ModelDef) -> String {
+    let name = &model.name.value;
+    let update_fields: Vec<_> = model
+        .fields
+        .iter()
+        .filter(|f| !is_auto_generated(f) && !is_primary(f))
+        .collect();
+
+    if update_fields.is_empty() {
+        return format!("// '{name}' no tiene campos actualizables.\n\n");
+    }
+
+    let mut out = String::new();
+    out.push_str("/** Cuerpo de la peticion PUT/PATCH. Todos los campos son opcionales. */\n");
+    out.push_str(&format!("export interface Update{name}Request {{\n"));
+
+    for field in update_fields {
+        let ts_ty = field.ty.value.ts_type();
+        let fname = &field.name.value;
+        out.push_str(&format!("  {fname}?: {ts_ty};\n"));
+    }
+
+    out.push_str("}\n");
+    out
+}
+
+fn ts_field_type(field: &FieldDef) -> String {
+    let base = field.ty.value.ts_type();
+    if field.optional {
+        format!("{base} | null")
+    } else {
+        base.to_owned()
+    }
+}
+
+fn is_auto_generated(field: &FieldDef) -> bool {
+    field
+        .annotations
+        .iter()
+        .any(|a| matches!(a.value, Annotation::Auto | Annotation::AutoUpdate))
+}
+
+fn is_primary(field: &FieldDef) -> bool {
+    field
+        .annotations
+        .iter()
+        .any(|a| a.value == Annotation::Primary)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::lexer::tokenize;
+    use crate::parser::parse_tokens;
+
+    fn schema_from(src: &str) -> Schema {
+        let (tokens, _) = tokenize(src);
+        let (ast, _) = parse_tokens(tokens, src.len());
+        ast.expect("valid schema")
+    }
+
+    #[test]
+    fn generates_interfaces() {
+        let schema = schema_from(
+            r#"
+model User {
+    id    UUID   @primary @auto
+    email String @unique
+    name  String
+}
+"#,
+        );
+        let ts = generate_types(&schema);
+        assert!(ts.contains("export interface User {"));
+        assert!(ts.contains("export interface CreateUserRequest {"));
+        assert!(ts.contains("export interface UpdateUserRequest {"));
+        // id no debe aparecer en Create (es @auto)
+        assert!(!ts.contains("export interface CreateUserRequest {\n  id:"));
+    }
+
+    #[test]
+    fn optional_field_uses_null_union() {
+        let schema = schema_from(
+            r#"
+model Profile {
+    id  UUID   @primary @auto
+    bio String?
+}
+"#,
+        );
+        let ts = generate_types(&schema);
+        assert!(ts.contains("bio?: string | null;"));
+    }
+
+    #[test]
+    fn uuid_maps_to_string() {
+        let schema = schema_from(
+            r#"
+model Item {
+    id UUID @primary @auto
+}
+"#,
+        );
+        let ts = generate_types(&schema);
+        assert!(ts.contains("id: string;"));
+    }
+}

--- a/crates/ag-dsl/src/diagnostics.rs
+++ b/crates/ag-dsl/src/diagnostics.rs
@@ -1,0 +1,165 @@
+//! Tipos de diagnostico del compilador Anti-DSL.
+//!
+//! Todos los errores y warnings del pipeline (lex, parse, semantic) se
+//! unifican en `Diagnostic`. Los consumidores (ag-cli) pueden filtrar por
+//! severidad y formatear los mensajes para el usuario.
+
+use crate::lexer::Span;
+use thiserror::Error;
+
+/// Severidad del diagnostico.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum Severity {
+    /// Error que impide la generacion de codigo.
+    Error,
+    /// Advertencia informativa; la generacion puede continuar.
+    Warning,
+}
+
+/// Diagnostico del compilador con posicion, severidad y mensaje.
+#[derive(Debug, Clone)]
+pub struct Diagnostic {
+    /// Posicion en el texto fuente.
+    pub span: Span,
+    /// Severidad del diagnostico.
+    pub severity: Severity,
+    /// Mensaje legible para el usuario.
+    pub message: String,
+    /// Sugerencia opcional de como corregirlo.
+    pub hint: Option<String>,
+}
+
+impl Diagnostic {
+    /// Error de lex: caracter no reconocido.
+    pub fn lex_error(span: Span) -> Self {
+        Self {
+            span,
+            severity: Severity::Error,
+            message: "caracter inesperado".to_owned(),
+            hint: None,
+        }
+    }
+
+    /// Error de parse: token inesperado.
+    pub fn parse_error(span: Span, message: impl Into<String>) -> Self {
+        Self {
+            span,
+            severity: Severity::Error,
+            message: message.into(),
+            hint: None,
+        }
+    }
+
+    /// Error semantico generico.
+    pub fn semantic_error(span: Span, message: impl Into<String>) -> Self {
+        Self {
+            span,
+            severity: Severity::Error,
+            message: message.into(),
+            hint: None,
+        }
+    }
+
+    /// Error semantico con sugerencia.
+    pub fn semantic_error_with_hint(
+        span: Span,
+        message: impl Into<String>,
+        hint: impl Into<String>,
+    ) -> Self {
+        Self {
+            span,
+            severity: Severity::Error,
+            message: message.into(),
+            hint: Some(hint.into()),
+        }
+    }
+
+    /// Warning semantico.
+    pub fn warning(span: Span, message: impl Into<String>) -> Self {
+        Self {
+            span,
+            severity: Severity::Warning,
+            message: message.into(),
+            hint: None,
+        }
+    }
+
+    /// Retorna true si este diagnostico es un error (bloquea generacion).
+    pub fn is_error(&self) -> bool {
+        self.severity == Severity::Error
+    }
+
+    /// Formatea el diagnostico como string legible para el usuario.
+    ///
+    /// Formato: `[error|warning] byte N-M: mensaje (sugerencia si aplica)`
+    pub fn display(&self, source: &str) -> String {
+        let severity = match self.severity {
+            Severity::Error => "error",
+            Severity::Warning => "warning",
+        };
+
+        // Calcula linea y columna desde el byte offset.
+        let (line, col) = byte_offset_to_line_col(source, self.span.start);
+        let location = format!("{}:{}", line, col);
+
+        let mut out = format!("{severity} [{location}]: {}", self.message);
+        if let Some(hint) = &self.hint {
+            out.push_str(&format!("\n  ayuda: {hint}"));
+        }
+        out
+    }
+}
+
+/// Error fatal del compilador (no un diagnostico por posicion).
+#[derive(Debug, Error)]
+pub enum CompilerError {
+    /// El texto fuente contiene errores que impiden compilar.
+    #[error("el schema contiene {0} error(es)")]
+    SchemaErrors(usize),
+}
+
+// Convierte byte offset a (linea, columna) 1-indexado.
+fn byte_offset_to_line_col(source: &str, offset: usize) -> (usize, usize) {
+    let before = &source[..offset.min(source.len())];
+    let line = before.bytes().filter(|&b| b == b'\n').count() + 1;
+    let col = before.rfind('\n').map(|i| offset - i - 1).unwrap_or(offset) + 1;
+    (line, col)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn lex_error_is_error_severity() {
+        let d = Diagnostic::lex_error(0..1);
+        assert!(d.is_error());
+    }
+
+    #[test]
+    fn warning_is_not_error() {
+        let d = Diagnostic::warning(0..1, "esto es un aviso");
+        assert!(!d.is_error());
+    }
+
+    #[test]
+    fn display_shows_line_col() {
+        let source = "model\nUser";
+        let d = Diagnostic::parse_error(6..10, "token inesperado");
+        let out = d.display(source);
+        assert!(out.contains("2:1"), "should show line 2 col 1, got: {out}");
+        assert!(out.contains("token inesperado"));
+    }
+
+    #[test]
+    fn display_with_hint() {
+        let source = "model User {}";
+        let d = Diagnostic::semantic_error_with_hint(
+            0..5,
+            "sin campos",
+            "anade al menos un campo al modelo",
+        );
+        let out = d.display(source);
+        assert!(out.contains("ayuda:"));
+    }
+}

--- a/crates/ag-dsl/src/lexer.rs
+++ b/crates/ag-dsl/src/lexer.rs
@@ -1,0 +1,283 @@
+//! Tokenizador del Anti-DSL generado con logos.
+//!
+//! Convierte texto fuente `.ag` en tokens posicionales. Los comentarios
+//! (`#` hasta fin de linea) y el whitespace se omiten automaticamente.
+//! Los tokens invalidos se acumulan como errores de lex sin detener el
+//! proceso; el parser recibe solo los tokens validos.
+
+use logos::Logos;
+use std::ops::Range;
+
+/// Rango de bytes en el texto fuente (byte offset, no char offset).
+pub type Span = Range<usize>;
+
+/// Tokens del Anti-DSL v0.1.
+///
+/// Los `#[token(...)]` tienen prioridad sobre los `#[regex(...)]`, por lo que
+/// las palabras clave siempre se reconocen antes que el identificador generico.
+#[derive(Logos, Debug, Clone, PartialEq, Eq, Hash)]
+#[logos(skip r"[ \t\r\n\f]+")] // whitespace
+#[logos(skip r"#[^\r\n]*")] // comentarios de linea
+pub enum Token {
+    // ---- Palabras clave de estructura ----
+    /// Definicion de modelo: `model Nombre { ... }`
+    #[token("model")]
+    Model,
+    /// Bloque de configuracion: `config { ... }`
+    #[token("config")]
+    Config,
+    /// Definicion de enum (reservado para DSL v0.2+).
+    #[token("enum")]
+    Enum,
+
+    // ---- Tipos primitivos de campo ----
+    /// `UUID` — uuid::Uuid en Rust, string (uuid) en TypeScript.
+    #[token("UUID")]
+    TyUuid,
+    /// `String` — String en Rust, string en TypeScript.
+    #[token("String")]
+    TyString,
+    /// `Int` — i64 en Rust, number en TypeScript.
+    #[token("Int")]
+    TyInt,
+    /// `Float` — f64 en Rust, number en TypeScript.
+    #[token("Float")]
+    TyFloat,
+    /// `Bool` — bool en Rust, boolean en TypeScript.
+    #[token("Bool")]
+    TyBool,
+    /// `Timestamp` — chrono::DateTime<Utc> en Rust, string (date-time) en TypeScript.
+    #[token("Timestamp")]
+    TyTimestamp,
+    /// `Decimal` — rust_decimal::Decimal en Rust, string (decimal) en TypeScript.
+    #[token("Decimal")]
+    TyDecimal,
+
+    // ---- Anotaciones DSL v0.1 ----
+    /// `@primary` — clave primaria de la tabla.
+    #[token("@primary")]
+    AtPrimary,
+    /// `@unique` — restriccion UNIQUE en la base de datos.
+    #[token("@unique")]
+    AtUnique,
+    /// `@auto` — valor generado automaticamente (uuid, serial, NOW()).
+    #[token("@auto")]
+    AtAuto,
+    /// `@auto_update` — actualizado automaticamente en cada UPDATE.
+    #[token("@auto_update")]
+    AtAutoUpdate,
+    /// `@default(valor)` — valor por defecto.
+    #[token("@default")]
+    AtDefault,
+
+    // ---- Literales ----
+    /// Literal entero: `42`, `255`, `0`.
+    #[regex(r"[0-9]+", |lex| lex.slice().parse::<i64>().unwrap())]
+    IntLit(i64),
+
+    /// Literal string entre comillas dobles: `"hola"`.
+    /// Los escapes basicos (`\"`, `\\`) estan soportados en el regex;
+    /// la validacion de escapes complejos pertenece al semantic pass.
+    #[regex(r#""([^"\\]|\\.)*""#, |lex| {
+        let s = lex.slice();
+        s[1..s.len() - 1].to_owned()
+    })]
+    StringLit(String),
+
+    /// Literal booleano `true`.
+    #[token("true")]
+    True,
+    /// Literal booleano `false`.
+    #[token("false")]
+    False,
+
+    // ---- Identificador generico ----
+    /// Nombre de modelo, campo, variante de enum, etc.
+    /// Debe ir despues de todos los `#[token]` para no capturar keywords.
+    #[regex(r"[a-zA-Z_][a-zA-Z0-9_]*", |lex| lex.slice().to_owned())]
+    Ident(String),
+
+    // ---- Puntuacion ----
+    #[token("{")]
+    LBrace,
+    #[token("}")]
+    RBrace,
+    #[token("(")]
+    LParen,
+    #[token(")")]
+    RParen,
+    #[token(",")]
+    Comma,
+    #[token("[")]
+    LBracket,
+    #[token("]")]
+    RBracket,
+    /// Campo opcional: `Nombre String?`
+    #[token("?")]
+    Question,
+}
+
+/// Resultado de tokenizar el texto fuente.
+///
+/// Retorna dos vectores:
+/// - `tokens`: tokens validos con su span de bytes.
+/// - `errors`: spans de caracteres no reconocidos.
+pub fn tokenize(source: &str) -> (Vec<(Token, Span)>, Vec<Span>) {
+    let mut tokens = Vec::new();
+    let mut errors = Vec::new();
+    for (result, span) in Token::lexer(source).spanned() {
+        match result {
+            Ok(tok) => tokens.push((tok, span)),
+            Err(_) => errors.push(span),
+        }
+    }
+    (tokens, errors)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn lex(src: &str) -> Vec<Token> {
+        let (toks, errs) = tokenize(src);
+        assert!(errs.is_empty(), "lex errors: {errs:?}");
+        toks.into_iter().map(|(t, _)| t).collect()
+    }
+
+    #[test]
+    fn keywords_not_captured_as_ident() {
+        let toks = lex("model config enum");
+        assert_eq!(toks, vec![Token::Model, Token::Config, Token::Enum]);
+    }
+
+    #[test]
+    fn type_keywords() {
+        let toks = lex("UUID String Int Float Bool Timestamp Decimal");
+        assert_eq!(
+            toks,
+            vec![
+                Token::TyUuid,
+                Token::TyString,
+                Token::TyInt,
+                Token::TyFloat,
+                Token::TyBool,
+                Token::TyTimestamp,
+                Token::TyDecimal,
+            ]
+        );
+    }
+
+    #[test]
+    fn annotations_v01() {
+        let toks = lex("@primary @unique @auto @auto_update @default");
+        assert_eq!(
+            toks,
+            vec![
+                Token::AtPrimary,
+                Token::AtUnique,
+                Token::AtAuto,
+                Token::AtAutoUpdate,
+                Token::AtDefault,
+            ]
+        );
+    }
+
+    #[test]
+    fn auto_does_not_eat_auto_update() {
+        let toks = lex("@auto_update @auto");
+        assert_eq!(toks, vec![Token::AtAutoUpdate, Token::AtAuto]);
+    }
+
+    #[test]
+    fn identifiers() {
+        let toks = lex("User email_address _private CamelCase");
+        assert_eq!(
+            toks,
+            vec![
+                Token::Ident("User".to_owned()),
+                Token::Ident("email_address".to_owned()),
+                Token::Ident("_private".to_owned()),
+                Token::Ident("CamelCase".to_owned()),
+            ]
+        );
+    }
+
+    #[test]
+    fn integer_literals() {
+        let toks = lex("0 42 255");
+        assert_eq!(
+            toks,
+            vec![Token::IntLit(0), Token::IntLit(42), Token::IntLit(255),]
+        );
+    }
+
+    #[test]
+    fn string_literal() {
+        let toks = lex(r#""hello world""#);
+        assert_eq!(toks, vec![Token::StringLit("hello world".to_owned())]);
+    }
+
+    #[test]
+    fn boolean_literals() {
+        let toks = lex("true false");
+        assert_eq!(toks, vec![Token::True, Token::False]);
+    }
+
+    #[test]
+    fn punctuation() {
+        let toks = lex("{ } ( ) , [ ] ?");
+        assert_eq!(
+            toks,
+            vec![
+                Token::LBrace,
+                Token::RBrace,
+                Token::LParen,
+                Token::RParen,
+                Token::Comma,
+                Token::LBracket,
+                Token::RBracket,
+                Token::Question,
+            ]
+        );
+    }
+
+    #[test]
+    fn comments_are_skipped() {
+        let toks = lex("model # esto es un comentario\nUser");
+        assert_eq!(toks, vec![Token::Model, Token::Ident("User".to_owned()),]);
+    }
+
+    #[test]
+    fn whitespace_is_skipped() {
+        let toks = lex("  model\t\nUser  ");
+        assert_eq!(toks, vec![Token::Model, Token::Ident("User".to_owned()),]);
+    }
+
+    #[test]
+    fn invalid_char_produces_error() {
+        let (toks, errs) = tokenize("model @ User");
+        // '@' solo no es un token valido; '@primary' etc si.
+        assert!(!errs.is_empty());
+        // Los tokens validos si se extraen
+        assert!(toks.iter().any(|(t, _)| *t == Token::Model));
+    }
+
+    #[test]
+    fn simple_model_tokenizes() {
+        let src = r#"
+model User {
+    id    UUID   @primary @auto
+    email String @unique
+    name  String
+}
+"#;
+        let (toks, errs) = tokenize(src);
+        assert!(errs.is_empty());
+        let kinds: Vec<_> = toks.into_iter().map(|(t, _)| t).collect();
+        assert!(kinds.contains(&Token::Model));
+        assert!(kinds.contains(&Token::TyUuid));
+        assert!(kinds.contains(&Token::AtPrimary));
+        assert!(kinds.contains(&Token::AtAuto));
+        assert!(kinds.contains(&Token::AtUnique));
+    }
+}

--- a/crates/ag-dsl/src/lib.rs
+++ b/crates/ag-dsl/src/lib.rs
@@ -1,5 +1,89 @@
 //! Compilador del Anti-DSL: lexer, parser, AST, analisis semantico y generadores de codigo.
 //!
-//! Estado: Fase 0 (Fundaciones y Gobernanza). Este crate aun no contiene
-//! codigo funcional. La implementacion se entrega en la fase declarada
-//! en el README del crate y en la Hoja de Ruta del proyecto.
+//! # Uso
+//!
+//! ```rust
+//! use ag_dsl::{compile, generate};
+//!
+//! let source = r#"
+//! model User {
+//!     id    UUID   @primary @auto
+//!     email String @unique
+//!     name  String
+//! }
+//! "#;
+//!
+//! match compile(source) {
+//!     Ok(schema) => {
+//!         let files = generate(&schema);
+//!         for (path, content) in &files.files {
+//!             println!("--- {} ---", path.display());
+//!             println!("{content}");
+//!         }
+//!     }
+//!     Err(diagnostics) => {
+//!         for d in &diagnostics {
+//!             eprintln!("{}", d.display(source));
+//!         }
+//!     }
+//! }
+//! ```
+//!
+//! # Pipeline
+//!
+//! ```text
+//! texto .ag
+//!   -> lexer (logos)      tokens + errores de lex
+//!   -> parser (chumsky)   AST parcial + errores de parse
+//!   -> semantic           errores/warnings semanticos
+//!   -> codegen            GeneratedFiles { rust, sql, typescript, openapi }
+//! ```
+
+pub mod ast;
+pub mod codegen;
+pub mod diagnostics;
+mod lexer;
+mod parser;
+mod semantic;
+
+pub use codegen::{generate, GeneratedFiles};
+pub use diagnostics::Diagnostic;
+
+/// Compila un texto fuente DSL y retorna el AST si no hay errores.
+///
+/// Los warnings (como un modelo sin @primary) no bloquean la compilacion.
+/// Solo los errores de severidad `Error` producen `Err`.
+///
+/// # Errors
+///
+/// Retorna `Err(Vec<Diagnostic>)` si hay errores de lex, parse o semantic.
+pub fn compile(source: &str) -> Result<ast::Schema, Vec<Diagnostic>> {
+    let (tokens, lex_spans) = lexer::tokenize(source);
+
+    let mut all_diags: Vec<Diagnostic> = lex_spans.into_iter().map(Diagnostic::lex_error).collect();
+
+    let (ast, parse_diags) = parser::parse_tokens(tokens, source.len());
+    all_diags.extend(parse_diags);
+
+    match ast {
+        Some(schema) => {
+            let semantic_diags = semantic::analyze(&schema);
+            all_diags.extend(semantic_diags);
+
+            if all_diags.iter().any(|d| d.is_error()) {
+                Err(all_diags)
+            } else {
+                Ok(schema)
+            }
+        }
+        None => {
+            if all_diags.is_empty() {
+                all_diags.push(Diagnostic::parse_error(
+                    0..source.len().max(1),
+                    "no se pudo construir el AST",
+                ));
+            }
+            Err(all_diags)
+        }
+    }
+}

--- a/crates/ag-dsl/src/parser.rs
+++ b/crates/ag-dsl/src/parser.rs
@@ -1,0 +1,356 @@
+//! Parser del Anti-DSL usando chumsky 0.9.
+//!
+//! Convierte un stream de tokens (producido por el lexer) en un AST.
+//! Usa `parse_recovery` para reportar multiples errores en una sola
+//! pasada en lugar de detenerse en el primero.
+//!
+//! `Simple<Token>` de chumsky contiene un HashSet con los tokens esperados.
+//! Con Token que tiene variantes String, el tamano del Err supera 128 bytes.
+//! Este es el comportamiento esperado de chumsky 0.9 y no puede reducirse
+//! sin cambiar el tipo de error del crate.
+#![allow(clippy::result_large_err)]
+
+use chumsky::prelude::*;
+
+use crate::ast::{
+    Annotation, Config, DefaultValue, FieldDef, FieldType, ModelDef, Schema, Spanned,
+};
+use crate::diagnostics::Diagnostic;
+use crate::lexer::{Span, Token};
+
+// Alias de tipo interno.
+type ParseErr = Simple<Token>;
+
+/// Parsea un stream de tokens en un `Schema`.
+///
+/// Retorna el AST (posiblemente parcial en presencia de errores) y la
+/// lista de diagnosticos de parse acumulados.
+pub fn parse_tokens(
+    tokens: Vec<(Token, Span)>,
+    source_len: usize,
+) -> (Option<Schema>, Vec<Diagnostic>) {
+    let end_span = source_len..source_len;
+
+    let stream = chumsky::Stream::from_iter(end_span, tokens.into_iter());
+
+    let (ast, errors) = schema_parser().parse_recovery_verbose(stream);
+
+    let diagnostics: Vec<Diagnostic> = errors.into_iter().map(parse_error_to_diagnostic).collect();
+
+    (ast, diagnostics)
+}
+
+// ---- Construccion del parser ----------------------------------------
+
+/// Parser principal: lee cero o mas items (model o config) hasta EOF.
+fn schema_parser() -> impl Parser<Token, Schema, Error = ParseErr> {
+    let model = model_parser();
+    let config = config_parser();
+
+    let item = choice((config.map(SchemaItem::Config), model.map(SchemaItem::Model)))
+        .recover_with(skip_then_retry_until([Token::Model, Token::Config]));
+
+    item.repeated().then_ignore(end()).map(|items| {
+        let mut schema = Schema::default();
+        for item in items {
+            match item {
+                SchemaItem::Config(c) => schema.config = Some(c),
+                SchemaItem::Model(m) => schema.models.push(m),
+            }
+        }
+        schema
+    })
+}
+
+/// Items posibles en el schema (union interna del parser).
+enum SchemaItem {
+    Config(Config),
+    Model(ModelDef),
+}
+
+/// Parser de bloque `config { ... }`.
+fn config_parser() -> impl Parser<Token, Config, Error = ParseErr> {
+    just(Token::Config)
+        .ignore_then(
+            config_field_parser()
+                .repeated()
+                .collect::<Vec<_>>()
+                .delimited_by(just(Token::LBrace), just(Token::RBrace)),
+        )
+        .map(|fields| {
+            let mut config = Config::default();
+            for (key, value) in fields {
+                match key.as_str() {
+                    "project_name" => config.project_name = Some(value),
+                    "database" => config.database = Some(value),
+                    _ => {} // campos desconocidos ignorados en parse; reportados en semantic
+                }
+            }
+            config
+        })
+        .labelled("bloque config")
+}
+
+/// Par clave-valor en el bloque config.
+fn config_field_parser() -> impl Parser<Token, (String, String), Error = ParseErr> {
+    let key = select! { Token::Ident(s) => s }.labelled("clave de config");
+
+    let value = choice((
+        select! { Token::StringLit(s) => s },
+        select! { Token::Ident(s) => s },
+        select! { Token::IntLit(n) => n.to_string() },
+    ))
+    .labelled("valor de config");
+
+    key.then(value)
+}
+
+/// Parser de definicion de modelo: `model Nombre { campos... }`.
+fn model_parser() -> impl Parser<Token, ModelDef, Error = ParseErr> {
+    let model_name = just(Token::Model)
+        .ignore_then(select! { Token::Ident(s) => s }.labelled("nombre del modelo"));
+
+    model_name
+        .map_with_span(|name, span: Span| Spanned::new(name, span))
+        .then(field_parser().repeated().collect::<Vec<_>>().delimited_by(
+            just(Token::LBrace).labelled("{"),
+            just(Token::RBrace).labelled("}"),
+        ))
+        .map_with_span(|(name, fields), span| ModelDef { name, fields, span })
+        .labelled("definicion de modelo")
+}
+
+/// Parser de campo: `nombre Tipo @anotacion1 @anotacion2(arg) ...`
+fn field_parser() -> impl Parser<Token, FieldDef, Error = ParseErr> {
+    let field_name = select! { Token::Ident(s) => s }
+        .map_with_span(|s, span: Span| Spanned::new(s, span))
+        .labelled("nombre de campo");
+
+    let field_type = choice((
+        just(Token::TyUuid).to(FieldType::Uuid),
+        just(Token::TyString).to(FieldType::String),
+        just(Token::TyInt).to(FieldType::Int),
+        just(Token::TyFloat).to(FieldType::Float),
+        just(Token::TyBool).to(FieldType::Bool),
+        just(Token::TyTimestamp).to(FieldType::Timestamp),
+        just(Token::TyDecimal).to(FieldType::Decimal),
+    ))
+    .map_with_span(|t, span: Span| Spanned::new(t, span))
+    .labelled("tipo de campo");
+
+    let optional = just(Token::Question).or_not().map(|q| q.is_some());
+
+    let annotations = annotation_parser().repeated().collect::<Vec<_>>();
+
+    field_name
+        .then(field_type)
+        .then(optional)
+        .then(annotations)
+        .map(|(((name, ty), optional), annotations)| FieldDef {
+            name,
+            ty,
+            optional,
+            annotations,
+        })
+}
+
+/// Parser de anotaciones individuales.
+fn annotation_parser() -> impl Parser<Token, Spanned<Annotation>, Error = ParseErr> {
+    let default_value = choice((
+        select! { Token::IntLit(n) => DefaultValue::Int(n) },
+        select! { Token::StringLit(s) => DefaultValue::String(s) },
+        just(Token::True).to(DefaultValue::Bool(true)),
+        just(Token::False).to(DefaultValue::Bool(false)),
+        select! { Token::Ident(s) => DefaultValue::Ident(s) },
+    ))
+    .labelled("valor de @default");
+
+    let at_default = just(Token::AtDefault)
+        .ignore_then(default_value.delimited_by(just(Token::LParen), just(Token::RParen)))
+        .map(Annotation::Default);
+
+    choice((
+        just(Token::AtPrimary).to(Annotation::Primary),
+        just(Token::AtUnique).to(Annotation::Unique),
+        just(Token::AtAutoUpdate).to(Annotation::AutoUpdate), // primero: mas especifico
+        just(Token::AtAuto).to(Annotation::Auto),
+        at_default,
+    ))
+    .map_with_span(|ann, span: Span| Spanned::new(ann, span))
+    .labelled("anotacion")
+}
+
+// ---- Conversion de errores de chumsky a Diagnostic ------------------
+
+fn parse_error_to_diagnostic(err: ParseErr) -> Diagnostic {
+    let span = err.span();
+
+    let msg = match err.reason() {
+        chumsky::error::SimpleReason::Unexpected => {
+            if let Some(found) = err.found() {
+                format!("token inesperado: {:?}", found)
+            } else {
+                "fin de archivo inesperado".to_owned()
+            }
+        }
+        chumsky::error::SimpleReason::Unclosed { span: _, delimiter } => {
+            format!("delimitador sin cerrar: {:?}", delimiter)
+        }
+        chumsky::error::SimpleReason::Custom(msg) => msg.clone(),
+    };
+
+    let expected_tokens: Vec<_> = err
+        .expected()
+        .filter_map(|e| e.as_ref())
+        .map(|t| format!("{t:?}"))
+        .collect();
+
+    let hint = if !expected_tokens.is_empty() {
+        Some(format!(
+            "se esperaba uno de: {}",
+            expected_tokens.join(", ")
+        ))
+    } else {
+        None
+    };
+
+    let mut d = Diagnostic::parse_error(span, msg);
+    d.hint = hint;
+    d
+}
+
+// ---- Tests ----------------------------------------------------------
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::lexer::tokenize;
+
+    fn parse(src: &str) -> (Option<Schema>, Vec<Diagnostic>) {
+        let (tokens, lex_errors) = tokenize(src);
+        let mut diagnostics: Vec<Diagnostic> =
+            lex_errors.into_iter().map(Diagnostic::lex_error).collect();
+        let (ast, parse_diags) = parse_tokens(tokens, src.len());
+        diagnostics.extend(parse_diags);
+        (ast, diagnostics)
+    }
+
+    #[test]
+    fn empty_schema_parses() {
+        let (ast, diags) = parse("");
+        assert!(ast.is_some());
+        assert!(diags.is_empty());
+        assert!(ast.unwrap().models.is_empty());
+    }
+
+    #[test]
+    fn simple_model_no_errors() {
+        let src = r#"
+model User {
+    id    UUID   @primary @auto
+    email String @unique
+    name  String
+}
+"#;
+        let (ast, diags) = parse(src);
+        assert!(
+            diags.iter().all(|d| !d.is_error()),
+            "parse errors: {diags:?}"
+        );
+        let schema = ast.expect("should produce AST");
+        assert_eq!(schema.models.len(), 1);
+        let model = &schema.models[0];
+        assert_eq!(model.name.value, "User");
+        assert_eq!(model.fields.len(), 3);
+        assert_eq!(model.fields[0].name.value, "id");
+        assert_eq!(model.fields[0].ty.value, FieldType::Uuid);
+        assert_eq!(model.fields[1].name.value, "email");
+        assert_eq!(model.fields[2].name.value, "name");
+    }
+
+    #[test]
+    fn annotations_parsed_correctly() {
+        let src = r#"
+model Item {
+    id    UUID @primary @auto
+    score Int  @unique @default(0)
+    active Bool @default(true)
+}
+"#;
+        let (ast, diags) = parse(src);
+        assert!(diags.iter().all(|d| !d.is_error()), "{diags:?}");
+        let model = &ast.unwrap().models[0];
+        let id_field = &model.fields[0];
+        assert!(id_field
+            .annotations
+            .iter()
+            .any(|a| a.value == Annotation::Primary));
+        assert!(id_field
+            .annotations
+            .iter()
+            .any(|a| a.value == Annotation::Auto));
+
+        let score_field = &model.fields[1];
+        let has_default_0 = score_field
+            .annotations
+            .iter()
+            .any(|a| a.value == Annotation::Default(DefaultValue::Int(0)));
+        assert!(has_default_0);
+    }
+
+    #[test]
+    fn optional_field_parsed() {
+        let src = r#"
+model Profile {
+    id  UUID   @primary @auto
+    bio String?
+}
+"#;
+        let (ast, diags) = parse(src);
+        assert!(diags.iter().all(|d| !d.is_error()), "{diags:?}");
+        let model = &ast.unwrap().models[0];
+        assert!(!model.fields[0].optional);
+        assert!(model.fields[1].optional);
+    }
+
+    #[test]
+    fn config_block_parsed() {
+        let src = r#"
+config {
+    project_name "mi-api"
+    database "postgres"
+}
+"#;
+        let (ast, diags) = parse(src);
+        assert!(diags.iter().all(|d| !d.is_error()), "{diags:?}");
+        let config = ast.unwrap().config.expect("debe tener config");
+        assert_eq!(config.project_name.as_deref(), Some("mi-api"));
+        assert_eq!(config.database.as_deref(), Some("postgres"));
+    }
+
+    #[test]
+    fn multiple_models() {
+        let src = r#"
+model User {
+    id UUID @primary @auto
+}
+
+model Post {
+    id UUID @primary @auto
+}
+"#;
+        let (ast, diags) = parse(src);
+        assert!(diags.iter().all(|d| !d.is_error()), "{diags:?}");
+        assert_eq!(ast.unwrap().models.len(), 2);
+    }
+
+    #[test]
+    fn missing_brace_produces_error() {
+        let src = "model User { id UUID @primary @auto";
+        let (_, diags) = parse(src);
+        assert!(
+            diags.iter().any(|d| d.is_error()),
+            "should have parse error"
+        );
+    }
+}

--- a/crates/ag-dsl/src/semantic.rs
+++ b/crates/ag-dsl/src/semantic.rs
@@ -1,0 +1,270 @@
+//! Analisis semantico del AST del Anti-DSL.
+//!
+//! Valida invariantes que el parser no puede verificar por ser
+//! context-free: nombres duplicados, modelos sin campos, multiples
+//! @primary, uso de @auto en tipos que no lo soportan, etc.
+//! Produce diagnosticos de error y warning sin modificar el AST.
+
+use std::collections::HashMap;
+
+use crate::ast::{Annotation, FieldType, Schema};
+use crate::diagnostics::Diagnostic;
+
+/// Analiza el schema y retorna la lista de diagnosticos.
+///
+/// No modifica el AST. Los errores de severidad `Error` deben bloquear
+/// la generacion de codigo en la capa superior.
+pub fn analyze(schema: &Schema) -> Vec<Diagnostic> {
+    let mut diags = Vec::new();
+
+    check_duplicate_model_names(schema, &mut diags);
+
+    for model in &schema.models {
+        check_model_has_fields(model, &mut diags);
+        check_duplicate_field_names(model, &mut diags);
+        check_primary_key(model, &mut diags);
+        check_auto_type_compatibility(model, &mut diags);
+        check_auto_update_type_compatibility(model, &mut diags);
+    }
+
+    diags
+}
+
+fn check_duplicate_model_names(schema: &Schema, diags: &mut Vec<Diagnostic>) {
+    let mut seen: HashMap<&str, usize> = HashMap::new();
+    for model in &schema.models {
+        let name = model.name.value.as_str();
+        if let Some(first_span_start) = seen.get(name) {
+            diags.push(Diagnostic::semantic_error_with_hint(
+                model.name.span.clone(),
+                format!("nombre de modelo duplicado: '{name}'"),
+                format!("el primer 'model {name}' esta en el byte {first_span_start}"),
+            ));
+        } else {
+            seen.insert(name, model.name.span.start);
+        }
+    }
+}
+
+fn check_model_has_fields(model: &crate::ast::ModelDef, diags: &mut Vec<Diagnostic>) {
+    if model.fields.is_empty() {
+        diags.push(Diagnostic::semantic_error_with_hint(
+            model.span.clone(),
+            format!("el modelo '{}' no tiene campos", model.name.value),
+            "anade al menos un campo con su tipo",
+        ));
+    }
+}
+
+fn check_duplicate_field_names(model: &crate::ast::ModelDef, diags: &mut Vec<Diagnostic>) {
+    let mut seen: HashMap<&str, usize> = HashMap::new();
+    for field in &model.fields {
+        let name = field.name.value.as_str();
+        if let Some(first_start) = seen.get(name) {
+            diags.push(Diagnostic::semantic_error_with_hint(
+                field.name.span.clone(),
+                format!(
+                    "campo duplicado '{}' en el modelo '{}'",
+                    name, model.name.value
+                ),
+                format!("el primer campo '{name}' esta en el byte {first_start}"),
+            ));
+        } else {
+            seen.insert(name, field.name.span.start);
+        }
+    }
+}
+
+fn check_primary_key(model: &crate::ast::ModelDef, diags: &mut Vec<Diagnostic>) {
+    let primary_fields: Vec<_> = model
+        .fields
+        .iter()
+        .filter(|f| f.annotations.iter().any(|a| a.value == Annotation::Primary))
+        .collect();
+
+    if primary_fields.is_empty() {
+        diags.push(Diagnostic::warning(
+            model.span.clone(),
+            format!("el modelo '{}' no tiene campo @primary", model.name.value),
+        ));
+    } else if primary_fields.len() > 1 {
+        for field in &primary_fields[1..] {
+            diags.push(Diagnostic::semantic_error_with_hint(
+                field.name.span.clone(),
+                format!("el modelo '{}' tiene mas de un @primary", model.name.value),
+                "solo puede haber un campo @primary por modelo",
+            ));
+        }
+    }
+}
+
+fn check_auto_type_compatibility(model: &crate::ast::ModelDef, diags: &mut Vec<Diagnostic>) {
+    let auto_compatible = [FieldType::Uuid, FieldType::Int, FieldType::Timestamp];
+    for field in &model.fields {
+        let has_auto = field
+            .annotations
+            .iter()
+            .any(|a| a.value == Annotation::Auto);
+        if has_auto && !auto_compatible.contains(&field.ty.value) {
+            diags.push(Diagnostic::semantic_error_with_hint(
+                field.name.span.clone(),
+                format!(
+                    "@auto en el campo '{}' no es compatible con el tipo {:?}",
+                    field.name.value, field.ty.value
+                ),
+                "@auto solo es valido en campos UUID (uuid_generate_v4()), \
+                 Int (SERIAL/SEQUENCE) y Timestamp (NOW())",
+            ));
+        }
+    }
+}
+
+fn check_auto_update_type_compatibility(model: &crate::ast::ModelDef, diags: &mut Vec<Diagnostic>) {
+    for field in &model.fields {
+        let has_auto_update = field
+            .annotations
+            .iter()
+            .any(|a| a.value == Annotation::AutoUpdate);
+        if has_auto_update && field.ty.value != FieldType::Timestamp {
+            diags.push(Diagnostic::semantic_error_with_hint(
+                field.name.span.clone(),
+                format!(
+                    "@auto_update en el campo '{}' requiere tipo Timestamp",
+                    field.name.value
+                ),
+                "cambia el tipo del campo a Timestamp",
+            ));
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::lexer::tokenize;
+    use crate::parser::parse_tokens;
+
+    fn compile(src: &str) -> (Option<Schema>, Vec<Diagnostic>) {
+        let (tokens, lex_errors) = tokenize(src);
+        let mut diags: Vec<Diagnostic> =
+            lex_errors.into_iter().map(Diagnostic::lex_error).collect();
+        let (ast, parse_diags) = parse_tokens(tokens, src.len());
+        diags.extend(parse_diags);
+        if let Some(ref schema) = ast {
+            diags.extend(analyze(schema));
+        }
+        (ast, diags)
+    }
+
+    #[test]
+    fn valid_model_no_errors() {
+        let src = r#"
+model Product {
+    id    UUID   @primary @auto
+    name  String @unique
+    price Int
+}
+"#;
+        let (_, diags) = compile(src);
+        let errors: Vec<_> = diags.iter().filter(|d| d.is_error()).collect();
+        assert!(errors.is_empty(), "unexpected errors: {errors:?}");
+    }
+
+    #[test]
+    fn duplicate_model_name_is_error() {
+        let src = r#"
+model User { id UUID @primary @auto }
+model User { id UUID @primary @auto }
+"#;
+        let (_, diags) = compile(src);
+        assert!(
+            diags
+                .iter()
+                .any(|d| d.is_error() && d.message.contains("duplicado")),
+            "should report duplicate model error"
+        );
+    }
+
+    #[test]
+    fn duplicate_field_is_error() {
+        let src = r#"
+model User {
+    id   UUID @primary @auto
+    name String
+    name String
+}
+"#;
+        let (_, diags) = compile(src);
+        assert!(diags
+            .iter()
+            .any(|d| d.is_error() && d.message.contains("campo duplicado")),);
+    }
+
+    #[test]
+    fn model_without_primary_is_warning() {
+        let src = r#"
+model Tag {
+    name String
+}
+"#;
+        let (_, diags) = compile(src);
+        let has_warning = diags
+            .iter()
+            .any(|d| !d.is_error() && d.message.contains("@primary"));
+        assert!(has_warning, "should warn about missing @primary");
+    }
+
+    #[test]
+    fn multiple_primary_is_error() {
+        let src = r#"
+model BadModel {
+    id1 UUID @primary @auto
+    id2 UUID @primary @auto
+}
+"#;
+        let (_, diags) = compile(src);
+        assert!(diags
+            .iter()
+            .any(|d| d.is_error() && d.message.contains("mas de un @primary")),);
+    }
+
+    #[test]
+    fn auto_on_string_is_error() {
+        let src = r#"
+model Bad {
+    id   UUID   @primary @auto
+    name String @auto
+}
+"#;
+        let (_, diags) = compile(src);
+        assert!(
+            diags
+                .iter()
+                .any(|d| d.is_error() && d.message.contains("@auto")),
+            "should error on @auto with String type"
+        );
+    }
+
+    #[test]
+    fn auto_update_on_non_timestamp_is_error() {
+        let src = r#"
+model Bad {
+    id      UUID @primary @auto
+    counter Int  @auto_update
+}
+"#;
+        let (_, diags) = compile(src);
+        assert!(diags
+            .iter()
+            .any(|d| d.is_error() && d.message.contains("@auto_update")),);
+    }
+
+    #[test]
+    fn empty_model_is_error() {
+        let src = r#"model Empty {}"#;
+        let (_, diags) = compile(src);
+        assert!(diags
+            .iter()
+            .any(|d| d.is_error() && d.message.contains("no tiene campos")),);
+    }
+}

--- a/docs/pr-drafts/fase-3.md
+++ b/docs/pr-drafts/fase-3.md
@@ -1,0 +1,102 @@
+# feat(fase-3): compilador Anti-DSL v0.1 — lexer, parser, semantic, codegen y CLI
+
+## Resumen
+
+Implementacion completa del primer incremento de la Fase 3: el compilador
+`ag-dsl` pasa de skeleton vacio a un compilador funcional de extremo a extremo
+que soporta DSL v0.1 (modelos, tipos primitivos, anotaciones @primary/@unique/@auto).
+La CLI `ag` recibe tres comandos nuevos: `generate`, `schema lint`, `schema diff`.
+
+## Fase afectada
+
+Fase 3 — Anti-DSL alpha
+
+## Tipo de cambio
+
+- [x] Nueva feature
+- [ ] Bugfix
+- [ ] Refactor
+- [ ] Documentacion
+
+## Documentos relacionados
+
+- `docs/rfc/RFC-0003-librerias-compilador-ag-dsl.md` (criterio de entrada)
+- `docs/roadmap/STATUS.md` (fase 3 marcada como "En curso")
+- `docs/roadmap/fase-03-anti-dsl-alpha.md`
+- `docs/master/ANTI-GRAVITAL-Arquitectura-Tecnica.md` §7
+
+## Cambios principales
+
+### crates/ag-dsl
+
+- `src/lexer.rs`: Token enum con logos 0.14 (keywords, tipos, anotaciones v0.1,
+  literales, puntuacion). `tokenize()` separa tokens validos de errores de lex.
+- `src/ast.rs`: tipos del AST — Schema, Config, ModelDef, FieldDef, FieldType,
+  Annotation, DefaultValue, Spanned<T>.
+- `src/parser.rs`: schema_parser() con chumsky 0.9. Soporta config{} y model{},
+  campos con tipo, opcionalidad `?` y todas las anotaciones v0.1.
+- `src/semantic.rs`: validaciones — nombres duplicados, modelo sin campos, campo
+  @auto incompatible con tipo, @auto_update en no-Timestamp, multiples @primary.
+- `src/diagnostics.rs`: Diagnostic con Severity, span, mensaje y hint. Formato
+  legible linea:columna para el usuario.
+- `src/codegen/rust_gen.rs`: genera structs Rust con serde, CreateRequest, UpdateRequest.
+- `src/codegen/sql_gen.rs`: genera CREATE TABLE IF NOT EXISTS con PRIMARY KEY,
+  UNIQUE INDEX, BIGSERIAL, gen_random_uuid(), tipos SQL correctos.
+- `src/codegen/ts_gen.rs`: genera interfaces TypeScript con tipos precisos,
+  Create/Update interfaces.
+- `src/codegen/openapi_gen.rs`: genera OpenAPI 3.1 JSON con components/schemas,
+  required fields, format annotations.
+- `src/codegen/mod.rs`: generate() retorna GeneratedFiles (BTreeMap ruta->contenido).
+- `src/lib.rs`: API publica compile() y generate().
+- `Cargo.toml`: dependencias logos 0.14, chumsky 0.9, thiserror, serde_json.
+
+### crates/ag-cli
+
+- `ag generate [--schema] [--output]`: compila schema.ag y escribe 4 artefactos.
+- `ag schema lint [--schema]`: reporta errores y warnings del schema.
+- `ag schema diff <ref> [--schema]`: detecta cambios BREAKING vs additive.
+- `Cargo.toml`: añade ag-dsl como dependencia.
+
+### Workspace
+
+- `Cargo.toml`: añade logos 0.14, chumsky 0.9, ag-dsl al workspace.
+
+### Documentacion
+
+- `docs/rfc/RFC-0003-librerias-compilador-ag-dsl.md`: decision formal sobre stack
+  del compilador (criterio de entrada 3.1 de la Fase 3).
+- `docs/rfc/README.md`: RFC-0003 añadida a la tabla.
+- `docs/roadmap/STATUS.md`: Fase 3 marcada como "En curso", criterios de entrada
+  marcados, entregables y criterios de salida listados.
+
+## Plan de prueba
+
+- [x] `cargo test -p ag-dsl -p ag-cli`: 56 tests verdes (50 ag-dsl + 5 ag-cli + 1 doctest)
+- [x] `cargo clippy -p ag-dsl -p ag-cli --all-targets -- -D warnings`: limpio
+- [x] `cargo fmt --check`: limpio
+- [ ] `cargo audit`: pendiente (sin dependencias nuevas con CVEs conocidos)
+- [ ] `cargo deny`: pendiente
+- [ ] Test manual: crear schema.ag, ejecutar `ag generate`, verificar artefactos
+
+## Criterios de salida que avanza
+
+- [x] Criterio de entrada 3.1.3: RFC-0003 aceptada.
+- Primer entregable 3.2.1 (DSL v0.1) en progreso — lexer, parser, semantic y
+  codegen funcionales para modelos con tipos primitivos y anotaciones basicas.
+
+## Checklist final
+
+- [x] Pertenece a la fase correcta (Fase 3).
+- [x] Respeta la documentacion (RFC-0003, Arquitectura §7, Hoja de Ruta §3).
+- [x] No rompe arquitectura.
+- [x] No anade complejidad innecesaria (format! sobre askama/quote para v0.1).
+- [x] No crea dependencias circulares (ag-dsl no depende de ag-core).
+- [x] Compila.
+- [x] Pasa tests.
+- [x] Pasa fmt.
+- [x] Pasa clippy.
+- [ ] Pasa audit.
+- [ ] Tiene benchmarks (no aplica en este incremento).
+- [x] Tiene documentacion (rustdoc en todos los modulos publicos).
+- [x] Tiene manejo de errores correcto (pipeline lex->parse->semantic->Diagnostic).
+- [x] Mantiene coherencia con Anti-Gravital v4.0.

--- a/docs/rfc/README.md
+++ b/docs/rfc/README.md
@@ -67,3 +67,4 @@ como `superseded`.
 | --- | --- | --- | --- |
 | 0001 | Paralelizar puertas externas de Fase 0 con implementacion de Fase 1 | aceptado | `RFC-0001-paralelizar-fase-0-externa-y-fase-1.md` |
 | 0002 | Diseno del Shield MVP (Fase 1) | aceptado | `RFC-0002-diseno-shield-mvp.md` |
+| 0003 | Librerias base del compilador ag-dsl (Fase 3) | aceptado | `RFC-0003-librerias-compilador-ag-dsl.md` |

--- a/docs/rfc/RFC-0003-librerias-compilador-ag-dsl.md
+++ b/docs/rfc/RFC-0003-librerias-compilador-ag-dsl.md
@@ -1,0 +1,354 @@
+# RFC-0003 - Librerias base del compilador ag-dsl
+
+- Estado: aceptado
+- Autor: Angel Nereira (BDFL inicial)
+- Fecha de borrador: 2026-05-21
+- Fecha de aceptacion: 2026-05-21
+- Fase objetivo: Fase 3
+- Modulos o crates afectados: `ag-dsl`, `ag-cli`
+- RFC predecesora: RFC-0002 (Shield MVP)
+- Periodo de comentarios: omitido por decision del BDFL en modo solo
+
+## 1. Motivacion
+
+La Hoja de Ruta v4.0 §3.1 fija como criterio de entrada de Fase 3 la
+decision formal sobre las librerias base del compilador del DSL,
+documentada en RFC. Esta RFC cumple ese requisito y fija las decisiones
+tecnicas que gobiernan la implementacion de `ag-dsl` desde v0.1 hasta
+v0.4, y el esqueleto de la infraestructura que soportara v0.5 a v1.0.
+
+La decision es irreversible en el corto plazo: cambiar el stack del
+compilador a mitad de la Fase 3 exigiria reescribir el crate completo
+y desestabilizar las herramientas derivadas (LSP, VS Code plugin).
+
+## 2. Problema
+
+El compilador del DSL requiere cuatro componentes con interfaces bien
+definidas:
+
+1. **Lexer**: tokeniza el texto fuente `.ag` en tokens con informacion
+   de span (linea/columna). Debe ser rapido y producir mensajes de
+   error utiles cuando encuentra caracteres no esperados.
+
+2. **Parser**: toma el stream de tokens y produce un AST. Debe
+   recuperarse de errores (error recovery) para reportar multiples
+   problemas en una sola pasada, no solo el primero. Los mensajes de
+   error deben ser legibles por un desarrollador que no conoce el
+   compilador.
+
+3. **Codegen textual** (TypeScript, SQL, OpenAPI, Dart): produce archivos
+   de texto a partir del AST validado. Debe ser auditabe, predecible y
+   facil de mantener. Los artefactos generados no deben sorprender al
+   usuario.
+
+4. **Codegen Rust** (structs con serde, query builders): produce codigo
+   Rust idiomatico. Las opciones son: generacion de texto plano
+   (misma estrategia que el resto) o generacion via AST de Rust con
+   `quote`/`proc-macro2` (codigo mas idiomatico, verificable a nivel
+   de tokens).
+
+Las alternativas son: construir cada componente desde cero, o usar
+librerias establecidas del ecosistema Rust.
+
+## 3. Alternativas consideradas
+
+### 3.1 Lexer: logos vs nom vs manual
+
+**logos**: genera el lexer a partir de un enum con derive macros
+(`#[derive(Logos)]`). Cada variante se anota con `#[token(...)]`
+para literales o `#[regex(...)]` para patrones. Produce automatas
+finitos deterministicos (DFA) eficientes. Es la libreria mas popular
+para lexers en el ecosistema Rust moderno.
+
+Pros: codigo declarativo, rapido, mantenido activamente, usado en
+produccion por proyectos como `rome`/`biome`. El enum de tokens es
+directamente legible como documentacion de la gramatica.
+
+Contras: genera codigo en tiempo de compilacion (macro expand), lo
+que ralentiza el primer build.
+
+**nom**: parser combinator que se puede usar como lexer.
+Pros: una sola dependencia para lexer y parser.
+Contras: diseñado para parsing binario/texto estructurado, no para
+lenguajes de programacion con keywords, indentacion y operadores.
+Los errores son verbosos y dificiles de humanizar.
+
+**Manual**: escribir el lexer a mano como una maquina de estados.
+Pros: control total. Contras: cientos de lineas de codigo repetitivo,
+propenso a bugs en los casos borde (escapes en strings, comentarios
+anidados). No se justifica cuando logos resuelve el problema.
+
+Se elige **logos**.
+
+### 3.2 Parser: chumsky vs lalrpop vs pest vs manual
+
+**chumsky 0.9**: parser combinator con soporte nativo de error recovery.
+`parse_recovery()` produce un AST parcial incluso en presencia de
+errores, permitiendo reportar multiples problemas en una sola pasada.
+La API de combinadores (`.then()`, `.or()`, `.repeated()`) es expresiva
+y el codigo resultante lee como la gramatica EBNF.
+
+Pros: error recovery nativo, mensajes de error con `.labelled()`,
+codigo legible, sin generacion de codigo externa. La feature `label`
+permite etiquetar combinadores para mensajes como "se esperaba un
+identificador".
+
+Contras: curva de aprendizaje pronunciada, especialmente para parsers
+recursivos. La version 0.9.x (stable) tiene API diferente a la 0.10
+(alpha). La eleccion 0.9.x se justifica por estabilidad.
+
+**lalrpop**: generador de parsers LALR(1) con gramatica en archivo
+separado. Pros: gramatica como fuente de verdad formal. Contras:
+genera codigo en tiempo de compilacion, los mensajes de error de
+LALR son poco amigables para el usuario, la gramatica del DSL es
+ambigua a nivel LALR (anotaciones opcionales al final de una linea
+sin separador). Descartado.
+
+**pest**: PEG parser con gramatica en archivo `.pest`.
+Pros: gramatica formal legible. Contras: no tiene error recovery,
+el CST que produce requiere una segunda pasada para construir el AST.
+Descartado.
+
+**Manual**: parser recursivo descendente escrito a mano.
+Pros: maximo control, potencialmente los mejores mensajes de error.
+Contras: implementar error recovery manualmente es costoso; el
+mantenimiento a largo plazo es significativamente mas alto que con
+una libreria establecida. Se puede reconsiderar en Fase 5+ si chumsky
+muestra limitaciones concretas.
+
+Se elige **chumsky 0.9** con la feature `label`.
+
+### 3.3 Codegen textual: askama vs minijinja vs format! macros
+
+**askama**: templates Jinja2 compilados en tiempo de compilacion.
+Los templates son archivos `.html`/`.txt`/`.rs` que el macro de
+askama incrusta y verifica en el build. Los errores de template se
+detectan al compilar ag-dsl, no en runtime.
+
+Pros: templates auditables en archivos dedicados, verificacion en
+compilacion, soporte de herencia y bloques.
+
+Contras: añade complejidad al build (requiere archivos de template
+en `templates/`), la API de datos es estaticamente tipada (struct
+de contexto), la curva de aprendizaje es moderada.
+
+**minijinja**: runtime Jinja2. Pros: templates dinamicos.
+Contras: errores en runtime, sin verificacion estatica.
+
+**format! macros**: generacion de texto con macros de la stdlib.
+Pros: sin dependencias adicionales, el codigo generado esta inline
+en el generador, maximo control sobre el formato. Contras: para
+templates grandes se vuelve verboso y dificil de leer.
+
+**Decision para v0.1**: se usan `format!` macros para los cuatro
+generadores (Rust, SQL, TypeScript, OpenAPI). Los templates son
+simples en v0.1 (structs basicos, tablas con columnas primitivas).
+Cuando los generadores crezcan en v0.2-v0.4 (endpoints, validaciones,
+relaciones), se evalua la migracion a `askama`. Este documento
+registra esa transicion pendiente como deuda tecnica planificada,
+no como deuda tecnica accidental.
+
+Se decide **format! macros para v0.1**, con transicion a **askama**
+a partir de v0.2 si la complejidad de los templates justifica el cambio.
+Esta decision se revisara en RFC-0004.
+
+### 3.4 Codegen Rust: format! texto vs quote + proc-macro2
+
+**format! texto**: el generador Rust produce el codigo fuente como
+un `String`. El codigo resultante es legible, pero no hay garantia
+de que sea Rust valido hasta que el usuario lo compila.
+
+**quote + proc-macro2**: la crate `quote!` permite construir
+`TokenStream` de Rust (el AST de tokens que usa el compilador).
+Combinada con `prettyplease` para formateo, produce codigo Rust
+idiomatico verificable a nivel de tokens.
+
+Pros de quote: el codigo generado puede verificarse programaticamente,
+no hay riesgo de generar un identificador invalido o un tipo
+desconocido.
+
+Contras de quote: `quote` es una libreria de proc-macros; su uso
+fuera de un contexto de proc-macro es posible pero inusual. La curva
+de aprendizaje es mayor que `format!`.
+
+**Decision para v0.1**: se usa `format!` texto para el generador Rust.
+La prioridad en v0.1 es tener un pipeline funcional de extremo a
+extremo. La migracion a `quote` + `prettyplease` se programa para
+v0.3 cuando el generador Rust manejara validadores, query builders y
+codigo mas complejo.
+
+## 4. Diseno propuesto
+
+### 4.1 Stack de dependencias de ag-dsl
+
+| Crate | Version | Feature | Proposito |
+| --- | --- | --- | --- |
+| `logos` | 0.14 | default | Lexer generado por derive macro |
+| `chumsky` | 0.9 | default | Parser combinator con error recovery (`.labelled()` disponible sin feature extra) |
+| `thiserror` | 1 | workspace | Tipos de error derivados |
+| `serde_json` | 1 | workspace | Serializacion OpenAPI v0.1 |
+
+Dependencias postergadas (se añaden cuando se justifica su uso):
+
+| Crate | Fase estimada | Motivo |
+| --- | --- | --- |
+| `askama` | v0.2 codegen | Templates para generadores complejos |
+| `quote` + `proc-macro2` | v0.3 codegen | Generacion de TokenStream Rust |
+| `prettyplease` | v0.3 codegen | Formateo del codigo Rust generado |
+| `tower-lsp` | LSP | Servidor LSP para editores |
+
+### 4.2 Arquitectura del pipeline de compilacion
+
+```
+texto .ag
+    |
+    v  [lexer.rs — logos]
+Vec<(Token, Span)> + Vec<LexError>
+    |
+    v  [parser.rs — chumsky 0.9]
+Option<Schema> + Vec<ParseError>
+    |
+    v  [semantic.rs]
+Vec<SemanticError>
+    |
+    v  [diagnostics.rs — unificacion de errores]
+Result<Schema, Vec<Diagnostic>>
+    |
+    v  [codegen/*.rs — format! macros v0.1]
+GeneratedFiles { rust, sql, typescript, openapi }
+```
+
+### 4.3 Versiones del DSL cubiertas en Fase 3
+
+Esta RFC autoriza la implementacion hasta DSL v0.4.
+Cada subversion extiende la anterior sin romper compatibilidad:
+
+- v0.1: modelos, tipos primitivos, anotaciones @primary/@unique/@auto
+- v0.2: endpoints, request/response, errors
+- v0.3: validaciones en campos (@min, @max, @email, @regex, @length)
+- v0.4: relaciones entre modelos (1:1, 1:N, N:M)
+
+Las versiones v0.5 a v1.0 requieren RFC separadas.
+
+### 4.4 Modulo ag-dsl: estructura de archivos
+
+```
+crates/ag-dsl/
+  Cargo.toml
+  src/
+    lib.rs            compilar() y generar() como API publica
+    lexer.rs          Token (logos), tokenize()
+    ast.rs            tipos AST: Schema, ModelDef, FieldDef, etc.
+    parser.rs         schema_parser() (chumsky 0.9)
+    semantic.rs       analyze(): validacion semantica
+    diagnostics.rs    Diagnostic, Severity
+    codegen/
+      mod.rs          GeneratedFiles, generate()
+      rust_gen.rs     -> src/models.rs (Rust structs)
+      sql_gen.rs      -> migrations/NNNN_initial.sql
+      ts_gen.rs       -> clients/typescript/types.ts
+      openapi_gen.rs  -> openapi.json (OpenAPI 3.1)
+  tests/
+    v01_models.rs     tests de integracion DSL v0.1
+```
+
+### 4.5 API publica de ag-dsl
+
+```rust
+/// Compila un texto fuente DSL. Retorna el schema si no hay errores de
+/// error severity. Los warnings se incluyen en el Ok si los hay.
+pub fn compile(source: &str) -> Result<Schema, Vec<Diagnostic>>;
+
+/// Genera artefactos a partir de un schema compilado.
+pub fn generate(schema: &Schema) -> GeneratedFiles;
+
+/// Coleccion de artefactos generados indexados por ruta relativa.
+pub struct GeneratedFiles {
+    pub files: std::collections::BTreeMap<PathBuf, String>,
+}
+```
+
+## 5. Plan de implementacion
+
+Los PRs implementan el pipeline capa por capa. Cada PR incluye tests,
+fmt y clippy. Los PRs de Fase 3 van a la rama `fase-3`.
+
+1. RFC-0003 + inicializacion ag-dsl: Cargo.toml, estructura modulos,
+   dependencias. No hay codigo funcional todavia.
+2. Lexer v0.1: Token enum con logos, funcion tokenize(), tests unitarios.
+3. AST v0.1: tipos Schema, ModelDef, FieldDef, anotaciones.
+4. Parser v0.1: schema_parser() con chumsky, parse model definitions.
+5. Semantic analysis v0.1: resolucion de nombres, tipos validos.
+6. Diagnostics: Diagnostic, Severity, formateo de mensajes.
+7. Codegen Rust v0.1: generate structs con serde.
+8. Codegen SQL v0.1: CREATE TABLE idempotente.
+9. Codegen TypeScript v0.1: interfaces tipadas.
+10. Codegen OpenAPI v0.1: components/schemas.
+11. Tests de integracion v0.1: golden tests con schemas reales.
+12. Comando ag generate en ag-cli.
+13. DSL v0.2: endpoints, request/response, errors.
+14. DSL v0.3: validaciones.
+15. DSL v0.4: relaciones.
+16. ag schema lint.
+17. ag schema diff.
+18. ag-lsp basico.
+19. Fuzzing con cargo-fuzz.
+20. Documentacion de referencia del DSL.
+
+## 6. Riesgos
+
+- **chumsky 0.9 vs 0.10**: la API 0.9 es estable pero 0.10 se acerca
+  a stable. Si 0.10 se publica antes de que terminemos Fase 3, se
+  evaluara la migracion en RFC-0004. No migramos durante Fase 3 para
+  evitar inestabilidad.
+
+- **logos y macros de expansion**: el build inicial puede ser lento en
+  maquinas con poco hardware. Mitigacion: memoizacion de build artifacts
+  con sccache en CI.
+
+- **Mensajes de error del compilador**: la calidad de los mensajes es
+  critica para DX. Mitigacion: tests dedicados que verifican el texto
+  exacto del mensaje de error para los casos mas comunes.
+
+- **Complejidad del codegen en v0.4**: las relaciones (1:N, N:M) generan
+  JOINs, foreign keys y tipos adicionales. Puede justificar la migracion
+  a askama antes del fin de Fase 3. Se abre RFC-0004 si ocurre.
+
+## 7. Impacto
+
+- Sobre el alcance: ninguno; dentro del perimetro de Fase 3.
+- Sobre cronograma: 3 meses estimados, consistente con la Hoja de Ruta.
+- Sobre dependencias: añade logos y chumsky al workspace.
+- Sobre la API publica: define la primera API del crate ag-dsl.
+- Sobre la documentacion: requiere actualizacion de
+  `docs/architecture/07-anti-dsl.md` a medida que avanza.
+
+## 8. Rollback
+
+Si logos o chumsky demuestran limitaciones concretas durante la
+implementacion (por ejemplo: rendimiento del lexer inaceptable, o
+mensajes de error de chumsky insuficientes para DX objetivo):
+
+1. Se abre RFC-0004 con la alternativa propuesta.
+2. Se suspende la implementacion de ag-dsl en la rama `fase-3`.
+3. Se revierte al skeleton Fase 0 de ag-dsl.
+4. Se implementa la alternativa en una rama separada con PR de RFC-0004.
+
+## 9. Decision
+
+Aceptada por el BDFL inicial en modo solo.
+Fecha de decision: 2026-05-21.
+
+Stack definitivo para Fase 3:
+- Lexer: logos 0.14
+- Parser: chumsky 0.9 con feature `label`
+- Codegen v0.1: format! macros
+- Codegen v0.2+: transicion a askama (evaluada en RFC-0004)
+- Codegen Rust v0.3+: transicion a quote + prettyplease (evaluada en RFC-0004)
+
+## 10. Referencias
+
+- `docs/master/ANTI-GRAVITAL-Hoja-de-Ruta.md` §3.1 (criterios de entrada Fase 3)
+- `docs/master/ANTI-GRAVITAL-Arquitectura-Tecnica.md` §7 (arquitectura del DSL)
+- `docs/roadmap/fase-03-anti-dsl-alpha.md`
+- RFC-0002 (Shield MVP)

--- a/docs/roadmap/STATUS.md
+++ b/docs/roadmap/STATUS.md
@@ -192,7 +192,47 @@ mas potente o pgbouncer. Criterios externos de comunidad pendientes.
 
 ## Fase 3 - Anti-DSL alpha
 
-Estado: Pendiente. Vease `docs/roadmap/fase-03-anti-dsl-alpha.md`.
+Estado: En curso. Iniciada 2026-05-21 en rama `fase-3`.
+RFC-0003 aceptada. Stack fijado: logos 0.14 (lexer), chumsky 0.9 (parser),
+format! macros v0.1 (codegen). Implementacion incremental v0.1 -> v0.4.
+
+### Criterios de entrada (3.1)
+
+- [/] Fase 2 completada. (Excepcion RFC-0001: implementacion tecnica completa;
+  criterios externos pendientes.)
+- [x] Crate `ag-dsl` iniciado. Skeleton Fase 0 presente.
+- [x] Decision final sobre librerias base del compilador. Documentada en
+  `docs/rfc/RFC-0003-librerias-compilador-ag-dsl.md`. Aceptada 2026-05-21.
+
+### Entregables (3.2)
+
+- [ ] DSL version 0.1: modelos basicos (@primary, @unique, @auto).
+- [ ] DSL version 0.2: endpoints (metodo, path, body, response).
+- [ ] DSL version 0.3: validaciones (@min, @max, @email, @regex, @length).
+- [ ] DSL version 0.4: relaciones entre modelos (1:1, 1:N, N:M).
+- [ ] Generador Rust: structs con serde.
+- [ ] Generador SQL: migraciones idempotentes.
+- [ ] Generador TypeScript: tipos y cliente HTTP.
+- [ ] Generador OpenAPI 3.1.
+- [ ] Comando ag generate.
+- [ ] Comando ag schema lint.
+- [ ] Comando ag schema diff.
+- [ ] Diagnostics legibles.
+- [ ] Servidor LSP basico (ag-lsp).
+- [ ] Plugin VS Code.
+- [ ] Cobertura tests >= 85%.
+- [ ] Fuzzing 24h sin crashes.
+- [ ] Documentacion de referencia del DSL.
+
+### Criterios de salida (3.3)
+
+- [ ] Proyecto completo definible en schema.ag, generado y ejecutable con CLI.
+- [ ] Example ecommerce-api reescrito con DSL.
+- [ ] CRUD generado por DSL no es mas lento que CRUD a mano.
+- [ ] Plugin VS Code >= 100 instalaciones.
+- [ ] Al menos un colaborador externo contribuyo al compilador.
+- [ ] Documentacion DSL revisada por dos personas.
+- [ ] Al menos 200 stars.
 
 ## Fase 4 - Modulos estandar
 


### PR DESCRIPTION
# feat(fase-3): compilador Anti-DSL v0.1 — lexer, parser, semantic, codegen y CLI

## Resumen

Implementacion completa del primer incremento de la Fase 3: el compilador
`ag-dsl` pasa de skeleton vacio a un compilador funcional de extremo a extremo
que soporta DSL v0.1 (modelos, tipos primitivos, anotaciones @primary/@unique/@auto).
La CLI `ag` recibe tres comandos nuevos: `generate`, `schema lint`, `schema diff`.

## Fase afectada

Fase 3 — Anti-DSL alpha

## Tipo de cambio

- [x] Nueva feature
- [ ] Bugfix
- [ ] Refactor
- [ ] Documentacion

## Documentos relacionados

- `docs/rfc/RFC-0003-librerias-compilador-ag-dsl.md` (criterio de entrada)
- `docs/roadmap/STATUS.md` (fase 3 marcada como "En curso")
- `docs/roadmap/fase-03-anti-dsl-alpha.md`
- `docs/master/ANTI-GRAVITAL-Arquitectura-Tecnica.md` §7

## Cambios principales

### crates/ag-dsl

- `src/lexer.rs`: Token enum con logos 0.14 (keywords, tipos, anotaciones v0.1,
  literales, puntuacion). `tokenize()` separa tokens validos de errores de lex.
- `src/ast.rs`: tipos del AST — Schema, Config, ModelDef, FieldDef, FieldType,
  Annotation, DefaultValue, Spanned<T>.
- `src/parser.rs`: schema_parser() con chumsky 0.9. Soporta config{} y model{},
  campos con tipo, opcionalidad `?` y todas las anotaciones v0.1.
- `src/semantic.rs`: validaciones — nombres duplicados, modelo sin campos, campo
  @auto incompatible con tipo, @auto_update en no-Timestamp, multiples @primary.
- `src/diagnostics.rs`: Diagnostic con Severity, span, mensaje y hint. Formato
  legible linea:columna para el usuario.
- `src/codegen/rust_gen.rs`: genera structs Rust con serde, CreateRequest, UpdateRequest.
- `src/codegen/sql_gen.rs`: genera CREATE TABLE IF NOT EXISTS con PRIMARY KEY,
  UNIQUE INDEX, BIGSERIAL, gen_random_uuid(), tipos SQL correctos.
- `src/codegen/ts_gen.rs`: genera interfaces TypeScript con tipos precisos,
  Create/Update interfaces.
- `src/codegen/openapi_gen.rs`: genera OpenAPI 3.1 JSON con components/schemas,
  required fields, format annotations.
- `src/codegen/mod.rs`: generate() retorna GeneratedFiles (BTreeMap ruta->contenido).
- `src/lib.rs`: API publica compile() y generate().
- `Cargo.toml`: dependencias logos 0.14, chumsky 0.9, thiserror, serde_json.

### crates/ag-cli

- `ag generate [--schema] [--output]`: compila schema.ag y escribe 4 artefactos.
- `ag schema lint [--schema]`: reporta errores y warnings del schema.
- `ag schema diff <ref> [--schema]`: detecta cambios BREAKING vs additive.
- `Cargo.toml`: añade ag-dsl como dependencia.

### Workspace

- `Cargo.toml`: añade logos 0.14, chumsky 0.9, ag-dsl al workspace.

### Documentacion

- `docs/rfc/RFC-0003-librerias-compilador-ag-dsl.md`: decision formal sobre stack
  del compilador (criterio de entrada 3.1 de la Fase 3).
- `docs/rfc/README.md`: RFC-0003 añadida a la tabla.
- `docs/roadmap/STATUS.md`: Fase 3 marcada como "En curso", criterios de entrada
  marcados, entregables y criterios de salida listados.

## Plan de prueba

- [x] `cargo test -p ag-dsl -p ag-cli`: 56 tests verdes (50 ag-dsl + 5 ag-cli + 1 doctest)
- [x] `cargo clippy -p ag-dsl -p ag-cli --all-targets -- -D warnings`: limpio
- [x] `cargo fmt --check`: limpio
- [ ] `cargo audit`: pendiente (sin dependencias nuevas con CVEs conocidos)
- [ ] `cargo deny`: pendiente
- [ ] Test manual: crear schema.ag, ejecutar `ag generate`, verificar artefactos

## Criterios de salida que avanza

- [x] Criterio de entrada 3.1.3: RFC-0003 aceptada.
- Primer entregable 3.2.1 (DSL v0.1) en progreso — lexer, parser, semantic y
  codegen funcionales para modelos con tipos primitivos y anotaciones basicas.

## Checklist final

- [x] Pertenece a la fase correcta (Fase 3).
- [x] Respeta la documentacion (RFC-0003, Arquitectura §7, Hoja de Ruta §3).
- [x] No rompe arquitectura.
- [x] No anade complejidad innecesaria (format! sobre askama/quote para v0.1).
- [x] No crea dependencias circulares (ag-dsl no depende de ag-core).
- [x] Compila.
- [x] Pasa tests.
- [x] Pasa fmt.
- [x] Pasa clippy.
- [ ] Pasa audit.
- [ ] Tiene benchmarks (no aplica en este incremento).
- [x] Tiene documentacion (rustdoc en todos los modulos publicos).
- [x] Tiene manejo de errores correcto (pipeline lex->parse->semantic->Diagnostic).
- [x] Mantiene coherencia con Anti-Gravital v4.0.
