### PR TITLE
Fase 3

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -910,6 +910,39 @@ en mensajes de commit, ni en titulos de PR, ni en issues, ni en
 plantillas. Los iconos se manejan como SVG o glifos tipograficos cuando
 sea estrictamente necesario.
 
+### Sincronizacion obligatoria del README
+
+El `README.md` es la ventana publica del proyecto. Cualquier cambio que
+altere el estado observable del proyecto debe actualizar el README en el
+mismo commit o PR. No se acepta un README desfasado de la realidad.
+
+Cambia que obligan a actualizar el README de forma inmediata:
+
+- Avance de fase o cambio del estado de una fase (de "proxima" a "en
+  curso", de "en curso" a "completada", etc.).
+- Nuevo comando de la CLI operativo (`ag generate`, `ag schema lint`, etc.).
+- Nueva version del DSL implementada (v0.1, v0.2, v0.3...).
+- Nuevo crate publicado o promovido a estado funcional.
+- Nuevo ejemplo disponible en `examples/`.
+- Nuevos benchmarks medidos en hardware real.
+- Cambio en los requisitos de instalacion (version minima de Rust,
+  nueva dependencia de sistema, etc.).
+- Cualquier cambio que haga que la seccion "Estado del proyecto" o
+  la tabla "Calendario" queden incorrectos.
+
+Que NO requiere actualizar el README:
+
+- Correcciones de bugs internos sin efecto en la API publica.
+- Mejoras de tests, cobertura o CI.
+- Cambios en documentacion tecnica interna (`docs/architecture/`, `docs/adr/`, etc.).
+- Actualizaciones de dependencias sin cambio de comportamiento visible.
+
+El README se actualiza en el mismo commit que el cambio que lo provoca.
+Nunca en un commit separado posterior. Nunca "lo actualizo despues".
+
+Un README que dice "Fase 3 proxima" cuando el codigo ya implementa el
+compilador DSL es una mentira tecnica y viola esta regla.
+
 ### Cierre
 
 Esta es la constitucion tecnica del repositorio. Primero documentacion,

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # Anti-Gravital
 
-> Estado: Fase 2 completada (implementacion tecnica). Fase 3 — Anti-DSL alpha, proxima.
-> Status: Phase 2 complete (technical implementation). Phase 3 — Anti-DSL alpha, next.
+> Estado: Fase 3 en curso — Anti-DSL alpha. DSL v0.1 (modelos) y v0.2 (endpoints) operativos.
+> Status: Phase 3 in progress — Anti-DSL alpha. DSL v0.1 (models) and v0.2 (endpoints) operational.
 
 Anti-Gravital es un ecosistema de software libre para construir
 aplicaciones backend de alto rendimiento en Rust puro, con tres
@@ -56,8 +56,12 @@ CRUD con PostgreSQL 14.5K req/s de lectura (cuello de botella en PG,
 no en el framework). Los criterios de throughput y latencia de la fase
 (40K req/s, p99 <= 5 ms) requieren hardware con mas nucleos o pgbouncer.
 
-**Fase 3 — Anti-DSL alpha:** proxima. El DSL genera codigo Rust, SQL,
-migraciones y OpenAPI desde archivos `.ag`.
+**Fase 3 — Anti-DSL alpha:** en curso (rama `fase-3`). El compilador
+`ag-dsl` esta operativo con DSL v0.1 y v0.2. Define modelos, endpoints,
+tipos de peticion y respuesta en un archivo `.ag` y genera
+automaticamente structs Rust con serde, migraciones SQL, interfaces
+TypeScript, un cliente HTTP tipado y documentacion OpenAPI 3.1 completa.
+La CLI expone `ag generate`, `ag schema lint` y `ag schema diff`.
 
 El estado detallado de cada criterio vive en `docs/roadmap/STATUS.md`.
 
@@ -86,6 +90,53 @@ Para el ejemplo completo CRUD con PostgreSQL:
 ```sh
 export DATABASE_URL="postgresql://usuario:clave@localhost/mi_db"
 cargo run -p todo-api
+```
+
+**Flujo DSL (Fase 3, operativo desde v0.1+v0.2):**
+
+Define tu API en un archivo `schema.ag`:
+
+```ag
+config {
+    project_name "mi-api"
+    database "postgres"
+}
+
+model User {
+    id    UUID   @primary @auto
+    email String @unique
+    name  String
+}
+
+request CreateUserRequest { email String  name String }
+response UserResponse     { id UUID  email String  name String }
+error EmailTaken { status 409 message "Email ya registrado" }
+
+endpoint CreateUser {
+    method   POST
+    path     /users
+    body     CreateUserRequest
+    response UserResponse
+    errors   [EmailTaken]
+}
+```
+
+Genera todos los artefactos con un comando:
+
+```sh
+ag generate --schema schema.ag --output ./generated
+```
+
+Produce: `src/models.rs`, `src/types.rs`, `src/handlers.rs`,
+`src/router.rs`, `migrations/0001_initial.sql`,
+`clients/typescript/types.ts`, `clients/typescript/client.ts`,
+`openapi.json`.
+
+Valida el schema sin generar:
+
+```sh
+ag schema lint --schema schema.ag
+ag schema diff schema-anterior.ag --schema schema.ag
 ```
 
 ### Rendimiento medido
@@ -182,8 +233,12 @@ CRUD with PostgreSQL 14.5K req/s reads (bottleneck is PostgreSQL,
 not the framework). Phase throughput and latency targets (40K req/s,
 p99 <= 5 ms) require hardware with more cores or pgbouncer.
 
-**Phase 3 — Anti-DSL alpha:** next. The DSL generates Rust code, SQL,
-migrations, and OpenAPI from `.ag` files.
+**Phase 3 — Anti-DSL alpha:** in progress (branch `fase-3`). The
+`ag-dsl` compiler is operational with DSL v0.1 and v0.2. Define models,
+endpoints, request and response types in a `.ag` file and automatically
+generate Rust structs with serde, SQL migrations, TypeScript interfaces,
+a typed HTTP client, and a full OpenAPI 3.1 document. The CLI exposes
+`ag generate`, `ag schema lint`, and `ag schema diff`.
 
 Detailed per-criterion status lives in `docs/roadmap/STATUS.md`.
 
@@ -212,6 +267,26 @@ For the full CRUD example with PostgreSQL:
 ```sh
 export DATABASE_URL="postgresql://user:pass@localhost/my_db"
 cargo run -p todo-api
+```
+
+**DSL workflow (Phase 3, operational since v0.1+v0.2):**
+
+Define your API in a `schema.ag` file and generate all artifacts:
+
+```sh
+ag generate --schema schema.ag --output ./generated
+```
+
+Produces: `src/models.rs`, `src/types.rs`, `src/handlers.rs`,
+`src/router.rs`, `migrations/0001_initial.sql`,
+`clients/typescript/types.ts`, `clients/typescript/client.ts`,
+`openapi.json`.
+
+Validate and diff schemas:
+
+```sh
+ag schema lint --schema schema.ag
+ag schema diff old-schema.ag --schema schema.ag
 ```
 
 ### Measured performance
@@ -276,7 +351,7 @@ maintainer: Angel Nereira.
 | 0            | Fundaciones y gobernanza      | En curso (externos pendientes) / In progress (externals pending) |
 | 1            | The Shield MVP                | Implementacion completa / Technical implementation complete |
 | 2            | The Core MVP                  | Implementacion completa / Technical implementation complete |
-| 3            | Anti-DSL alpha                | Proxima / Next                                          |
+| 3            | Anti-DSL alpha                | En curso / In progress — DSL v0.1+v0.2 operativos       |
 | 4            | Modulos estandar              | Pendiente / Pending                                     |
 | 5            | ag-cloud y version 0.5 beta   | Pendiente / Pending                                     |
 | 6            | ag-ai y Knowledge Graph       | Pendiente / Pending                                     |

--- a/crates/ag-dsl/src/ast.rs
+++ b/crates/ag-dsl/src/ast.rs
@@ -2,8 +2,8 @@
 //!
 //! Todas las construcciones del lenguaje se representan como nodos del AST.
 //! Los nodos clave llevan informacion de span para reportar errores precisos.
-//! En DSL v0.1 el AST cubre modelos, campos, tipos primitivos y anotaciones
-//! basicas (@primary, @unique, @auto, @auto_update, @default).
+//! En DSL v0.1–v0.2 el AST cubre modelos, request/response/error types,
+//! endpoints HTTP y anotaciones basicas.
 
 use crate::lexer::Span;
 
@@ -25,14 +25,21 @@ impl<T> Spanned<T> {
 
 /// Schema completo: punto de entrada del AST.
 ///
-/// En v0.1 contiene configuracion opcional y cero o mas modelos.
-/// Las versiones futuras añadiran endpoints, enums y eventos.
+/// Contiene configuracion, modelos (v0.1) y tipos de API + endpoints (v0.2).
 #[derive(Debug, Clone, Default)]
 pub struct Schema {
     /// Bloque `config { ... }` opcional.
     pub config: Option<Config>,
     /// Definiciones de modelo en orden de aparicion.
     pub models: Vec<ModelDef>,
+    /// Tipos de cuerpo de peticion: `request Nombre { ... }`.
+    pub requests: Vec<RequestDef>,
+    /// Tipos de cuerpo de respuesta: `response Nombre { ... }`.
+    pub responses: Vec<ResponseDef>,
+    /// Tipos de error HTTP: `error Nombre { status N message "..." }`.
+    pub errors: Vec<ErrorDef>,
+    /// Definiciones de endpoint: `endpoint Nombre { method path body response errors }`.
+    pub endpoints: Vec<EndpointDef>,
 }
 
 /// Bloque `config { ... }`.
@@ -186,4 +193,164 @@ impl std::fmt::Display for DefaultValue {
             DefaultValue::Ident(s) => write!(f, "'{s}'"),
         }
     }
+}
+
+// ============================================================
+// DSL v0.2 — API types y endpoints
+// ============================================================
+
+/// Definicion de tipo de cuerpo de peticion: `request Nombre { campos... }`.
+#[derive(Debug, Clone)]
+pub struct RequestDef {
+    /// Nombre del tipo con span.
+    pub name: Spanned<std::string::String>,
+    /// Campos del cuerpo de peticion.
+    pub fields: Vec<FieldDef>,
+    /// Span del bloque completo.
+    pub span: Span,
+}
+
+/// Definicion de tipo de cuerpo de respuesta: `response Nombre { campos... }`.
+#[derive(Debug, Clone)]
+pub struct ResponseDef {
+    /// Nombre del tipo con span.
+    pub name: Spanned<std::string::String>,
+    /// Campos del cuerpo de respuesta.
+    pub fields: Vec<FieldDef>,
+    /// Span del bloque completo.
+    pub span: Span,
+}
+
+/// Definicion de error HTTP: `error Nombre { status N message "texto" }`.
+#[derive(Debug, Clone)]
+pub struct ErrorDef {
+    /// Nombre del tipo de error con span.
+    pub name: Spanned<std::string::String>,
+    /// Codigo de estado HTTP (ej. 409, 422).
+    pub status: Spanned<u16>,
+    /// Mensaje legible para el cliente.
+    pub message: Spanned<std::string::String>,
+    /// Span del bloque completo.
+    pub span: Span,
+}
+
+/// Definicion de endpoint HTTP.
+///
+/// ```text
+/// endpoint CreateUser {
+///     method   POST
+///     path     /users
+///     body     CreateUserRequest
+///     response UserResponse
+///     errors   [EmailTaken, WeakPassword]
+/// }
+/// ```
+#[derive(Debug, Clone)]
+pub struct EndpointDef {
+    /// Nombre del endpoint con span.
+    pub name: Spanned<std::string::String>,
+    /// Metodo HTTP.
+    pub method: Spanned<HttpMethod>,
+    /// Path HTTP (ej. `/users/{id}`).
+    pub path: Spanned<std::string::String>,
+    /// Nombre del tipo de cuerpo de peticion (referencia a `RequestDef`).
+    pub body: Option<Spanned<std::string::String>>,
+    /// Nombre del tipo de respuesta (referencia a `ResponseDef`).
+    pub response: Option<Spanned<std::string::String>>,
+    /// Nombres de tipos de error (referencias a `ErrorDef`).
+    pub errors: Vec<Spanned<std::string::String>>,
+    /// Span del bloque completo.
+    pub span: Span,
+}
+
+/// Metodo HTTP soportado en DSL v0.2.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum HttpMethod {
+    /// HTTP GET — lectura.
+    Get,
+    /// HTTP POST — creacion.
+    Post,
+    /// HTTP PUT — reemplazo completo.
+    Put,
+    /// HTTP PATCH — actualizacion parcial.
+    Patch,
+    /// HTTP DELETE — eliminacion.
+    Delete,
+}
+
+impl HttpMethod {
+    /// Retorna la representacion textual del metodo en mayusculas.
+    pub fn as_str(&self) -> &'static str {
+        match self {
+            HttpMethod::Get => "GET",
+            HttpMethod::Post => "POST",
+            HttpMethod::Put => "PUT",
+            HttpMethod::Patch => "PATCH",
+            HttpMethod::Delete => "DELETE",
+        }
+    }
+}
+
+impl std::fmt::Display for HttpMethod {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.write_str(self.as_str())
+    }
+}
+
+/// Convierte un path DSL (`/users/{id}`) a formato Axum (`/users/:id`).
+pub fn dsl_path_to_axum(path: &str) -> std::string::String {
+    let mut result = std::string::String::new();
+    let mut chars = path.chars().peekable();
+    while let Some(ch) = chars.next() {
+        if ch == '{' {
+            result.push(':');
+            for inner in chars.by_ref() {
+                if inner == '}' {
+                    break;
+                }
+                result.push(inner);
+            }
+        } else {
+            result.push(ch);
+        }
+    }
+    result
+}
+
+/// Extrae los nombres de los parametros de path de un path DSL.
+///
+/// `/users/{id}/posts/{postId}` → `["id", "postId"]`
+pub fn extract_path_params(path: &str) -> Vec<std::string::String> {
+    let mut params = Vec::new();
+    let mut current = std::string::String::new();
+    let mut inside = false;
+    for ch in path.chars() {
+        match ch {
+            '{' => inside = true,
+            '}' => {
+                if !current.is_empty() {
+                    params.push(current.clone());
+                    current.clear();
+                }
+                inside = false;
+            }
+            c if inside => current.push(c),
+            _ => {}
+        }
+    }
+    params
+}
+
+/// Convierte PascalCase o camelCase a snake_case.
+///
+/// Usado para convertir nombres de endpoints/modelos a nombres de funcion Rust.
+pub fn to_snake_case(s: &str) -> std::string::String {
+    let mut result = std::string::String::with_capacity(s.len() + 4);
+    for (i, ch) in s.chars().enumerate() {
+        if ch.is_uppercase() && i > 0 {
+            result.push('_');
+        }
+        result.push(ch.to_lowercase().next().unwrap());
+    }
+    result
 }

--- a/crates/ag-dsl/src/codegen/mod.rs
+++ b/crates/ag-dsl/src/codegen/mod.rs
@@ -47,21 +47,49 @@ impl GeneratedFiles {
 pub fn generate(schema: &Schema) -> GeneratedFiles {
     let mut files = GeneratedFiles::default();
 
+    // v0.1: modelos DB
     files.insert(
         PathBuf::from("src/models.rs"),
         rust_gen::generate_models(schema),
     );
 
+    // v0.1: migracion SQL
     files.insert(
         PathBuf::from("migrations/0001_initial.sql"),
         sql_gen::generate_migration(schema),
     );
 
+    // v0.2: tipos API (request/response/error)
+    let types_rs = rust_gen::generate_types(schema);
+    if !types_rs.is_empty() {
+        files.insert(PathBuf::from("src/types.rs"), types_rs);
+    }
+
+    // v0.2: handler stubs
+    let handlers_rs = rust_gen::generate_handlers(schema);
+    if !handlers_rs.is_empty() {
+        files.insert(PathBuf::from("src/handlers.rs"), handlers_rs);
+    }
+
+    // v0.2: router Axum
+    let router_rs = rust_gen::generate_router(schema);
+    if !router_rs.is_empty() {
+        files.insert(PathBuf::from("src/router.rs"), router_rs);
+    }
+
+    // TypeScript: interfaces (v0.1+v0.2)
     files.insert(
         PathBuf::from("clients/typescript/types.ts"),
         ts_gen::generate_types(schema),
     );
 
+    // TypeScript: cliente HTTP (v0.2)
+    let client_ts = ts_gen::generate_client(schema);
+    if !client_ts.is_empty() {
+        files.insert(PathBuf::from("clients/typescript/client.ts"), client_ts);
+    }
+
+    // OpenAPI 3.1 completo (schemas + paths en v0.2)
     files.insert(
         PathBuf::from("openapi.json"),
         openapi_gen::generate_openapi(schema),

--- a/crates/ag-dsl/src/codegen/openapi_gen.rs
+++ b/crates/ag-dsl/src/codegen/openapi_gen.rs
@@ -1,23 +1,31 @@
-//! Generador OpenAPI 3.1 para DSL v0.1.
+//! Generador OpenAPI 3.1 para DSL v0.1–v0.2.
 //!
-//! Produce el bloque `components/schemas` del documento OpenAPI en formato
-//! JSON. La salida puede convertirse a YAML con herramientas externas.
-//! En DSL v0.2 se añadiran los bloques `paths` y `operations`.
+//! Produce `components/schemas` (v0.1) y `paths` con operaciones (v0.2).
+//! La salida esta en formato JSON; puede convertirse a YAML con herramientas externas.
 
 use serde_json::{json, Value};
 
-use crate::ast::{Annotation, FieldDef, ModelDef, Schema};
+use crate::ast::{Annotation, EndpointDef, FieldDef, HttpMethod, ModelDef, Schema};
 
-/// Genera el documento OpenAPI 3.1 con solo `components/schemas`.
+/// Genera el documento OpenAPI 3.1 completo.
 ///
 /// Retorna JSON formateado con indentacion de dos espacios.
 pub fn generate_openapi(schema: &Schema) -> String {
     let mut schemas = serde_json::Map::new();
 
+    // Schemas de modelos (v0.1)
     for model in &schema.models {
         let name = &model.name.value;
         schemas.insert(name.clone(), model_schema(model, false));
         schemas.insert(format!("Create{name}Request"), model_schema(model, true));
+    }
+
+    // Schemas de request/response types (v0.2)
+    for req in &schema.requests {
+        schemas.insert(req.name.value.clone(), simple_type_schema(&req.fields));
+    }
+    for resp in &schema.responses {
+        schemas.insert(resp.name.value.clone(), simple_type_schema(&resp.fields));
     }
 
     let project_name = schema
@@ -26,19 +34,141 @@ pub fn generate_openapi(schema: &Schema) -> String {
         .and_then(|c| c.project_name.as_deref())
         .unwrap_or("anti-gravital-api");
 
+    // Paths (v0.2)
+    let paths = if schema.endpoints.is_empty() {
+        Value::Object(serde_json::Map::new())
+    } else {
+        build_paths(schema)
+    };
+
     let doc = json!({
         "openapi": "3.1.0",
         "info": {
             "title": project_name,
             "version": "0.1.0",
-            "description": "API generada por Anti-Gravital ag-dsl v0.1"
+            "description": "API generada por Anti-Gravital ag-dsl v0.2"
         },
+        "paths": paths,
         "components": {
             "schemas": schemas
         }
     });
 
     serde_json::to_string_pretty(&doc).expect("serde_json serialization is infallible")
+}
+
+/// Construye el objeto `paths` para todos los endpoints del schema.
+fn build_paths(schema: &Schema) -> Value {
+    let mut paths: serde_json::Map<String, Value> = serde_json::Map::new();
+
+    // Agrupa endpoints por path
+    let mut by_path: std::collections::BTreeMap<&str, Vec<&EndpointDef>> =
+        std::collections::BTreeMap::new();
+    for ep in &schema.endpoints {
+        by_path.entry(ep.path.value.as_str()).or_default().push(ep);
+    }
+
+    for (path, endpoints) in by_path {
+        let mut path_item = serde_json::Map::new();
+        for ep in endpoints {
+            let method_key = ep.method.value.as_str().to_lowercase();
+            let operation = build_operation(ep, schema);
+            path_item.insert(method_key, operation);
+        }
+        // Convierte path DSL {id} a OpenAPI {id} (misma sintaxis)
+        paths.insert(path.to_owned(), Value::Object(path_item));
+    }
+
+    Value::Object(paths)
+}
+
+fn build_operation(ep: &EndpointDef, schema: &Schema) -> Value {
+    let mut op = serde_json::Map::new();
+    op.insert("operationId".to_owned(), json!(ep.name.value));
+
+    // Request body
+    if let Some(body) = &ep.body {
+        let rb = json!({
+            "required": true,
+            "content": {
+                "application/json": {
+                    "schema": { "$ref": format!("#/components/schemas/{}", body.value) }
+                }
+            }
+        });
+        op.insert("requestBody".to_owned(), rb);
+    }
+
+    // Responses
+    let mut responses = serde_json::Map::new();
+    let success_code = match ep.method.value {
+        HttpMethod::Post => "201",
+        HttpMethod::Delete => "204",
+        _ => "200",
+    };
+    if let Some(resp) = &ep.response {
+        responses.insert(
+            success_code.to_owned(),
+            json!({
+                "description": "Respuesta exitosa",
+                "content": {
+                    "application/json": {
+                        "schema": { "$ref": format!("#/components/schemas/{}", resp.value) }
+                    }
+                }
+            }),
+        );
+    } else {
+        responses.insert(success_code.to_owned(), json!({ "description": "Exito" }));
+    }
+
+    // Error responses desde ErrorDef del schema
+    for err_ref in &ep.errors {
+        if let Some(err_def) = schema.errors.iter().find(|e| e.name.value == err_ref.value) {
+            let code = err_def.status.value.to_string();
+            responses.insert(
+                code,
+                json!({
+                    "description": err_def.message.value
+                }),
+            );
+        }
+    }
+    op.insert("responses".to_owned(), Value::Object(responses));
+
+    Value::Object(op)
+}
+
+/// Schema para campos de request/response types simples (sin @auto).
+fn simple_type_schema(fields: &[FieldDef]) -> Value {
+    let mut properties = serde_json::Map::new();
+    let mut required: Vec<Value> = Vec::new();
+
+    for field in fields {
+        let fname = &field.name.value;
+        let (ts_type, format) = field.ty.value.openapi_type();
+        let mut prop = serde_json::Map::new();
+        if field.optional {
+            prop.insert("type".to_owned(), json!([ts_type, "null"]));
+        } else {
+            prop.insert("type".to_owned(), json!(ts_type));
+        }
+        if let Some(fmt) = format {
+            prop.insert("format".to_owned(), json!(fmt));
+        }
+        properties.insert(fname.clone(), Value::Object(prop));
+        if !field.optional {
+            required.push(json!(fname));
+        }
+    }
+
+    let mut schema = serde_json::Map::new();
+    schema.insert("type".to_owned(), json!("object"));
+    if !required.is_empty() {
+        schema.insert("required".to_owned(), Value::Array(required));
+    }
+    schema.insert("properties".to_owned(), Value::Object(properties));
+    Value::Object(schema)
 }
 
 /// Genera el schema JSON Schema de un modelo.

--- a/crates/ag-dsl/src/codegen/rust_gen.rs
+++ b/crates/ag-dsl/src/codegen/rust_gen.rs
@@ -1,13 +1,12 @@
-//! Generador Rust para DSL v0.1.
+//! Generador Rust para DSL v0.1–v0.2.
 //!
-//! Produce structs Rust con serde::{Serialize, Deserialize} a partir de
-//! los modelos del schema. Por cada modelo genera:
-//!
-//! - `NombreModel` — struct completo (para respuestas y persistencia).
-//! - `CreateNombreRequest` — sin campos @auto (para POST).
-//! - `UpdateNombreRequest` — todos los campos no-@auto como `Option<T>` (para PUT/PATCH).
+//! Produce structs Rust con serde a partir de los modelos del schema (v0.1),
+//! y tipos API + handler stubs + router a partir de endpoints (v0.2).
 
-use crate::ast::{Annotation, FieldDef, FieldType, ModelDef, Schema};
+use crate::ast::{
+    extract_path_params, to_snake_case, Annotation, EndpointDef, FieldDef, FieldType, HttpMethod,
+    ModelDef, RequestDef, ResponseDef, Schema,
+};
 
 /// Genera el contenido del archivo `src/models.rs` para el schema dado.
 pub fn generate_models(schema: &Schema) -> String {
@@ -161,6 +160,176 @@ fn is_primary(field: &FieldDef) -> bool {
         .annotations
         .iter()
         .any(|a| a.value == Annotation::Primary)
+}
+
+// ---- Generadores DSL v0.2 -------------------------------------------
+
+/// Genera el contenido de `src/types.rs`: structs para request, response y error.
+///
+/// Retorna cadena vacia si el schema no define ningun tipo API.
+pub fn generate_types(schema: &Schema) -> String {
+    if schema.requests.is_empty() && schema.responses.is_empty() && schema.errors.is_empty() {
+        return String::new();
+    }
+    let mut out = String::new();
+    out.push_str("//! Tipos de API generados por Anti-Gravital ag-dsl v0.2.\n");
+    out.push_str("//! NO editar manualmente. Regenerar con `ag generate`.\n\n");
+    out.push_str("#![allow(dead_code)]\n\n");
+    out.push_str("use serde::{Deserialize, Serialize};\n");
+
+    let needs_uuid = schema
+        .requests
+        .iter()
+        .any(|r| r.fields.iter().any(|f| f.ty.value == FieldType::Uuid))
+        || schema
+            .responses
+            .iter()
+            .any(|r| r.fields.iter().any(|f| f.ty.value == FieldType::Uuid));
+    if needs_uuid {
+        out.push_str("use uuid::Uuid;\n");
+    }
+    out.push('\n');
+
+    for req in &schema.requests {
+        out.push_str(&generate_request_struct(req));
+        out.push('\n');
+    }
+    for resp in &schema.responses {
+        out.push_str(&generate_response_struct(resp));
+        out.push('\n');
+    }
+    for err in &schema.errors {
+        out.push_str(&format!(
+            "/// Error HTTP {}: {}\n",
+            err.status.value, err.message.value
+        ));
+        out.push_str(&format!(
+            "pub const {}_STATUS: u16 = {};\n",
+            to_snake_case(&err.name.value).to_uppercase(),
+            err.status.value
+        ));
+        out.push_str(&format!(
+            "pub const {}_MESSAGE: &str = \"{}\";\n\n",
+            to_snake_case(&err.name.value).to_uppercase(),
+            err.message.value
+        ));
+    }
+    out
+}
+
+fn generate_request_struct(req: &RequestDef) -> String {
+    let name = &req.name.value;
+    let mut out = String::new();
+    out.push_str(&format!("/// Cuerpo de peticion para `{name}`.\n"));
+    out.push_str("#[derive(Debug, Clone, Serialize, Deserialize)]\n");
+    out.push_str(&format!("pub struct {name} {{\n"));
+    for field in &req.fields {
+        let rust_ty = field.ty.value.rust_type(field.optional);
+        let fname = &field.name.value;
+        out.push_str(&format!("    pub {fname}: {rust_ty},\n"));
+    }
+    out.push_str("}\n");
+    out
+}
+
+fn generate_response_struct(resp: &ResponseDef) -> String {
+    let name = &resp.name.value;
+    let mut out = String::new();
+    out.push_str(&format!("/// Cuerpo de respuesta para `{name}`.\n"));
+    out.push_str("#[derive(Debug, Clone, Serialize, Deserialize)]\n");
+    out.push_str(&format!("pub struct {name} {{\n"));
+    for field in &resp.fields {
+        let rust_ty = field.ty.value.rust_type(field.optional);
+        let fname = &field.name.value;
+        out.push_str(&format!("    pub {fname}: {rust_ty},\n"));
+    }
+    out.push_str("}\n");
+    out
+}
+
+/// Genera el contenido de `src/handlers.rs`: stubs de handlers Axum.
+pub fn generate_handlers(schema: &Schema) -> String {
+    if schema.endpoints.is_empty() {
+        return String::new();
+    }
+    let mut out = String::new();
+    out.push_str("//! Handler stubs generados por Anti-Gravital ag-dsl v0.2.\n");
+    out.push_str("//! Implementa el cuerpo de cada funcion para completar la API.\n\n");
+    out.push_str("#![allow(unused_variables, clippy::unused_async)]\n\n");
+    out.push_str("use axum::{extract::{Path, State}, Json};\n\n");
+    for ep in &schema.endpoints {
+        out.push_str(&generate_handler_stub(ep));
+        out.push('\n');
+    }
+    out
+}
+
+fn generate_handler_stub(ep: &EndpointDef) -> String {
+    let fn_name = to_snake_case(&ep.name.value);
+    let method_str = ep.method.value.as_str();
+    let path_str = &ep.path.value;
+    let path_params = extract_path_params(path_str);
+
+    let mut params = vec!["State(state): State<AppState>".to_owned()];
+    for param in &path_params {
+        params.push(format!("Path({param}): Path<String>"));
+    }
+    if let Some(body) = &ep.body {
+        params.push(format!("Json(body): Json<{}>", body.value));
+    }
+
+    let return_ty = if let Some(resp) = &ep.response {
+        format!("Result<Json<{}>, axum::http::StatusCode>", resp.value)
+    } else {
+        "axum::http::StatusCode".to_owned()
+    };
+
+    let mut out = String::new();
+    out.push_str(&format!(
+        "/// {method_str} {path_str} — {}\n",
+        ep.name.value
+    ));
+    out.push_str(&format!(
+        "pub async fn {fn_name}(\n    {}\n) -> {return_ty} {{\n",
+        params.join(",\n    ")
+    ));
+    out.push_str("    todo!()\n}\n");
+    out
+}
+
+/// Genera el contenido de `src/router.rs`: registro de rutas Axum.
+pub fn generate_router(schema: &Schema) -> String {
+    if schema.endpoints.is_empty() {
+        return String::new();
+    }
+    use crate::ast::dsl_path_to_axum;
+
+    let mut out = String::new();
+    out.push_str("//! Router generado por Anti-Gravital ag-dsl v0.2.\n\n");
+    out.push_str("use axum::routing;\n");
+    out.push_str("use super::handlers;\n\n");
+    out.push_str("/// Placeholder para el estado de la aplicacion.\n");
+    out.push_str("pub type AppState = ();\n\n");
+    out.push_str("/// Crea el router Axum con todas las rutas definidas en el schema.\n");
+    out.push_str("pub fn api_router() -> axum::Router<AppState> {\n");
+    out.push_str("    axum::Router::new()\n");
+
+    for ep in &schema.endpoints {
+        let fn_name = to_snake_case(&ep.name.value);
+        let axum_path = dsl_path_to_axum(&ep.path.value);
+        let axum_method = match ep.method.value {
+            HttpMethod::Get => "get",
+            HttpMethod::Post => "post",
+            HttpMethod::Put => "put",
+            HttpMethod::Patch => "patch",
+            HttpMethod::Delete => "delete",
+        };
+        out.push_str(&format!(
+            "        .route(\"{axum_path}\", routing::{axum_method}(handlers::{fn_name}))\n"
+        ));
+    }
+    out.push_str("}\n");
+    out
 }
 
 #[cfg(test)]

--- a/crates/ag-dsl/src/codegen/sql_gen.rs
+++ b/crates/ag-dsl/src/codegen/sql_gen.rs
@@ -134,16 +134,9 @@ fn generate_column(field: &FieldDef) -> String {
     col
 }
 
-/// Convierte PascalCase o camelCase a snake_case para nombres de tabla/columna.
+/// Delega a la utilidad de conversion en `ast`.
 fn to_snake_case(s: &str) -> String {
-    let mut result = String::with_capacity(s.len() + 4);
-    for (i, ch) in s.chars().enumerate() {
-        if ch.is_uppercase() && i > 0 {
-            result.push('_');
-        }
-        result.push(ch.to_lowercase().next().unwrap());
-    }
-    result
+    crate::ast::to_snake_case(s)
 }
 
 #[cfg(test)]

--- a/crates/ag-dsl/src/codegen/ts_gen.rs
+++ b/crates/ag-dsl/src/codegen/ts_gen.rs
@@ -1,16 +1,17 @@
-//! Generador TypeScript para DSL v0.1.
+//! Generador TypeScript para DSL v0.1–v0.2.
 //!
-//! Produce interfaces TypeScript con tipos precisos para cada modelo.
-//! Los campos @auto se incluyen como requeridos en la interfaz completa
-//! y se excluyen en la interfaz de creacion.
+//! Produce interfaces TypeScript para modelos, request/response types y
+//! un cliente HTTP tipado por cada endpoint.
 
-use crate::ast::{Annotation, FieldDef, ModelDef, Schema};
+use crate::ast::{extract_path_params, Annotation, EndpointDef, FieldDef, ModelDef, Schema};
 
 /// Genera el contenido del archivo `clients/typescript/types.ts`.
+///
+/// Incluye interfaces para modelos (v0.1) y para request/response/error types (v0.2).
 pub fn generate_types(schema: &Schema) -> String {
     let mut out = String::new();
 
-    out.push_str("// Tipos generados por Anti-Gravital ag-dsl v0.1.\n");
+    out.push_str("// Tipos generados por Anti-Gravital ag-dsl v0.1-v0.2.\n");
     out.push_str("// NO editar manualmente. Regenerar con `ag generate`.\n\n");
 
     for model in &schema.models {
@@ -22,7 +23,115 @@ pub fn generate_types(schema: &Schema) -> String {
         out.push('\n');
     }
 
+    for req in &schema.requests {
+        out.push_str(&generate_simple_interface(&req.name.value, &req.fields));
+        out.push('\n');
+    }
+    for resp in &schema.responses {
+        out.push_str(&generate_simple_interface(&resp.name.value, &resp.fields));
+        out.push('\n');
+    }
+
     out
+}
+
+/// Genera el contenido del archivo `clients/typescript/client.ts`.
+///
+/// Produce funciones tipadas para cada endpoint del schema.
+pub fn generate_client(schema: &Schema) -> String {
+    if schema.endpoints.is_empty() {
+        return String::new();
+    }
+    let mut out = String::new();
+    out.push_str("// Cliente HTTP generado por Anti-Gravital ag-dsl v0.2.\n");
+    out.push_str("// NO editar manualmente. Regenerar con `ag generate`.\n\n");
+    out.push_str("const BASE_URL = '';\n\n");
+    for ep in &schema.endpoints {
+        out.push_str(&generate_api_function(ep));
+        out.push('\n');
+    }
+    out
+}
+
+fn generate_api_function(ep: &EndpointDef) -> String {
+    let fn_name = to_camel_case(&ep.name.value);
+    let method = ep.method.value.as_str();
+    let path = &ep.path.value;
+    let path_params = extract_path_params(path);
+
+    // Parametros de la funcion
+    let mut params: Vec<String> = path_params.iter().map(|p| format!("{p}: string")).collect();
+    if let Some(body) = &ep.body {
+        params.push(format!("body: {}", body.value));
+    }
+
+    let return_ty = if let Some(resp) = &ep.response {
+        format!("Promise<{}>", resp.value)
+    } else {
+        "Promise<void>".to_owned()
+    };
+
+    // Construye la URL con interpolacion de path params
+    let url = if path_params.is_empty() {
+        format!("`${{BASE_URL}}{path}`")
+    } else {
+        let mut url = format!("`${{BASE_URL}}{path}");
+        // Reemplaza {param} por ${param} en la template string
+        for p in &path_params {
+            url = url.replace(&format!("{{{p}}}"), &format!("${{{p}}}"));
+        }
+        url.push('`');
+        url
+    };
+
+    let needs_json = ep.body.is_some();
+    let method_lower = method.to_lowercase();
+
+    let mut out = String::new();
+    out.push_str(&format!("/** {method} {path} */\n"));
+    out.push_str(&format!(
+        "export async function {fn_name}({}) : {return_ty} {{\n",
+        params.join(", ")
+    ));
+    out.push_str(&format!("  const resp = await fetch({url}, {{\n"));
+    out.push_str(&format!("    method: '{method_lower}',\n"));
+    if needs_json {
+        out.push_str("    headers: { 'Content-Type': 'application/json' },\n");
+        out.push_str("    body: JSON.stringify(body),\n");
+    }
+    out.push_str("  });\n");
+    out.push_str(&format!(
+        "  if (!resp.ok) throw new Error(`{fn_name} failed: ${{resp.status}}`);\n"
+    ));
+    if ep.response.is_some() {
+        out.push_str("  return resp.json();\n");
+    }
+    out.push_str("}\n");
+    out
+}
+
+/// Interfaz simple sin variantes Create/Update (para request/response types).
+fn generate_simple_interface(name: &str, fields: &[FieldDef]) -> String {
+    let mut out = String::new();
+    out.push_str(&format!("/** API type `{name}`. */\n"));
+    out.push_str(&format!("export interface {name} {{\n"));
+    for field in fields {
+        let ts_ty = ts_field_type(field);
+        let fname = &field.name.value;
+        let opt = if field.optional { "?" } else { "" };
+        out.push_str(&format!("  {fname}{opt}: {ts_ty};\n"));
+    }
+    out.push_str("}\n");
+    out
+}
+
+/// Convierte PascalCase a camelCase para nombres de funcion TypeScript.
+fn to_camel_case(s: &str) -> String {
+    let mut chars = s.chars();
+    match chars.next() {
+        None => String::new(),
+        Some(c) => c.to_lowercase().collect::<String>() + chars.as_str(),
+    }
 }
 
 /// Interfaz completa del modelo.

--- a/crates/ag-dsl/src/lexer.rs
+++ b/crates/ag-dsl/src/lexer.rs
@@ -11,7 +11,7 @@ use std::ops::Range;
 /// Rango de bytes en el texto fuente (byte offset, no char offset).
 pub type Span = Range<usize>;
 
-/// Tokens del Anti-DSL v0.1.
+/// Tokens del Anti-DSL v0.1–v0.2.
 ///
 /// Los `#[token(...)]` tienen prioridad sobre los `#[regex(...)]`, por lo que
 /// las palabras clave siempre se reconocen antes que el identificador generico.
@@ -53,6 +53,37 @@ pub enum Token {
     #[token("Decimal")]
     TyDecimal,
 
+    // ---- Palabras clave DSL v0.2 ----
+    /// `endpoint` — define un endpoint HTTP: metodo, path, body, response, errores.
+    #[token("endpoint")]
+    Endpoint,
+    /// `request` — define el cuerpo de una peticion HTTP.
+    #[token("request")]
+    Request,
+    /// `response` — define el cuerpo de una respuesta HTTP.
+    #[token("response")]
+    Response,
+    /// `error` — define un tipo de error con codigo HTTP y mensaje.
+    #[token("error")]
+    ErrorKw,
+
+    // ---- Metodos HTTP (DSL v0.2) ----
+    /// Metodo HTTP GET.
+    #[token("GET")]
+    HttpGet,
+    /// Metodo HTTP POST.
+    #[token("POST")]
+    HttpPost,
+    /// Metodo HTTP PUT.
+    #[token("PUT")]
+    HttpPut,
+    /// Metodo HTTP PATCH.
+    #[token("PATCH")]
+    HttpPatch,
+    /// Metodo HTTP DELETE.
+    #[token("DELETE")]
+    HttpDelete,
+
     // ---- Anotaciones DSL v0.1 ----
     /// `@primary` — clave primaria de la tabla.
     #[token("@primary")]
@@ -74,6 +105,11 @@ pub enum Token {
     /// Literal entero: `42`, `255`, `0`.
     #[regex(r"[0-9]+", |lex| lex.slice().parse::<i64>().unwrap())]
     IntLit(i64),
+
+    /// Literal de path HTTP: `/users`, `/users/{id}`, `/a/b/{c}`.
+    /// Empieza siempre con `/`; captura letras, digitos, `_`, `-`, `{`, `}`, `.`.
+    #[regex(r"/[a-zA-Z0-9_\-{}/\.]*", |lex| lex.slice().to_owned())]
+    PathLit(String),
 
     /// Literal string entre comillas dobles: `"hola"`.
     /// Los escapes basicos (`\"`, `\\`) estan soportados en el regex;
@@ -279,5 +315,65 @@ model User {
         assert!(kinds.contains(&Token::AtPrimary));
         assert!(kinds.contains(&Token::AtAuto));
         assert!(kinds.contains(&Token::AtUnique));
+    }
+
+    // ---- Tests DSL v0.2 ----
+
+    #[test]
+    fn v02_structure_keywords() {
+        let toks = lex("endpoint request response error");
+        assert_eq!(
+            toks,
+            vec![
+                Token::Endpoint,
+                Token::Request,
+                Token::Response,
+                Token::ErrorKw,
+            ]
+        );
+    }
+
+    #[test]
+    fn v02_http_methods() {
+        let toks = lex("GET POST PUT PATCH DELETE");
+        assert_eq!(
+            toks,
+            vec![
+                Token::HttpGet,
+                Token::HttpPost,
+                Token::HttpPut,
+                Token::HttpPatch,
+                Token::HttpDelete,
+            ]
+        );
+    }
+
+    #[test]
+    fn v02_path_literals() {
+        let toks = lex("/users /users/{id} /a/b/c");
+        assert_eq!(
+            toks,
+            vec![
+                Token::PathLit("/users".to_owned()),
+                Token::PathLit("/users/{id}".to_owned()),
+                Token::PathLit("/a/b/c".to_owned()),
+            ]
+        );
+    }
+
+    #[test]
+    fn v02_root_path() {
+        let toks = lex("/");
+        assert_eq!(toks, vec![Token::PathLit("/".to_owned())]);
+    }
+
+    #[test]
+    fn v02_keywords_not_captured_as_ident() {
+        let (toks, errs) = tokenize("endpoint GET /users");
+        assert!(errs.is_empty());
+        let kinds: Vec<_> = toks.into_iter().map(|(t, _)| t).collect();
+        assert!(kinds.contains(&Token::Endpoint));
+        assert!(kinds.contains(&Token::HttpGet));
+        assert!(kinds.contains(&Token::PathLit("/users".to_owned())));
     }
 }

--- a/crates/ag-dsl/src/parser.rs
+++ b/crates/ag-dsl/src/parser.rs
@@ -13,7 +13,8 @@
 use chumsky::prelude::*;
 
 use crate::ast::{
-    Annotation, Config, DefaultValue, FieldDef, FieldType, ModelDef, Schema, Spanned,
+    Annotation, Config, DefaultValue, EndpointDef, ErrorDef, FieldDef, FieldType, HttpMethod,
+    ModelDef, RequestDef, ResponseDef, Schema, Spanned,
 };
 use crate::diagnostics::Diagnostic;
 use crate::lexer::{Span, Token};
@@ -42,13 +43,24 @@ pub fn parse_tokens(
 
 // ---- Construccion del parser ----------------------------------------
 
-/// Parser principal: lee cero o mas items (model o config) hasta EOF.
+/// Parser principal: lee cero o mas items hasta EOF.
 fn schema_parser() -> impl Parser<Token, Schema, Error = ParseErr> {
-    let model = model_parser();
-    let config = config_parser();
-
-    let item = choice((config.map(SchemaItem::Config), model.map(SchemaItem::Model)))
-        .recover_with(skip_then_retry_until([Token::Model, Token::Config]));
+    let item = choice((
+        config_parser().map(SchemaItem::Config),
+        model_parser().map(SchemaItem::Model),
+        request_parser().map(SchemaItem::Request),
+        response_parser().map(SchemaItem::Response),
+        error_def_parser().map(SchemaItem::Error),
+        endpoint_parser().map(SchemaItem::Endpoint),
+    ))
+    .recover_with(skip_then_retry_until([
+        Token::Model,
+        Token::Config,
+        Token::Request,
+        Token::Response,
+        Token::ErrorKw,
+        Token::Endpoint,
+    ]));
 
     item.repeated().then_ignore(end()).map(|items| {
         let mut schema = Schema::default();
@@ -56,6 +68,10 @@ fn schema_parser() -> impl Parser<Token, Schema, Error = ParseErr> {
             match item {
                 SchemaItem::Config(c) => schema.config = Some(c),
                 SchemaItem::Model(m) => schema.models.push(m),
+                SchemaItem::Request(r) => schema.requests.push(r),
+                SchemaItem::Response(r) => schema.responses.push(r),
+                SchemaItem::Error(e) => schema.errors.push(e),
+                SchemaItem::Endpoint(ep) => schema.endpoints.push(ep),
             }
         }
         schema
@@ -66,6 +82,10 @@ fn schema_parser() -> impl Parser<Token, Schema, Error = ParseErr> {
 enum SchemaItem {
     Config(Config),
     Model(ModelDef),
+    Request(RequestDef),
+    Response(ResponseDef),
+    Error(ErrorDef),
+    Endpoint(EndpointDef),
 }
 
 /// Parser de bloque `config { ... }`.
@@ -178,6 +198,161 @@ fn annotation_parser() -> impl Parser<Token, Spanned<Annotation>, Error = ParseE
     ))
     .map_with_span(|ann, span: Span| Spanned::new(ann, span))
     .labelled("anotacion")
+}
+
+// ---- Parsers DSL v0.2 -----------------------------------------------
+
+/// Parser de `request Nombre { campos... }`.
+fn request_parser() -> impl Parser<Token, RequestDef, Error = ParseErr> {
+    just(Token::Request)
+        .ignore_then(select! { Token::Ident(s) => s }.labelled("nombre del request"))
+        .map_with_span(|name, span: Span| Spanned::new(name, span))
+        .then(field_parser().repeated().collect::<Vec<_>>().delimited_by(
+            just(Token::LBrace).labelled("{"),
+            just(Token::RBrace).labelled("}"),
+        ))
+        .map_with_span(|(name, fields), span| RequestDef { name, fields, span })
+        .labelled("definicion de request")
+}
+
+/// Parser de `response Nombre { campos... }`.
+fn response_parser() -> impl Parser<Token, ResponseDef, Error = ParseErr> {
+    just(Token::Response)
+        .ignore_then(select! { Token::Ident(s) => s }.labelled("nombre del response"))
+        .map_with_span(|name, span: Span| Spanned::new(name, span))
+        .then(field_parser().repeated().collect::<Vec<_>>().delimited_by(
+            just(Token::LBrace).labelled("{"),
+            just(Token::RBrace).labelled("}"),
+        ))
+        .map_with_span(|(name, fields), span| ResponseDef { name, fields, span })
+        .labelled("definicion de response")
+}
+
+/// Parser de `error Nombre { status N message "texto" }`.
+fn error_def_parser() -> impl Parser<Token, ErrorDef, Error = ParseErr> {
+    let error_name = just(Token::ErrorKw)
+        .ignore_then(select! { Token::Ident(s) => s }.labelled("nombre del error"))
+        .map_with_span(|name, span: Span| Spanned::new(name, span));
+
+    let status_field = just(Token::Ident("status".to_owned())).ignore_then(
+        select! { Token::IntLit(n) => n as u16 }
+            .map_with_span(|n, span: Span| Spanned::new(n, span))
+            .labelled("codigo de estado HTTP"),
+    );
+
+    let message_field = just(Token::Ident("message".to_owned())).ignore_then(
+        select! { Token::StringLit(s) => s }
+            .map_with_span(|s, span: Span| Spanned::new(s, span))
+            .labelled("mensaje de error"),
+    );
+
+    let body = status_field
+        .then(message_field)
+        .delimited_by(just(Token::LBrace), just(Token::RBrace));
+
+    error_name
+        .then(body)
+        .map_with_span(|(name, (status, message)), span| ErrorDef {
+            name,
+            status,
+            message,
+            span,
+        })
+        .labelled("definicion de error")
+}
+
+/// Parser de `endpoint Nombre { method path [body] [response] [errors] }`.
+fn endpoint_parser() -> impl Parser<Token, EndpointDef, Error = ParseErr> {
+    let endpoint_name = just(Token::Endpoint)
+        .ignore_then(select! { Token::Ident(s) => s }.labelled("nombre del endpoint"))
+        .map_with_span(|name, span: Span| Spanned::new(name, span));
+
+    let http_method = choice((
+        just(Token::HttpGet).to(HttpMethod::Get),
+        just(Token::HttpPost).to(HttpMethod::Post),
+        just(Token::HttpPut).to(HttpMethod::Put),
+        just(Token::HttpPatch).to(HttpMethod::Patch),
+        just(Token::HttpDelete).to(HttpMethod::Delete),
+    ))
+    .map_with_span(|m, span: Span| Spanned::new(m, span))
+    .labelled("metodo HTTP");
+
+    let ident_ref =
+        select! { Token::Ident(s) => s }.map_with_span(|s, span: Span| Spanned::new(s, span));
+
+    let error_list = ident_ref
+        .separated_by(just(Token::Comma))
+        .allow_trailing()
+        .collect::<Vec<_>>()
+        .delimited_by(just(Token::LBracket), just(Token::RBracket))
+        .labelled("lista de errores");
+
+    // Cada campo del bloque endpoint es un par clave-valor
+    #[allow(clippy::type_complexity)]
+    let endpoint_field = choice((
+        just(Token::Ident("method".to_owned()))
+            .ignore_then(http_method)
+            .map(EndpointField::Method),
+        just(Token::Ident("path".to_owned()))
+            .ignore_then(
+                select! { Token::PathLit(s) => s }
+                    .map_with_span(|s, span: Span| Spanned::new(s, span))
+                    .labelled("path HTTP"),
+            )
+            .map(EndpointField::Path),
+        just(Token::Ident("body".to_owned()))
+            .ignore_then(ident_ref)
+            .map(EndpointField::Body),
+        just(Token::Response) // 'response' es keyword
+            .ignore_then(ident_ref)
+            .map(EndpointField::Response),
+        just(Token::Ident("errors".to_owned()))
+            .ignore_then(error_list)
+            .map(EndpointField::Errors),
+    ));
+
+    endpoint_name
+        .then(
+            endpoint_field
+                .repeated()
+                .collect::<Vec<_>>()
+                .delimited_by(just(Token::LBrace), just(Token::RBrace)),
+        )
+        .map_with_span(|(name, fields), span: Span| {
+            let mut method = None;
+            let mut path = None;
+            let mut body = None;
+            let mut response = None;
+            let mut errors = Vec::new();
+            for f in fields {
+                match f {
+                    EndpointField::Method(m) => method = Some(m),
+                    EndpointField::Path(p) => path = Some(p),
+                    EndpointField::Body(b) => body = Some(b),
+                    EndpointField::Response(r) => response = Some(r),
+                    EndpointField::Errors(e) => errors = e,
+                }
+            }
+            EndpointDef {
+                name,
+                method: method.unwrap_or_else(|| Spanned::new(HttpMethod::Get, span.clone())),
+                path: path.unwrap_or_else(|| Spanned::new("/".to_owned(), span.clone())),
+                body,
+                response,
+                errors,
+                span,
+            }
+        })
+        .labelled("definicion de endpoint")
+}
+
+/// Campos posibles dentro de un bloque endpoint.
+enum EndpointField {
+    Method(Spanned<HttpMethod>),
+    Path(Spanned<String>),
+    Body(Spanned<String>),
+    Response(Spanned<String>),
+    Errors(Vec<Spanned<String>>),
 }
 
 // ---- Conversion de errores de chumsky a Diagnostic ------------------
@@ -352,5 +527,152 @@ model Post {
             diags.iter().any(|d| d.is_error()),
             "should have parse error"
         );
+    }
+
+    // ---- Tests DSL v0.2 ----
+
+    #[test]
+    fn request_def_parses() {
+        let src = r#"
+request CreateUserRequest {
+    email String
+    name  String
+}
+"#;
+        let (ast, diags) = parse(src);
+        assert!(diags.iter().all(|d| !d.is_error()), "{diags:?}");
+        let schema = ast.unwrap();
+        assert_eq!(schema.requests.len(), 1);
+        let req = &schema.requests[0];
+        assert_eq!(req.name.value, "CreateUserRequest");
+        assert_eq!(req.fields.len(), 2);
+    }
+
+    #[test]
+    fn response_def_parses() {
+        let src = r#"
+response UserResponse {
+    id    UUID
+    email String
+    name  String
+}
+"#;
+        let (ast, diags) = parse(src);
+        assert!(diags.iter().all(|d| !d.is_error()), "{diags:?}");
+        let schema = ast.unwrap();
+        assert_eq!(schema.responses.len(), 1);
+        assert_eq!(schema.responses[0].name.value, "UserResponse");
+        assert_eq!(schema.responses[0].fields.len(), 3);
+    }
+
+    #[test]
+    fn error_def_parses() {
+        let src = r#"error EmailTaken { status 409 message "Email already registered" }"#;
+        let (ast, diags) = parse(src);
+        assert!(diags.iter().all(|d| !d.is_error()), "{diags:?}");
+        let schema = ast.unwrap();
+        assert_eq!(schema.errors.len(), 1);
+        let err = &schema.errors[0];
+        assert_eq!(err.name.value, "EmailTaken");
+        assert_eq!(err.status.value, 409u16);
+        assert_eq!(err.message.value, "Email already registered");
+    }
+
+    #[test]
+    fn endpoint_with_all_fields_parses() {
+        let src = r#"
+endpoint CreateUser {
+    method   POST
+    path     /users
+    body     CreateUserRequest
+    response UserResponse
+    errors   [EmailTaken, WeakPassword]
+}
+"#;
+        let (ast, diags) = parse(src);
+        assert!(diags.iter().all(|d| !d.is_error()), "{diags:?}");
+        let schema = ast.unwrap();
+        assert_eq!(schema.endpoints.len(), 1);
+        let ep = &schema.endpoints[0];
+        assert_eq!(ep.name.value, "CreateUser");
+        assert_eq!(ep.method.value, HttpMethod::Post);
+        assert_eq!(ep.path.value, "/users");
+        assert_eq!(
+            ep.body.as_ref().map(|b| b.value.as_str()),
+            Some("CreateUserRequest")
+        );
+        assert_eq!(
+            ep.response.as_ref().map(|r| r.value.as_str()),
+            Some("UserResponse")
+        );
+        assert_eq!(ep.errors.len(), 2);
+    }
+
+    #[test]
+    fn endpoint_get_without_body_parses() {
+        let src = r#"
+endpoint GetUser {
+    method   GET
+    path     /users/{id}
+    response UserResponse
+}
+"#;
+        let (ast, diags) = parse(src);
+        assert!(diags.iter().all(|d| !d.is_error()), "{diags:?}");
+        let ep = &ast.unwrap().endpoints[0];
+        assert_eq!(ep.method.value, HttpMethod::Get);
+        assert_eq!(ep.path.value, "/users/{id}");
+        assert!(ep.body.is_none());
+    }
+
+    #[test]
+    fn full_v02_schema_parses() {
+        let src = r#"
+config {
+    project_name "users-api"
+    database "postgres"
+}
+
+model User {
+    id    UUID   @primary @auto
+    email String @unique
+    name  String
+}
+
+request CreateUserRequest {
+    email String
+    name  String
+}
+
+response UserResponse {
+    id    UUID
+    email String
+    name  String
+}
+
+error EmailTaken { status 409 message "Email already taken" }
+
+endpoint CreateUser {
+    method   POST
+    path     /users
+    body     CreateUserRequest
+    response UserResponse
+    errors   [EmailTaken]
+}
+
+endpoint GetUser {
+    method   GET
+    path     /users/{id}
+    response UserResponse
+}
+"#;
+        let (ast, diags) = parse(src);
+        assert!(diags.iter().all(|d| !d.is_error()), "{diags:?}");
+        let schema = ast.unwrap();
+        assert_eq!(schema.models.len(), 1);
+        assert_eq!(schema.requests.len(), 1);
+        assert_eq!(schema.responses.len(), 1);
+        assert_eq!(schema.errors.len(), 1);
+        assert_eq!(schema.endpoints.len(), 2);
     }
 }

--- a/crates/ag-dsl/src/semantic.rs
+++ b/crates/ag-dsl/src/semantic.rs
@@ -2,10 +2,10 @@
 //!
 //! Valida invariantes que el parser no puede verificar por ser
 //! context-free: nombres duplicados, modelos sin campos, multiples
-//! @primary, uso de @auto en tipos que no lo soportan, etc.
+//! @primary, referencias a tipos inexistentes en endpoints, etc.
 //! Produce diagnosticos de error y warning sin modificar el AST.
 
-use std::collections::HashMap;
+use std::collections::{HashMap, HashSet};
 
 use crate::ast::{Annotation, FieldType, Schema};
 use crate::diagnostics::Diagnostic;
@@ -17,15 +17,23 @@ use crate::diagnostics::Diagnostic;
 pub fn analyze(schema: &Schema) -> Vec<Diagnostic> {
     let mut diags = Vec::new();
 
+    // v0.1 validaciones
     check_duplicate_model_names(schema, &mut diags);
-
     for model in &schema.models {
         check_model_has_fields(model, &mut diags);
-        check_duplicate_field_names(model, &mut diags);
+        check_duplicate_field_names_in_model(model, &mut diags);
         check_primary_key(model, &mut diags);
         check_auto_type_compatibility(model, &mut diags);
         check_auto_update_type_compatibility(model, &mut diags);
     }
+
+    // v0.2 validaciones
+    check_duplicate_request_names(schema, &mut diags);
+    check_duplicate_response_names(schema, &mut diags);
+    check_duplicate_error_names(schema, &mut diags);
+    check_duplicate_endpoint_names(schema, &mut diags);
+    check_error_status_codes(schema, &mut diags);
+    check_endpoint_references(schema, &mut diags);
 
     diags
 }
@@ -56,7 +64,7 @@ fn check_model_has_fields(model: &crate::ast::ModelDef, diags: &mut Vec<Diagnost
     }
 }
 
-fn check_duplicate_field_names(model: &crate::ast::ModelDef, diags: &mut Vec<Diagnostic>) {
+fn check_duplicate_field_names_in_model(model: &crate::ast::ModelDef, diags: &mut Vec<Diagnostic>) {
     let mut seen: HashMap<&str, usize> = HashMap::new();
     for field in &model.fields {
         let name = field.name.value.as_str();
@@ -134,6 +142,156 @@ fn check_auto_update_type_compatibility(model: &crate::ast::ModelDef, diags: &mu
                 ),
                 "cambia el tipo del campo a Timestamp",
             ));
+        }
+    }
+}
+
+// ---- Validaciones DSL v0.2 -------------------------------------------
+
+fn check_duplicate_request_names(schema: &Schema, diags: &mut Vec<Diagnostic>) {
+    let mut seen: HashMap<&str, usize> = HashMap::new();
+    for r in &schema.requests {
+        let name = r.name.value.as_str();
+        if let Some(first) = seen.get(name) {
+            diags.push(Diagnostic::semantic_error_with_hint(
+                r.name.span.clone(),
+                format!("nombre de request duplicado: '{name}'"),
+                format!("el primer 'request {name}' esta en el byte {first}"),
+            ));
+        } else {
+            seen.insert(name, r.name.span.start);
+        }
+    }
+}
+
+fn check_duplicate_response_names(schema: &Schema, diags: &mut Vec<Diagnostic>) {
+    let mut seen: HashMap<&str, usize> = HashMap::new();
+    for r in &schema.responses {
+        let name = r.name.value.as_str();
+        if let Some(first) = seen.get(name) {
+            diags.push(Diagnostic::semantic_error_with_hint(
+                r.name.span.clone(),
+                format!("nombre de response duplicado: '{name}'"),
+                format!("el primer 'response {name}' esta en el byte {first}"),
+            ));
+        } else {
+            seen.insert(name, r.name.span.start);
+        }
+    }
+}
+
+fn check_duplicate_error_names(schema: &Schema, diags: &mut Vec<Diagnostic>) {
+    let mut seen: HashMap<&str, usize> = HashMap::new();
+    for e in &schema.errors {
+        let name = e.name.value.as_str();
+        if let Some(first) = seen.get(name) {
+            diags.push(Diagnostic::semantic_error_with_hint(
+                e.name.span.clone(),
+                format!("nombre de error duplicado: '{name}'"),
+                format!("el primer 'error {name}' esta en el byte {first}"),
+            ));
+        } else {
+            seen.insert(name, e.name.span.start);
+        }
+    }
+}
+
+fn check_duplicate_endpoint_names(schema: &Schema, diags: &mut Vec<Diagnostic>) {
+    let mut seen_names: HashMap<&str, usize> = HashMap::new();
+    let mut seen_routes: HashSet<String> = HashSet::new();
+    for ep in &schema.endpoints {
+        let name = ep.name.value.as_str();
+        if let Some(first) = seen_names.get(name) {
+            diags.push(Diagnostic::semantic_error_with_hint(
+                ep.name.span.clone(),
+                format!("nombre de endpoint duplicado: '{name}'"),
+                format!("el primer 'endpoint {name}' esta en el byte {first}"),
+            ));
+        } else {
+            seen_names.insert(name, ep.name.span.start);
+        }
+        let route = format!("{} {}", ep.method.value, ep.path.value);
+        if seen_routes.contains(&route) {
+            diags.push(Diagnostic::semantic_error_with_hint(
+                ep.path.span.clone(),
+                format!("ruta duplicada: {route}"),
+                "dos endpoints no pueden tener el mismo metodo y path",
+            ));
+        } else {
+            seen_routes.insert(route);
+        }
+    }
+}
+
+fn check_error_status_codes(schema: &Schema, diags: &mut Vec<Diagnostic>) {
+    for e in &schema.errors {
+        let code = e.status.value;
+        if !(400..=599).contains(&code) {
+            diags.push(Diagnostic::semantic_error_with_hint(
+                e.status.span.clone(),
+                format!(
+                    "codigo de estado HTTP invalido {code} en el error '{}'",
+                    e.name.value
+                ),
+                "los errores deben usar codigos HTTP 4xx o 5xx",
+            ));
+        }
+    }
+}
+
+fn check_endpoint_references(schema: &Schema, diags: &mut Vec<Diagnostic>) {
+    let request_names: HashSet<&str> = schema
+        .requests
+        .iter()
+        .map(|r| r.name.value.as_str())
+        .collect();
+    let response_names: HashSet<&str> = schema
+        .responses
+        .iter()
+        .map(|r| r.name.value.as_str())
+        .collect();
+    let error_names: HashSet<&str> = schema
+        .errors
+        .iter()
+        .map(|e| e.name.value.as_str())
+        .collect();
+
+    for ep in &schema.endpoints {
+        if let Some(body) = &ep.body {
+            if !request_names.contains(body.value.as_str()) {
+                diags.push(Diagnostic::semantic_error_with_hint(
+                    body.span.clone(),
+                    format!(
+                        "body '{}' en endpoint '{}' no esta definido",
+                        body.value, ep.name.value
+                    ),
+                    format!("define 'request {} {{ ... }}' en el schema", body.value),
+                ));
+            }
+        }
+        if let Some(resp) = &ep.response {
+            if !response_names.contains(resp.value.as_str()) {
+                diags.push(Diagnostic::semantic_error_with_hint(
+                    resp.span.clone(),
+                    format!(
+                        "response '{}' en endpoint '{}' no esta definido",
+                        resp.value, ep.name.value
+                    ),
+                    format!("define 'response {} {{ ... }}' en el schema", resp.value),
+                ));
+            }
+        }
+        for err_ref in &ep.errors {
+            if !error_names.contains(err_ref.value.as_str()) {
+                diags.push(Diagnostic::semantic_error_with_hint(
+                    err_ref.span.clone(),
+                    format!(
+                        "error '{}' en endpoint '{}' no esta definido",
+                        err_ref.value, ep.name.value
+                    ),
+                    format!("define 'error {} {{ ... }}' en el schema", err_ref.value),
+                ));
+            }
         }
     }
 }
@@ -266,5 +424,97 @@ model Bad {
         assert!(diags
             .iter()
             .any(|d| d.is_error() && d.message.contains("no tiene campos")),);
+    }
+
+    // ---- Tests DSL v0.2 ----
+
+    #[test]
+    fn valid_endpoint_no_errors() {
+        let src = r#"
+request CreateUserRequest { email String }
+response UserResponse { id UUID }
+error EmailTaken { status 409 message "Email taken" }
+endpoint CreateUser {
+    method   POST
+    path     /users
+    body     CreateUserRequest
+    response UserResponse
+    errors   [EmailTaken]
+}
+"#;
+        let (_, diags) = compile(src);
+        let errors: Vec<_> = diags.iter().filter(|d| d.is_error()).collect();
+        assert!(errors.is_empty(), "unexpected errors: {errors:?}");
+    }
+
+    #[test]
+    fn endpoint_with_undefined_body_is_error() {
+        let src = r#"
+response UserResponse { id UUID }
+endpoint Create {
+    method   POST
+    path     /users
+    body     NonExistentRequest
+    response UserResponse
+}
+"#;
+        let (_, diags) = compile(src);
+        assert!(
+            diags
+                .iter()
+                .any(|d| d.is_error() && d.message.contains("body")),
+            "should error on undefined body reference"
+        );
+    }
+
+    #[test]
+    fn endpoint_with_undefined_response_is_error() {
+        let src = r#"
+endpoint GetUser {
+    method   GET
+    path     /users/{id}
+    response NonExistentResponse
+}
+"#;
+        let (_, diags) = compile(src);
+        assert!(diags
+            .iter()
+            .any(|d| d.is_error() && d.message.contains("response")),);
+    }
+
+    #[test]
+    fn endpoint_with_undefined_error_ref_is_error() {
+        let src = r#"
+endpoint Create {
+    method POST
+    path   /items
+    errors [UndefinedError]
+}
+"#;
+        let (_, diags) = compile(src);
+        assert!(diags
+            .iter()
+            .any(|d| d.is_error() && d.message.contains("error")),);
+    }
+
+    #[test]
+    fn duplicate_route_is_error() {
+        let src = r#"
+endpoint A { method GET path /users }
+endpoint B { method GET path /users }
+"#;
+        let (_, diags) = compile(src);
+        assert!(diags
+            .iter()
+            .any(|d| d.is_error() && d.message.contains("duplicada")),);
+    }
+
+    #[test]
+    fn invalid_error_status_code_is_error() {
+        let src = r#"error BadCode { status 200 message "ok" }"#;
+        let (_, diags) = compile(src);
+        assert!(diags
+            .iter()
+            .any(|d| d.is_error() && d.message.contains("invalido")),);
     }
 }

--- a/docs/roadmap/STATUS.md
+++ b/docs/roadmap/STATUS.md
@@ -194,7 +194,7 @@ mas potente o pgbouncer. Criterios externos de comunidad pendientes.
 
 Estado: En curso. Iniciada 2026-05-21 en rama `fase-3`.
 RFC-0003 aceptada. Stack fijado: logos 0.14 (lexer), chumsky 0.9 (parser),
-format! macros v0.1 (codegen). Implementacion incremental v0.1 -> v0.4.
+format! macros (codegen). Implementacion incremental: v0.1 y v0.2 completados.
 
 ### Criterios de entrada (3.1)
 
@@ -206,21 +206,21 @@ format! macros v0.1 (codegen). Implementacion incremental v0.1 -> v0.4.
 
 ### Entregables (3.2)
 
-- [ ] DSL version 0.1: modelos basicos (@primary, @unique, @auto).
-- [ ] DSL version 0.2: endpoints (metodo, path, body, response).
+- [x] DSL version 0.1: modelos basicos (@primary, @unique, @auto). Commit 5aa442d.
+- [x] DSL version 0.2: endpoints (metodo, path, body, response, errors). Commit 7d41930.
 - [ ] DSL version 0.3: validaciones (@min, @max, @email, @regex, @length).
 - [ ] DSL version 0.4: relaciones entre modelos (1:1, 1:N, N:M).
-- [ ] Generador Rust: structs con serde.
-- [ ] Generador SQL: migraciones idempotentes.
-- [ ] Generador TypeScript: tipos y cliente HTTP.
-- [ ] Generador OpenAPI 3.1.
-- [ ] Comando ag generate.
-- [ ] Comando ag schema lint.
-- [ ] Comando ag schema diff.
-- [ ] Diagnostics legibles.
+- [x] Generador Rust: structs con serde (v0.1), types.rs + handlers.rs + router.rs (v0.2).
+- [x] Generador SQL: migraciones idempotentes (v0.1).
+- [x] Generador TypeScript: tipos y cliente HTTP (v0.1+v0.2).
+- [x] Generador OpenAPI 3.1: schemas (v0.1) + paths (v0.2).
+- [x] Comando ag generate. Operativo desde v0.1.
+- [x] Comando ag schema lint. Operativo desde v0.1.
+- [x] Comando ag schema diff. Operativo desde v0.1.
+- [x] Diagnostics legibles. Lex + parse + semantic con linea:columna.
 - [ ] Servidor LSP basico (ag-lsp).
 - [ ] Plugin VS Code.
-- [ ] Cobertura tests >= 85%.
+- [/] Cobertura tests >= 85%. 73 tests verdes; cobertura formal pendiente.
 - [ ] Fuzzing 24h sin crashes.
 - [ ] Documentacion de referencia del DSL.
 


### PR DESCRIPTION
# feat(fase-3): compilador Anti-DSL v0.1 — lexer, parser, semantic, codegen y CLI

## Resumen

Implementacion completa del primer incremento de la Fase 3: el compilador
`ag-dsl` pasa de skeleton vacio a un compilador funcional de extremo a extremo
que soporta DSL v0.1 (modelos, tipos primitivos, anotaciones @primary/@unique/@auto).
La CLI `ag` recibe tres comandos nuevos: `generate`, `schema lint`, `schema diff`.

## Fase afectada

Fase 3 — Anti-DSL alpha

## Tipo de cambio

- [x] Nueva feature
- [ ] Bugfix
- [ ] Refactor
- [ ] Documentacion

## Documentos relacionados

- `docs/rfc/RFC-0003-librerias-compilador-ag-dsl.md` (criterio de entrada)
- `docs/roadmap/STATUS.md` (fase 3 marcada como "En curso")
- `docs/roadmap/fase-03-anti-dsl-alpha.md`
- `docs/master/ANTI-GRAVITAL-Arquitectura-Tecnica.md` §7

## Cambios principales

### crates/ag-dsl

- `src/lexer.rs`: Token enum con logos 0.14 (keywords, tipos, anotaciones v0.1,
  literales, puntuacion). `tokenize()` separa tokens validos de errores de lex.
- `src/ast.rs`: tipos del AST — Schema, Config, ModelDef, FieldDef, FieldType,
  Annotation, DefaultValue, Spanned<T>.
- `src/parser.rs`: schema_parser() con chumsky 0.9. Soporta config{} y model{},
  campos con tipo, opcionalidad `?` y todas las anotaciones v0.1.
- `src/semantic.rs`: validaciones — nombres duplicados, modelo sin campos, campo
  @auto incompatible con tipo, @auto_update en no-Timestamp, multiples @primary.
- `src/diagnostics.rs`: Diagnostic con Severity, span, mensaje y hint. Formato
  legible linea:columna para el usuario.
- `src/codegen/rust_gen.rs`: genera structs Rust con serde, CreateRequest, UpdateRequest.
- `src/codegen/sql_gen.rs`: genera CREATE TABLE IF NOT EXISTS con PRIMARY KEY,
  UNIQUE INDEX, BIGSERIAL, gen_random_uuid(), tipos SQL correctos.
- `src/codegen/ts_gen.rs`: genera interfaces TypeScript con tipos precisos,
  Create/Update interfaces.
- `src/codegen/openapi_gen.rs`: genera OpenAPI 3.1 JSON con components/schemas,
  required fields, format annotations.
- `src/codegen/mod.rs`: generate() retorna GeneratedFiles (BTreeMap ruta->contenido).
- `src/lib.rs`: API publica compile() y generate().
- `Cargo.toml`: dependencias logos 0.14, chumsky 0.9, thiserror, serde_json.

### crates/ag-cli

- `ag generate [--schema] [--output]`: compila schema.ag y escribe 4 artefactos.
- `ag schema lint [--schema]`: reporta errores y warnings del schema.
- `ag schema diff <ref> [--schema]`: detecta cambios BREAKING vs additive.
- `Cargo.toml`: añade ag-dsl como dependencia.

### Workspace

- `Cargo.toml`: añade logos 0.14, chumsky 0.9, ag-dsl al workspace.

### Documentacion

- `docs/rfc/RFC-0003-librerias-compilador-ag-dsl.md`: decision formal sobre stack
  del compilador (criterio de entrada 3.1 de la Fase 3).
- `docs/rfc/README.md`: RFC-0003 añadida a la tabla.
- `docs/roadmap/STATUS.md`: Fase 3 marcada como "En curso", criterios de entrada
  marcados, entregables y criterios de salida listados.

## Plan de prueba

- [x] `cargo test -p ag-dsl -p ag-cli`: 56 tests verdes (50 ag-dsl + 5 ag-cli + 1 doctest)
- [x] `cargo clippy -p ag-dsl -p ag-cli --all-targets -- -D warnings`: limpio
- [x] `cargo fmt --check`: limpio
- [ ] `cargo audit`: pendiente (sin dependencias nuevas con CVEs conocidos)
- [ ] `cargo deny`: pendiente
- [ ] Test manual: crear schema.ag, ejecutar `ag generate`, verificar artefactos

## Criterios de salida que avanza

- [x] Criterio de entrada 3.1.3: RFC-0003 aceptada.
- Primer entregable 3.2.1 (DSL v0.1) en progreso — lexer, parser, semantic y
  codegen funcionales para modelos con tipos primitivos y anotaciones basicas.

## Checklist final

- [x] Pertenece a la fase correcta (Fase 3).
- [x] Respeta la documentacion (RFC-0003, Arquitectura §7, Hoja de Ruta §3).
- [x] No rompe arquitectura.
- [x] No anade complejidad innecesaria (format! sobre askama/quote para v0.1).
- [x] No crea dependencias circulares (ag-dsl no depende de ag-core).
- [x] Compila.
- [x] Pasa tests.
- [x] Pasa fmt.
- [x] Pasa clippy.
- [ ] Pasa audit.
- [ ] Tiene benchmarks (no aplica en este incremento).
- [x] Tiene documentacion (rustdoc en todos los modulos publicos).
- [x] Tiene manejo de errores correcto (pipeline lex->parse->semantic->Diagnostic).
- [x] Mantiene coherencia con Anti-Gravital v4.0.
