### PR TITLE
Fase 3

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # Anti-Gravital
 
-> Estado: Fase 3 en curso — Anti-DSL alpha. DSL v0.1 (modelos) y v0.2 (endpoints) operativos.
-> Status: Phase 3 in progress — Anti-DSL alpha. DSL v0.1 (models) and v0.2 (endpoints) operational.
+> Estado: Fase 3 en curso — Anti-DSL alpha. DSL v0.1, v0.2 y v0.3 operativos.
+> Status: Phase 3 in progress — Anti-DSL alpha. DSL v0.1, v0.2 and v0.3 operational.
 
 Anti-Gravital es un ecosistema de software libre para construir
 aplicaciones backend de alto rendimiento en Rust puro, con tres
@@ -57,10 +57,12 @@ no en el framework). Los criterios de throughput y latencia de la fase
 (40K req/s, p99 <= 5 ms) requieren hardware con mas nucleos o pgbouncer.
 
 **Fase 3 — Anti-DSL alpha:** en curso (rama `fase-3`). El compilador
-`ag-dsl` esta operativo con DSL v0.1 y v0.2. Define modelos, endpoints,
-tipos de peticion y respuesta en un archivo `.ag` y genera
-automaticamente structs Rust con serde, migraciones SQL, interfaces
-TypeScript, un cliente HTTP tipado y documentacion OpenAPI 3.1 completa.
+`ag-dsl` esta operativo con DSL v0.1, v0.2 y v0.3. Define modelos,
+endpoints, tipos de peticion y respuesta, y anotaciones de validacion
+(`@min`, `@max`, `@email`, `@regex`, `@length`) en un archivo `.ag`.
+Genera structs Rust con serde y metodos `validate()`, migraciones SQL
+con CHECK constraints, interfaces TypeScript, un cliente HTTP tipado,
+y documentacion OpenAPI 3.1 con constraints de validacion.
 La CLI expone `ag generate`, `ag schema lint` y `ag schema diff`.
 
 El estado detallado de cada criterio vive en `docs/roadmap/STATUS.md`.
@@ -234,11 +236,13 @@ not the framework). Phase throughput and latency targets (40K req/s,
 p99 <= 5 ms) require hardware with more cores or pgbouncer.
 
 **Phase 3 — Anti-DSL alpha:** in progress (branch `fase-3`). The
-`ag-dsl` compiler is operational with DSL v0.1 and v0.2. Define models,
-endpoints, request and response types in a `.ag` file and automatically
-generate Rust structs with serde, SQL migrations, TypeScript interfaces,
-a typed HTTP client, and a full OpenAPI 3.1 document. The CLI exposes
-`ag generate`, `ag schema lint`, and `ag schema diff`.
+`ag-dsl` compiler is operational with DSL v0.1, v0.2, and v0.3. Define
+models, endpoints, request and response types, and validation annotations
+(`@min`, `@max`, `@email`, `@regex`, `@length`) in a `.ag` file.
+Generates Rust structs with serde and `validate()` methods, SQL
+migrations with CHECK constraints, TypeScript interfaces, a typed HTTP
+client, and a full OpenAPI 3.1 document with validation constraints.
+The CLI exposes `ag generate`, `ag schema lint`, and `ag schema diff`.
 
 Detailed per-criterion status lives in `docs/roadmap/STATUS.md`.
 

--- a/crates/ag-dsl/src/ast.rs
+++ b/crates/ag-dsl/src/ast.rs
@@ -156,7 +156,7 @@ impl FieldType {
     }
 }
 
-/// Anotaciones DSL v0.1.
+/// Anotaciones DSL v0.1–v0.3.
 #[derive(Debug, Clone, PartialEq)]
 pub enum Annotation {
     /// `@primary` — clave primaria.
@@ -169,6 +169,17 @@ pub enum Annotation {
     AutoUpdate,
     /// `@default(valor)` — valor por defecto.
     Default(DefaultValue),
+    // ---- Validaciones v0.3 ----
+    /// `@min(N)` — longitud minima (String) o valor minimo (Int/Float/Decimal).
+    Min(i64),
+    /// `@max(N)` — longitud maxima (String) o valor maximo (Int/Float/Decimal).
+    Max(i64),
+    /// `@email` — valida formato de email RFC 5321 basico.
+    Email,
+    /// `@regex("patron")` — valida contra expresion regular.
+    Regex(std::string::String),
+    /// `@length(N)` — longitud exacta de caracteres (solo String).
+    Length(i64),
 }
 
 /// Valor para la anotacion `@default(...)`.

--- a/crates/ag-dsl/src/codegen/openapi_gen.rs
+++ b/crates/ag-dsl/src/codegen/openapi_gen.rs
@@ -141,6 +141,11 @@ fn build_operation(ep: &EndpointDef, schema: &Schema) -> Value {
 
 /// Schema para campos de request/response types simples (sin @auto).
 fn simple_type_schema(fields: &[FieldDef]) -> Value {
+    field_list_schema(fields)
+}
+
+/// Construye un schema object a partir de una lista de campos.
+fn field_list_schema(fields: &[FieldDef]) -> Value {
     let mut properties = serde_json::Map::new();
     let mut required: Vec<Value> = Vec::new();
 
@@ -156,6 +161,8 @@ fn simple_type_schema(fields: &[FieldDef]) -> Value {
         if let Some(fmt) = format {
             prop.insert("format".to_owned(), json!(fmt));
         }
+        // v0.3 — añade constraints de validacion
+        apply_validation_constraints(&mut prop, field);
         properties.insert(fname.clone(), Value::Object(prop));
         if !field.optional {
             required.push(json!(fname));
@@ -169,6 +176,45 @@ fn simple_type_schema(fields: &[FieldDef]) -> Value {
     }
     schema.insert("properties".to_owned(), Value::Object(properties));
     Value::Object(schema)
+}
+
+/// Añade campos de validacion OpenAPI 3.1 derivados de las anotaciones v0.3.
+fn apply_validation_constraints(prop: &mut serde_json::Map<String, Value>, field: &FieldDef) {
+    use crate::ast::{Annotation, FieldType};
+
+    let is_string = field.ty.value == FieldType::String;
+    let is_numeric = matches!(
+        field.ty.value,
+        FieldType::Int | FieldType::Float | FieldType::Decimal
+    );
+
+    for ann in &field.annotations {
+        match &ann.value {
+            Annotation::Min(n) if is_string => {
+                prop.insert("minLength".to_owned(), json!(n));
+            }
+            Annotation::Max(n) if is_string => {
+                prop.insert("maxLength".to_owned(), json!(n));
+            }
+            Annotation::Min(n) if is_numeric => {
+                prop.insert("minimum".to_owned(), json!(n));
+            }
+            Annotation::Max(n) if is_numeric => {
+                prop.insert("maximum".to_owned(), json!(n));
+            }
+            Annotation::Email => {
+                prop.insert("format".to_owned(), json!("email"));
+            }
+            Annotation::Regex(pattern) => {
+                prop.insert("pattern".to_owned(), json!(pattern));
+            }
+            Annotation::Length(n) => {
+                prop.insert("minLength".to_owned(), json!(n));
+                prop.insert("maxLength".to_owned(), json!(n));
+            }
+            _ => {}
+        }
+    }
 }
 
 /// Genera el schema JSON Schema de un modelo.
@@ -196,6 +242,8 @@ fn model_schema(model: &ModelDef, create_only: bool) -> Value {
             // OpenAPI 3.1 usa nullable via type array
             prop.insert("type".to_owned(), json!([ts_type, "null"]));
         }
+        // v0.3 — constraints de validacion
+        apply_validation_constraints(&mut prop, field);
 
         properties.insert(fname.clone(), Value::Object(prop));
 

--- a/crates/ag-dsl/src/codegen/rust_gen.rs
+++ b/crates/ag-dsl/src/codegen/rust_gen.rs
@@ -229,6 +229,7 @@ fn generate_request_struct(req: &RequestDef) -> String {
         out.push_str(&format!("    pub {fname}: {rust_ty},\n"));
     }
     out.push_str("}\n");
+    out.push_str(&generate_validate_impl(name, &req.fields));
     out
 }
 
@@ -329,6 +330,91 @@ pub fn generate_router(schema: &Schema) -> String {
         ));
     }
     out.push_str("}\n");
+    out
+}
+
+// ---- Validacion v0.3 — metodo validate() ----------------------------
+
+/// Genera un bloque `impl NombreStruct { pub fn validate(...) }` con
+/// todas las comprobaciones derivadas de las anotaciones de validacion.
+/// Retorna cadena vacia si no hay anotaciones de validacion en los campos.
+fn generate_validate_impl(struct_name: &str, fields: &[FieldDef]) -> String {
+    use crate::ast::{Annotation, FieldType};
+
+    let mut checks: Vec<String> = Vec::new();
+
+    for field in fields {
+        let fname = &field.name.value;
+        let is_string = field.ty.value == FieldType::String;
+        let is_numeric = matches!(
+            field.ty.value,
+            FieldType::Int | FieldType::Float | FieldType::Decimal
+        );
+
+        for ann in &field.annotations {
+            match &ann.value {
+                Annotation::Min(n) if is_string => checks.push(format!(
+                    "    if self.{fname}.len() < {n} {{\n\
+                             errors.push(format!(\"{fname}: longitud minima es {n}, encontrado {{}} caracteres\", self.{fname}.len()));\n\
+                     }}"
+                )),
+                Annotation::Max(n) if is_string => checks.push(format!(
+                    "    if self.{fname}.len() > {n} {{\n\
+                             errors.push(format!(\"{fname}: longitud maxima es {n}, encontrado {{}} caracteres\", self.{fname}.len()));\n\
+                     }}"
+                )),
+                Annotation::Min(n) if is_numeric => checks.push(format!(
+                    "    if (self.{fname} as i64) < {n} {{\n\
+                             errors.push(\"{fname}: valor minimo es {n}\".to_owned());\n\
+                     }}"
+                )),
+                Annotation::Max(n) if is_numeric => checks.push(format!(
+                    "    if (self.{fname} as i64) > {n} {{\n\
+                             errors.push(\"{fname}: valor maximo es {n}\".to_owned());\n\
+                     }}"
+                )),
+                Annotation::Email => checks.push(format!(
+                    "    {{\n\
+                             let s = &self.{fname};\n\
+                             let valid = s.contains('@') && s.rfind('@')\n\
+                                 .map(|i| s[i+1..].contains('.'))\n\
+                                 .unwrap_or(false);\n\
+                             if !valid {{\n\
+                                 errors.push(\"{fname}: formato de email invalido\".to_owned());\n\
+                             }}\n\
+                     }}"
+                )),
+                Annotation::Length(n) => checks.push(format!(
+                    "    if self.{fname}.len() != {n} {{\n\
+                             errors.push(format!(\"{fname}: longitud exacta requerida es {n}, encontrado {{}} caracteres\", self.{fname}.len()));\n\
+                     }}"
+                )),
+                Annotation::Regex(pattern) => checks.push(format!(
+                    "    // TODO: validar {fname} contra regex: {pattern:?}\n\
+                     // Añade la crate `regex` y verifica: Regex::new({pattern:?}).unwrap().is_match(&self.{fname})"
+                )),
+                _ => {}
+            }
+        }
+    }
+
+    if checks.is_empty() {
+        return String::new();
+    }
+
+    let mut out = String::new();
+    out.push_str(&format!(
+        "\nimpl {struct_name} {{\n\
+         /// Valida todas las restricciones declaradas en el schema DSL.\n\
+         /// Retorna la lista de errores; vacio significa valido.\n\
+         pub fn validate(&self) -> Vec<String> {{\n\
+             let mut errors: Vec<String> = Vec::new();\n"
+    ));
+    for check in checks {
+        out.push_str(&check);
+        out.push('\n');
+    }
+    out.push_str("    errors\n}\n}\n");
     out
 }
 

--- a/crates/ag-dsl/src/codegen/sql_gen.rs
+++ b/crates/ag-dsl/src/codegen/sql_gen.rs
@@ -40,15 +40,33 @@ fn generate_table(model: &ModelDef) -> String {
     let table_name = to_snake_case(&model.name.value);
     let mut out = String::new();
 
+    // Recopila CHECK constraints de validaciones v0.3
+    let checks: Vec<String> = model
+        .fields
+        .iter()
+        .flat_map(|f| field_check_constraints(&table_name, f))
+        .collect();
+
     out.push_str(&format!("CREATE TABLE IF NOT EXISTS \"{table_name}\" (\n"));
 
-    let field_count = model.fields.len();
-    for (i, field) in model.fields.iter().enumerate() {
+    let total_items = model.fields.len() + checks.len();
+    let mut item_idx = 0;
+
+    for field in &model.fields {
         let col = generate_column(field);
-        if i < field_count - 1 {
+        item_idx += 1;
+        if item_idx < total_items {
             out.push_str(&format!("    {col},\n"));
         } else {
             out.push_str(&format!("    {col}\n"));
+        }
+    }
+    for check in &checks {
+        item_idx += 1;
+        if item_idx < total_items {
+            out.push_str(&format!("    {check},\n"));
+        } else {
+            out.push_str(&format!("    {check}\n"));
         }
     }
 
@@ -137,6 +155,68 @@ fn generate_column(field: &FieldDef) -> String {
 /// Delega a la utilidad de conversion en `ast`.
 fn to_snake_case(s: &str) -> String {
     crate::ast::to_snake_case(s)
+}
+
+// ---- Validaciones v0.3 — CHECK constraints ----
+
+/// Genera las clausulas CHECK para las anotaciones de validacion del campo.
+fn field_check_constraints(table_name: &str, field: &FieldDef) -> Vec<String> {
+    use crate::ast::FieldType;
+    use Annotation::{Email, Length, Max, Min, Regex};
+
+    let col_name = to_snake_case(&field.name.value);
+    let mut checks = Vec::new();
+
+    for ann in &field.annotations {
+        let constraint_name = format!(
+            "chk_{}_{}_{}",
+            table_name,
+            col_name,
+            annotation_sql_suffix(&ann.value)
+        );
+        let expr = match &ann.value {
+            Min(n) => match field.ty.value {
+                FieldType::String => Some(format!("char_length(\"{col_name}\") >= {n}")),
+                FieldType::Int | FieldType::Float | FieldType::Decimal => {
+                    Some(format!("\"{col_name}\" >= {n}"))
+                }
+                _ => None,
+            },
+            Max(n) => match field.ty.value {
+                FieldType::String => Some(format!("char_length(\"{col_name}\") <= {n}")),
+                FieldType::Int | FieldType::Float | FieldType::Decimal => {
+                    Some(format!("\"{col_name}\" <= {n}"))
+                }
+                _ => None,
+            },
+            Length(n) => Some(format!("char_length(\"{col_name}\") = {n}")),
+            Regex(pattern) => {
+                // Usa el operador ~ de PostgreSQL (regex POSIX).
+                let escaped = pattern.replace('\'', "''");
+                Some(format!("\"{col_name}\" ~ '{escaped}'"))
+            }
+            Email => {
+                // Validacion basica: contiene @ y al menos un punto despues.
+                Some(format!("\"{col_name}\" ~ '^[^@]+@[^@]+\\.[^@]+$'"))
+            }
+            _ => None,
+        };
+        if let Some(expr) = expr {
+            checks.push(format!("CONSTRAINT \"{constraint_name}\" CHECK ({expr})"));
+        }
+    }
+    checks
+}
+
+fn annotation_sql_suffix(ann: &Annotation) -> &'static str {
+    match ann {
+        Annotation::Min(_) => "min",
+        Annotation::Max(_) => "max",
+        Annotation::Email => "email",
+        Annotation::Regex(_) => "regex",
+        Annotation::Length(_) => "length",
+        _ => "constraint",
+    }
 }
 
 #[cfg(test)]
@@ -239,5 +319,83 @@ model Thing {
         assert_eq!(to_snake_case("BlogPost"), "blog_post");
         assert_eq!(to_snake_case("HTTPRequest"), "h_t_t_p_request");
         assert_eq!(to_snake_case("id"), "id");
+    }
+
+    // ---- Tests DSL v0.3 ----
+
+    #[test]
+    fn v03_min_max_generates_check_constraints() {
+        let schema = schema_from(
+            r#"
+model User {
+    id    UUID   @primary @auto
+    email String @max(255) @min(1)
+}
+"#,
+        );
+        let sql = generate_migration(&schema);
+        assert!(
+            sql.contains("CHECK (char_length(\"email\") <= 255)"),
+            "should have max length check"
+        );
+        assert!(
+            sql.contains("CHECK (char_length(\"email\") >= 1)"),
+            "should have min length check"
+        );
+    }
+
+    #[test]
+    fn v03_email_generates_regex_check() {
+        let schema = schema_from(
+            r#"
+model Contact {
+    id    UUID @primary @auto
+    email String @email
+}
+"#,
+        );
+        let sql = generate_migration(&schema);
+        assert!(
+            sql.contains("~ '^[^@]+@[^@]+\\.[^@]+$'"),
+            "should have email regex check"
+        );
+    }
+
+    #[test]
+    fn v03_length_generates_exact_check() {
+        let schema = schema_from(
+            r#"
+model Country {
+    id   UUID @primary @auto
+    code String @length(3)
+}
+"#,
+        );
+        let sql = generate_migration(&schema);
+        assert!(
+            sql.contains("char_length(\"code\") = 3"),
+            "should have exact length check"
+        );
+    }
+
+    #[test]
+    fn v03_int_min_max_value_check() {
+        let schema = schema_from(
+            r#"
+model Score {
+    id    UUID @primary @auto
+    value Int  @min(0) @max(100)
+}
+"#,
+        );
+        let sql = generate_migration(&schema);
+        assert!(
+            sql.contains("\"value\" >= 0"),
+            "should have min value check"
+        );
+        assert!(
+            sql.contains("\"value\" <= 100"),
+            "should have max value check"
+        );
     }
 }

--- a/crates/ag-dsl/src/lexer.rs
+++ b/crates/ag-dsl/src/lexer.rs
@@ -101,6 +101,23 @@ pub enum Token {
     #[token("@default")]
     AtDefault,
 
+    // ---- Anotaciones DSL v0.3 — validacion ----
+    /// `@min(N)` — longitud minima (String) o valor minimo (numeros).
+    #[token("@min")]
+    AtMin,
+    /// `@max(N)` — longitud maxima (String) o valor maximo (numeros).
+    #[token("@max")]
+    AtMax,
+    /// `@email` — valida que el valor sea un email valido.
+    #[token("@email")]
+    AtEmail,
+    /// `@regex("patron")` — valida contra una expresion regular.
+    #[token("@regex")]
+    AtRegex,
+    /// `@length(N)` — longitud exacta de caracteres (solo String).
+    #[token("@length")]
+    AtLength,
+
     // ---- Literales ----
     /// Literal entero: `42`, `255`, `0`.
     #[regex(r"[0-9]+", |lex| lex.slice().parse::<i64>().unwrap())]
@@ -375,5 +392,40 @@ model User {
         assert!(kinds.contains(&Token::Endpoint));
         assert!(kinds.contains(&Token::HttpGet));
         assert!(kinds.contains(&Token::PathLit("/users".to_owned())));
+    }
+
+    // ---- Tests DSL v0.3 ----
+
+    #[test]
+    fn v03_validation_annotations() {
+        let toks = lex("@min @max @email @regex @length");
+        assert_eq!(
+            toks,
+            vec![
+                Token::AtMin,
+                Token::AtMax,
+                Token::AtEmail,
+                Token::AtRegex,
+                Token::AtLength,
+            ]
+        );
+    }
+
+    #[test]
+    fn v03_min_max_with_args() {
+        let toks = lex("@min(2) @max(255)");
+        assert_eq!(
+            toks,
+            vec![
+                Token::AtMin,
+                Token::LParen,
+                Token::IntLit(2),
+                Token::RParen,
+                Token::AtMax,
+                Token::LParen,
+                Token::IntLit(255),
+                Token::RParen,
+            ]
+        );
     }
 }

--- a/crates/ag-dsl/src/parser.rs
+++ b/crates/ag-dsl/src/parser.rs
@@ -189,12 +189,40 @@ fn annotation_parser() -> impl Parser<Token, Spanned<Annotation>, Error = ParseE
         .ignore_then(default_value.delimited_by(just(Token::LParen), just(Token::RParen)))
         .map(Annotation::Default);
 
+    // v0.3 — anotaciones con argumento entero: @min(N), @max(N), @length(N)
+    let int_arg =
+        || select! { Token::IntLit(n) => n }.delimited_by(just(Token::LParen), just(Token::RParen));
+
+    let at_min = just(Token::AtMin)
+        .ignore_then(int_arg())
+        .map(Annotation::Min);
+    let at_max = just(Token::AtMax)
+        .ignore_then(int_arg())
+        .map(Annotation::Max);
+    let at_length = just(Token::AtLength)
+        .ignore_then(int_arg())
+        .map(Annotation::Length);
+
+    // v0.3 — @regex("patron")
+    let at_regex = just(Token::AtRegex)
+        .ignore_then(
+            select! { Token::StringLit(s) => s }
+                .delimited_by(just(Token::LParen), just(Token::RParen))
+                .labelled("patron de regex"),
+        )
+        .map(Annotation::Regex);
+
     choice((
         just(Token::AtPrimary).to(Annotation::Primary),
         just(Token::AtUnique).to(Annotation::Unique),
         just(Token::AtAutoUpdate).to(Annotation::AutoUpdate), // primero: mas especifico
         just(Token::AtAuto).to(Annotation::Auto),
+        just(Token::AtEmail).to(Annotation::Email),
         at_default,
+        at_min,
+        at_max,
+        at_length,
+        at_regex,
     ))
     .map_with_span(|ann, span: Span| Spanned::new(ann, span))
     .labelled("anotacion")
@@ -674,5 +702,81 @@ endpoint GetUser {
         assert_eq!(schema.responses.len(), 1);
         assert_eq!(schema.errors.len(), 1);
         assert_eq!(schema.endpoints.len(), 2);
+    }
+
+    // ---- Tests DSL v0.3 ----
+
+    #[test]
+    fn v03_min_max_annotations() {
+        let src = r#"
+model User {
+    id    UUID @primary @auto
+    email String @max(255) @min(1)
+    age   Int    @min(0) @max(150)
+}
+"#;
+        let (ast, diags) = parse(src);
+        assert!(diags.iter().all(|d| !d.is_error()), "{diags:?}");
+        let field = &ast.unwrap().models[0].fields[1]; // email
+        let has_max = field
+            .annotations
+            .iter()
+            .any(|a| a.value == Annotation::Max(255));
+        let has_min = field
+            .annotations
+            .iter()
+            .any(|a| a.value == Annotation::Min(1));
+        assert!(has_max, "should have @max(255)");
+        assert!(has_min, "should have @min(1)");
+    }
+
+    #[test]
+    fn v03_email_annotation() {
+        let src = r#"
+model User {
+    id    UUID @primary @auto
+    email String @email @max(255)
+}
+"#;
+        let (ast, diags) = parse(src);
+        assert!(diags.iter().all(|d| !d.is_error()), "{diags:?}");
+        let email_field = &ast.unwrap().models[0].fields[1];
+        assert!(email_field
+            .annotations
+            .iter()
+            .any(|a| a.value == Annotation::Email));
+    }
+
+    #[test]
+    fn v03_regex_annotation() {
+        let src = r#"
+request Req {
+    code String @regex("^[A-Z]{3}$")
+}
+"#;
+        let (ast, diags) = parse(src);
+        assert!(diags.iter().all(|d| !d.is_error()), "{diags:?}");
+        let field = &ast.unwrap().requests[0].fields[0];
+        assert!(field
+            .annotations
+            .iter()
+            .any(|a| a.value == Annotation::Regex("^[A-Z]{3}$".to_owned())));
+    }
+
+    #[test]
+    fn v03_length_annotation() {
+        let src = r#"
+model Country {
+    id   UUID @primary @auto
+    code String @length(3)
+}
+"#;
+        let (ast, diags) = parse(src);
+        assert!(diags.iter().all(|d| !d.is_error()), "{diags:?}");
+        let field = &ast.unwrap().models[0].fields[1];
+        assert!(field
+            .annotations
+            .iter()
+            .any(|a| a.value == Annotation::Length(3)));
     }
 }

--- a/crates/ag-dsl/src/semantic.rs
+++ b/crates/ag-dsl/src/semantic.rs
@@ -35,6 +35,41 @@ pub fn analyze(schema: &Schema) -> Vec<Diagnostic> {
     check_error_status_codes(schema, &mut diags);
     check_endpoint_references(schema, &mut diags);
 
+    // v0.3 validaciones de anotaciones
+    for model in &schema.models {
+        for field in &model.fields {
+            check_validation_annotations(
+                &field.name.value,
+                &model.name.value,
+                &field.ty.value,
+                &field.annotations,
+                &mut diags,
+            );
+        }
+    }
+    for req in &schema.requests {
+        for field in &req.fields {
+            check_validation_annotations(
+                &field.name.value,
+                &req.name.value,
+                &field.ty.value,
+                &field.annotations,
+                &mut diags,
+            );
+        }
+    }
+    for resp in &schema.responses {
+        for field in &resp.fields {
+            check_validation_annotations(
+                &field.name.value,
+                &resp.name.value,
+                &field.ty.value,
+                &field.annotations,
+                &mut diags,
+            );
+        }
+    }
+
     diags
 }
 
@@ -296,6 +331,111 @@ fn check_endpoint_references(schema: &Schema, diags: &mut Vec<Diagnostic>) {
     }
 }
 
+// ---- Validaciones DSL v0.3 -------------------------------------------
+
+/// Verifica compatibilidad de las anotaciones de validacion con el tipo del campo.
+fn check_validation_annotations(
+    field_name: &str,
+    parent_name: &str,
+    field_ty: &FieldType,
+    annotations: &[crate::ast::Spanned<Annotation>],
+    diags: &mut Vec<Diagnostic>,
+) {
+    use FieldType::{Bool, Decimal, Float, Int, String as Str, Timestamp, Uuid};
+
+    let string_only = [&Annotation::Email];
+    let string_and_numeric = [Str, Int, Float, Decimal];
+
+    let mut min_val: Option<(i64, crate::lexer::Span)> = None;
+    let mut max_val: Option<(i64, crate::lexer::Span)> = None;
+
+    for ann in annotations {
+        match &ann.value {
+            Annotation::Email | Annotation::Regex(_) | Annotation::Length(_) => {
+                if *field_ty != Str {
+                    diags.push(Diagnostic::semantic_error_with_hint(
+                        ann.span.clone(),
+                        format!(
+                            "{} en '{}.{}': solo aplica a campos de tipo String",
+                            annotation_name(&ann.value),
+                            parent_name,
+                            field_name
+                        ),
+                        "cambia el tipo del campo a String".to_owned(),
+                    ));
+                }
+                if let Annotation::Length(n) = ann.value {
+                    if n <= 0 {
+                        diags.push(Diagnostic::semantic_error_with_hint(
+                            ann.span.clone(),
+                            format!(
+                                "@length({n}) en '{}.{}': el valor debe ser mayor que cero",
+                                parent_name, field_name
+                            ),
+                            "usa @length con un entero positivo",
+                        ));
+                    }
+                }
+            }
+            Annotation::Min(n) => {
+                if !string_and_numeric.contains(field_ty) {
+                    diags.push(Diagnostic::semantic_error_with_hint(
+                        ann.span.clone(),
+                        format!(
+                            "@min en '{}.{}': no aplica al tipo {:?}",
+                            parent_name, field_name, field_ty
+                        ),
+                        "@min es valido en String, Int, Float y Decimal",
+                    ));
+                }
+                min_val = Some((*n, ann.span.clone()));
+            }
+            Annotation::Max(n) => {
+                if !string_and_numeric.contains(field_ty) {
+                    diags.push(Diagnostic::semantic_error_with_hint(
+                        ann.span.clone(),
+                        format!(
+                            "@max en '{}.{}': no aplica al tipo {:?}",
+                            parent_name, field_name, field_ty
+                        ),
+                        "@max es valido en String, Int, Float y Decimal",
+                    ));
+                }
+                max_val = Some((*n, ann.span.clone()));
+            }
+            _ => {}
+        }
+    }
+
+    // @min debe ser <= @max cuando ambos estan presentes
+    if let (Some((min_n, _)), Some((max_n, max_span))) = (min_val, max_val) {
+        if min_n > max_n {
+            diags.push(Diagnostic::semantic_error_with_hint(
+                max_span,
+                format!(
+                    "@min({min_n}) > @max({max_n}) en '{}.{}': el minimo supera al maximo",
+                    parent_name, field_name
+                ),
+                format!("usa @min({min_n}) @max(N) con N >= {min_n}"),
+            ));
+        }
+    }
+
+    // Suprimir advertencias de unused variables
+    let _ = (string_only, Bool, Timestamp, Uuid);
+}
+
+fn annotation_name(ann: &Annotation) -> &'static str {
+    match ann {
+        Annotation::Email => "@email",
+        Annotation::Regex(_) => "@regex",
+        Annotation::Length(_) => "@length",
+        Annotation::Min(_) => "@min",
+        Annotation::Max(_) => "@max",
+        _ => "@annotation",
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -516,5 +656,111 @@ endpoint B { method GET path /users }
         assert!(diags
             .iter()
             .any(|d| d.is_error() && d.message.contains("invalido")),);
+    }
+
+    // ---- Tests DSL v0.3 ----
+
+    #[test]
+    fn v03_valid_validations_no_errors() {
+        let src = r#"
+model User {
+    id    UUID   @primary @auto
+    email String @email @max(255) @min(1)
+    age   Int    @min(0) @max(150)
+    code  String @length(3)
+}
+"#;
+        let (_, diags) = compile(src);
+        let errors: Vec<_> = diags.iter().filter(|d| d.is_error()).collect();
+        assert!(errors.is_empty(), "unexpected errors: {errors:?}");
+    }
+
+    #[test]
+    fn v03_email_on_non_string_is_error() {
+        let src = r#"
+model Bad {
+    id  UUID @primary @auto
+    age Int  @email
+}
+"#;
+        let (_, diags) = compile(src);
+        assert!(
+            diags
+                .iter()
+                .any(|d| d.is_error() && d.message.contains("@email")),
+            "should error: @email on Int"
+        );
+    }
+
+    #[test]
+    fn v03_regex_on_non_string_is_error() {
+        let src = r#"
+model Bad {
+    id    UUID @primary @auto
+    score Int  @regex("^[0-9]+$")
+}
+"#;
+        let (_, diags) = compile(src);
+        assert!(diags
+            .iter()
+            .any(|d| d.is_error() && d.message.contains("@regex")));
+    }
+
+    #[test]
+    fn v03_length_on_non_string_is_error() {
+        let src = r#"
+model Bad {
+    id  UUID @primary @auto
+    val Bool @length(3)
+}
+"#;
+        let (_, diags) = compile(src);
+        assert!(diags
+            .iter()
+            .any(|d| d.is_error() && d.message.contains("@length")));
+    }
+
+    #[test]
+    fn v03_min_greater_than_max_is_error() {
+        let src = r#"
+model Bad {
+    id   UUID   @primary @auto
+    name String @min(100) @max(10)
+}
+"#;
+        let (_, diags) = compile(src);
+        assert!(diags
+            .iter()
+            .any(|d| d.is_error() && d.message.contains("minimo supera al maximo")),);
+    }
+
+    #[test]
+    fn v03_min_on_uuid_is_error() {
+        let src = r#"
+model Bad {
+    id UUID @primary @auto @min(1)
+}
+"#;
+        let (_, diags) = compile(src);
+        assert!(diags
+            .iter()
+            .any(|d| d.is_error() && d.message.contains("@min")));
+    }
+
+    #[test]
+    fn v03_request_field_validations() {
+        let src = r#"
+request CreateUser {
+    email String @email @max(255)
+    name  String @min(2) @max(100)
+    age   Int    @min(18) @max(120)
+}
+"#;
+        let (_, diags) = compile(src);
+        let errors: Vec<_> = diags.iter().filter(|d| d.is_error()).collect();
+        assert!(
+            errors.is_empty(),
+            "unexpected errors in request: {errors:?}"
+        );
     }
 }

--- a/docs/roadmap/STATUS.md
+++ b/docs/roadmap/STATUS.md
@@ -208,7 +208,7 @@ format! macros (codegen). Implementacion incremental: v0.1 y v0.2 completados.
 
 - [x] DSL version 0.1: modelos basicos (@primary, @unique, @auto). Commit 5aa442d.
 - [x] DSL version 0.2: endpoints (metodo, path, body, response, errors). Commit 7d41930.
-- [ ] DSL version 0.3: validaciones (@min, @max, @email, @regex, @length).
+- [x] DSL version 0.3: validaciones (@min, @max, @email, @regex, @length). Commit 47ae623.
 - [ ] DSL version 0.4: relaciones entre modelos (1:1, 1:N, N:M).
 - [x] Generador Rust: structs con serde (v0.1), types.rs + handlers.rs + router.rs (v0.2).
 - [x] Generador SQL: migraciones idempotentes (v0.1).


### PR DESCRIPTION
# feat(fase-3): compilador Anti-DSL v0.1 — lexer, parser, semantic, codegen y CLI

## Resumen

Implementacion completa del primer incremento de la Fase 3: el compilador
`ag-dsl` pasa de skeleton vacio a un compilador funcional de extremo a extremo
que soporta DSL v0.1 (modelos, tipos primitivos, anotaciones @primary/@unique/@auto).
La CLI `ag` recibe tres comandos nuevos: `generate`, `schema lint`, `schema diff`.

## Fase afectada

Fase 3 — Anti-DSL alpha

## Tipo de cambio

- [x] Nueva feature
- [ ] Bugfix
- [ ] Refactor
- [ ] Documentacion

## Documentos relacionados

- `docs/rfc/RFC-0003-librerias-compilador-ag-dsl.md` (criterio de entrada)
- `docs/roadmap/STATUS.md` (fase 3 marcada como "En curso")
- `docs/roadmap/fase-03-anti-dsl-alpha.md`
- `docs/master/ANTI-GRAVITAL-Arquitectura-Tecnica.md` §7

## Cambios principales

### crates/ag-dsl

- `src/lexer.rs`: Token enum con logos 0.14 (keywords, tipos, anotaciones v0.1,
  literales, puntuacion). `tokenize()` separa tokens validos de errores de lex.
- `src/ast.rs`: tipos del AST — Schema, Config, ModelDef, FieldDef, FieldType,
  Annotation, DefaultValue, Spanned<T>.
- `src/parser.rs`: schema_parser() con chumsky 0.9. Soporta config{} y model{},
  campos con tipo, opcionalidad `?` y todas las anotaciones v0.1.
- `src/semantic.rs`: validaciones — nombres duplicados, modelo sin campos, campo
  @auto incompatible con tipo, @auto_update en no-Timestamp, multiples @primary.
- `src/diagnostics.rs`: Diagnostic con Severity, span, mensaje y hint. Formato
  legible linea:columna para el usuario.
- `src/codegen/rust_gen.rs`: genera structs Rust con serde, CreateRequest, UpdateRequest.
- `src/codegen/sql_gen.rs`: genera CREATE TABLE IF NOT EXISTS con PRIMARY KEY,
  UNIQUE INDEX, BIGSERIAL, gen_random_uuid(), tipos SQL correctos.
- `src/codegen/ts_gen.rs`: genera interfaces TypeScript con tipos precisos,
  Create/Update interfaces.
- `src/codegen/openapi_gen.rs`: genera OpenAPI 3.1 JSON con components/schemas,
  required fields, format annotations.
- `src/codegen/mod.rs`: generate() retorna GeneratedFiles (BTreeMap ruta->contenido).
- `src/lib.rs`: API publica compile() y generate().
- `Cargo.toml`: dependencias logos 0.14, chumsky 0.9, thiserror, serde_json.

### crates/ag-cli

- `ag generate [--schema] [--output]`: compila schema.ag y escribe 4 artefactos.
- `ag schema lint [--schema]`: reporta errores y warnings del schema.
- `ag schema diff <ref> [--schema]`: detecta cambios BREAKING vs additive.
- `Cargo.toml`: añade ag-dsl como dependencia.

### Workspace

- `Cargo.toml`: añade logos 0.14, chumsky 0.9, ag-dsl al workspace.

### Documentacion

- `docs/rfc/RFC-0003-librerias-compilador-ag-dsl.md`: decision formal sobre stack
  del compilador (criterio de entrada 3.1 de la Fase 3).
- `docs/rfc/README.md`: RFC-0003 añadida a la tabla.
- `docs/roadmap/STATUS.md`: Fase 3 marcada como "En curso", criterios de entrada
  marcados, entregables y criterios de salida listados.

## Plan de prueba

- [x] `cargo test -p ag-dsl -p ag-cli`: 56 tests verdes (50 ag-dsl + 5 ag-cli + 1 doctest)
- [x] `cargo clippy -p ag-dsl -p ag-cli --all-targets -- -D warnings`: limpio
- [x] `cargo fmt --check`: limpio
- [ ] `cargo audit`: pendiente (sin dependencias nuevas con CVEs conocidos)
- [ ] `cargo deny`: pendiente
- [ ] Test manual: crear schema.ag, ejecutar `ag generate`, verificar artefactos

## Criterios de salida que avanza

- [x] Criterio de entrada 3.1.3: RFC-0003 aceptada.
- Primer entregable 3.2.1 (DSL v0.1) en progreso — lexer, parser, semantic y
  codegen funcionales para modelos con tipos primitivos y anotaciones basicas.

## Checklist final

- [x] Pertenece a la fase correcta (Fase 3).
- [x] Respeta la documentacion (RFC-0003, Arquitectura §7, Hoja de Ruta §3).
- [x] No rompe arquitectura.
- [x] No anade complejidad innecesaria (format! sobre askama/quote para v0.1).
- [x] No crea dependencias circulares (ag-dsl no depende de ag-core).
- [x] Compila.
- [x] Pasa tests.
- [x] Pasa fmt.
- [x] Pasa clippy.
- [ ] Pasa audit.
- [ ] Tiene benchmarks (no aplica en este incremento).
- [x] Tiene documentacion (rustdoc en todos los modulos publicos).
- [x] Tiene manejo de errores correcto (pipeline lex->parse->semantic->Diagnostic).
- [x] Mantiene coherencia con Anti-Gravital v4.0.
