### PR TITLE
test(dsl): cobertura 95.26% lineas — tests de integracion compile()/g…

### DIFF
--- a/crates/ag-dsl/src/lib.rs
+++ b/crates/ag-dsl/src/lib.rs
@@ -49,14 +49,14 @@ mod semantic;
 pub use codegen::{generate, GeneratedFiles};
 pub use diagnostics::Diagnostic;
 
-/// Compila un texto fuente DSL y retorna el AST si no hay errores.
+/// Compila texto fuente DSL y retorna el AST si no hay errores de lex, parse o semantica.
 ///
 /// Los warnings (como un modelo sin @primary) no bloquean la compilacion.
 /// Solo los errores de severidad `Error` producen `Err`.
 ///
 /// # Errors
 ///
-/// Retorna `Err(Vec<Diagnostic>)` si hay errores de lex, parse o semantic.
+/// Retorna `Err(Vec<Diagnostic>)` si hay errores de lex, parse o semanticos.
 pub fn compile(source: &str) -> Result<ast::Schema, Vec<Diagnostic>> {
     let (tokens, lex_spans) = lexer::tokenize(source);
 
@@ -85,5 +85,128 @@ pub fn compile(source: &str) -> Result<ast::Schema, Vec<Diagnostic>> {
             }
             Err(all_diags)
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    const VALID_MODEL: &str = r#"
+model User {
+    id    UUID   @primary @auto
+    email String @unique @email @max(255)
+    name  String @min(2)
+}
+"#;
+
+    #[test]
+    fn compile_valid_schema_returns_ok() {
+        let schema = compile(VALID_MODEL).expect("valid schema should compile");
+        assert_eq!(schema.models.len(), 1);
+        assert_eq!(schema.models[0].name.value, "User");
+    }
+
+    #[test]
+    fn compile_with_warnings_returns_ok() {
+        let src = "model Tag { name String }";
+        let schema = compile(src).expect("warnings should not block compilation");
+        assert_eq!(schema.models[0].name.value, "Tag");
+    }
+
+    #[test]
+    fn compile_semantic_error_returns_err() {
+        let src = "model Bad { id UUID @primary @auto @min(1) }";
+        let diags = compile(src).expect_err("@min on UUID should fail");
+        assert!(diags.iter().any(|d| d.is_error()));
+    }
+
+    #[test]
+    fn compile_parse_error_returns_err() {
+        let src = "model Unclosed { id UUID @primary @auto";
+        let diags = compile(src).expect_err("unclosed brace should fail");
+        assert!(diags.iter().any(|d| d.is_error()));
+    }
+
+    #[test]
+    fn compile_lex_error_returns_err() {
+        let src = "model Bad { id UUID @ }";
+        assert!(compile(src).is_err());
+    }
+
+    #[test]
+    fn generate_produces_files_for_valid_schema() {
+        let schema = compile(VALID_MODEL).unwrap();
+        let files = generate(&schema);
+        assert!(!files.files.is_empty());
+        let paths: Vec<_> = files.files.keys().collect();
+        assert!(
+            paths.iter().any(|p| p.to_string_lossy().contains("models")),
+            "should generate models file"
+        );
+        assert!(
+            paths.iter().any(|p| p.to_string_lossy().contains("sql")),
+            "should generate migration"
+        );
+    }
+
+    #[test]
+    fn generate_full_schema_produces_all_artefacts() {
+        let src = r#"
+config { project_name "test" database "postgres" }
+model User {
+    id    UUID   @primary @auto
+    email String @unique @email @max(255)
+}
+request CreateUser { email String @email }
+response UserResp  { id UUID email String }
+error EmailTaken   { status 409 message "taken" }
+endpoint CreateUser {
+    method POST
+    path   /users
+    body   CreateUser
+    response UserResp
+    errors [EmailTaken]
+}
+endpoint GetUser {
+    method GET
+    path   /users/{id}
+    response UserResp
+    errors [EmailTaken]
+}
+"#;
+        let schema = compile(src).expect("full schema should compile");
+        let files = generate(&schema);
+        let paths: Vec<_> = files
+            .files
+            .keys()
+            .map(|p| p.to_string_lossy().into_owned())
+            .collect();
+        assert!(paths.iter().any(|p| p.contains("handlers")), "handlers");
+        assert!(paths.iter().any(|p| p.contains("router")), "router");
+        assert!(paths.iter().any(|p| p.contains("types")), "types");
+        assert!(paths.iter().any(|p| p.contains("client")), "client");
+        assert!(paths.iter().any(|p| p.contains("openapi")), "openapi");
+    }
+
+    #[test]
+    fn generate_with_relations_produces_fk_sql() {
+        let src = r#"
+model User { id UUID @primary @auto }
+model Post {
+    id        UUID @primary @auto
+    author_id UUID @references(User.id)
+    author    User @relation(author_id)
+}
+"#;
+        let schema = compile(src).unwrap();
+        let files = generate(&schema);
+        let sql = files
+            .files
+            .iter()
+            .find(|(p, _)| p.to_string_lossy().contains("sql"))
+            .map(|(_, c)| c.as_str())
+            .unwrap_or("");
+        assert!(sql.contains("FOREIGN KEY"), "should have FK in SQL");
     }
 }

--- a/docs/roadmap/STATUS.md
+++ b/docs/roadmap/STATUS.md
@@ -221,7 +221,8 @@ format! macros (codegen). Implementacion incremental: v0.1 y v0.2 completados.
 - [x] Diagnostics legibles. Lex + parse + semantic con linea:columna.
 - [ ] Servidor LSP basico (ag-lsp).
 - [ ] Plugin VS Code.
-- [/] Cobertura tests >= 85%. 73 tests verdes; cobertura formal pendiente.
+- [x] Cobertura tests >= 85%. Medicion 2026-05-21: 95.26% lineas, 93.02% funciones (cargo-llvm-cov).
+  115 tests verdes. Objetivo superado.
 - [ ] Fuzzing 24h sin crashes.
 - [x] Documentacion de referencia del DSL. `docs/dsl/referencia-v01-v04.md` — cubre tipos,
   anotaciones v0.1–v0.4, generacion de codigo, diagnostics y limitaciones conocidas.


### PR DESCRIPTION
# feat(fase-3): compilador Anti-DSL v0.1 — lexer, parser, semantic, codegen y CLI

## Resumen

Implementacion completa del primer incremento de la Fase 3: el compilador
`ag-dsl` pasa de skeleton vacio a un compilador funcional de extremo a extremo
que soporta DSL v0.1 (modelos, tipos primitivos, anotaciones @primary/@unique/@auto).
La CLI `ag` recibe tres comandos nuevos: `generate`, `schema lint`, `schema diff`.

## Fase afectada

Fase 3 — Anti-DSL alpha

## Tipo de cambio

- [x] Nueva feature
- [ ] Bugfix
- [ ] Refactor
- [ ] Documentacion

## Documentos relacionados

- `docs/rfc/RFC-0003-librerias-compilador-ag-dsl.md` (criterio de entrada)
- `docs/roadmap/STATUS.md` (fase 3 marcada como "En curso")
- `docs/roadmap/fase-03-anti-dsl-alpha.md`
- `docs/master/ANTI-GRAVITAL-Arquitectura-Tecnica.md` §7

## Cambios principales

### crates/ag-dsl

- `src/lexer.rs`: Token enum con logos 0.14 (keywords, tipos, anotaciones v0.1,
  literales, puntuacion). `tokenize()` separa tokens validos de errores de lex.
- `src/ast.rs`: tipos del AST — Schema, Config, ModelDef, FieldDef, FieldType,
  Annotation, DefaultValue, Spanned<T>.
- `src/parser.rs`: schema_parser() con chumsky 0.9. Soporta config{} y model{},
  campos con tipo, opcionalidad `?` y todas las anotaciones v0.1.
- `src/semantic.rs`: validaciones — nombres duplicados, modelo sin campos, campo
  @auto incompatible con tipo, @auto_update en no-Timestamp, multiples @primary.
- `src/diagnostics.rs`: Diagnostic con Severity, span, mensaje y hint. Formato
  legible linea:columna para el usuario.
- `src/codegen/rust_gen.rs`: genera structs Rust con serde, CreateRequest, UpdateRequest.
- `src/codegen/sql_gen.rs`: genera CREATE TABLE IF NOT EXISTS con PRIMARY KEY,
  UNIQUE INDEX, BIGSERIAL, gen_random_uuid(), tipos SQL correctos.
- `src/codegen/ts_gen.rs`: genera interfaces TypeScript con tipos precisos,
  Create/Update interfaces.
- `src/codegen/openapi_gen.rs`: genera OpenAPI 3.1 JSON con components/schemas,
  required fields, format annotations.
- `src/codegen/mod.rs`: generate() retorna GeneratedFiles (BTreeMap ruta->contenido).
- `src/lib.rs`: API publica compile() y generate().
- `Cargo.toml`: dependencias logos 0.14, chumsky 0.9, thiserror, serde_json.

### crates/ag-cli

- `ag generate [--schema] [--output]`: compila schema.ag y escribe 4 artefactos.
- `ag schema lint [--schema]`: reporta errores y warnings del schema.
- `ag schema diff <ref> [--schema]`: detecta cambios BREAKING vs additive.
- `Cargo.toml`: añade ag-dsl como dependencia.

### Workspace

- `Cargo.toml`: añade logos 0.14, chumsky 0.9, ag-dsl al workspace.

### Documentacion

- `docs/rfc/RFC-0003-librerias-compilador-ag-dsl.md`: decision formal sobre stack
  del compilador (criterio de entrada 3.1 de la Fase 3).
- `docs/rfc/README.md`: RFC-0003 añadida a la tabla.
- `docs/roadmap/STATUS.md`: Fase 3 marcada como "En curso", criterios de entrada
  marcados, entregables y criterios de salida listados.

## Plan de prueba

- [x] `cargo test -p ag-dsl -p ag-cli`: 56 tests verdes (50 ag-dsl + 5 ag-cli + 1 doctest)
- [x] `cargo clippy -p ag-dsl -p ag-cli --all-targets -- -D warnings`: limpio
- [x] `cargo fmt --check`: limpio
- [ ] `cargo audit`: pendiente (sin dependencias nuevas con CVEs conocidos)
- [ ] `cargo deny`: pendiente
- [ ] Test manual: crear schema.ag, ejecutar `ag generate`, verificar artefactos

## Criterios de salida que avanza

- [x] Criterio de entrada 3.1.3: RFC-0003 aceptada.
- Primer entregable 3.2.1 (DSL v0.1) en progreso — lexer, parser, semantic y
  codegen funcionales para modelos con tipos primitivos y anotaciones basicas.

## Checklist final

- [x] Pertenece a la fase correcta (Fase 3).
- [x] Respeta la documentacion (RFC-0003, Arquitectura §7, Hoja de Ruta §3).
- [x] No rompe arquitectura.
- [x] No anade complejidad innecesaria (format! sobre askama/quote para v0.1).
- [x] No crea dependencias circulares (ag-dsl no depende de ag-core).
- [x] Compila.
- [x] Pasa tests.
- [x] Pasa fmt.
- [x] Pasa clippy.
- [ ] Pasa audit.
- [ ] Tiene benchmarks (no aplica en este incremento).
- [x] Tiene documentacion (rustdoc en todos los modulos publicos).
- [x] Tiene manejo de errores correcto (pipeline lex->parse->semantic->Diagnostic).
- [x] Mantiene coherencia con Anti-Gravital v4.0.
