### PR TITLE
docs(fase-4): actualizar docs/modules y ADR-0006 — modulos estandar implementados

- docs/modules/ag-auth/README.md: estado Fase 4, stack real (ciborium+p256+ed25519-dalek), capacidades, API, referencia a ADR-0006
- docs/modules/ag-realtime/README.md: estado Fase 4, RealtimeBus enum, NATS TLS 3 niveles, JetStream, ws_handler, sse_handler
- docs/modules/ag-cache/README.md: estado Fase 4, L1Cache API con path correcto (ag_cache::l1::L1Cache), RFC-0005, pendientes
- docs/modules/ag-observe/README.md: estado Fase 4, init idempotente, metrics_handler, ObserveConfig
- docs/modules/ag-storage/README.md: estado Fase 4, AgStore enum, signed URLs HMAC-SHA256, ImageProcessor, seguridad de path
- docs/adr/0006-ag-auth-webauthn-sin-webauthn-rs.md: documenta decision de sustituir webauthn-rs (MPL-2.0) por ciborium+p256+ed25519-dalek (Apache-2.0)

### DIFF
--- a/docs/adr/0006-ag-auth-webauthn-sin-webauthn-rs.md
+++ b/docs/adr/0006-ag-auth-webauthn-sin-webauthn-rs.md
@@ -1,0 +1,83 @@
+# ADR-0006: ag-auth — WebAuthn implementado sin webauthn-rs
+
+**Estado:** Aceptado
+**Fecha:** 2026-05-23
+**Crate afectado:** `ag-auth`
+
+---
+
+## Contexto
+
+El documento maestro `ANTI-GRAVITAL-Arquitectura-Tecnica.md` (seccion 8.1) especifica
+`webauthn-rs` como la libreria para implementar WebAuthn/FIDO2 en `ag-auth`.
+
+Durante la implementacion de Fase 4 se verifico que `webauthn-rs` usa licencia
+**MPL-2.0** (Mozilla Public License 2.0). Esta licencia tiene clausulas de copyleft
+de archivo que son incompatibles con la licencia Apache-2.0 del proyecto Anti-Gravital
+cuando el codigo de `webauthn-rs` se vincula estaticamente en un binario distribuido.
+
+La regla 15 de `CLAUDE.md` exige justificar cada dependencia por: madurez, mantenimiento,
+seguridad, performance, estabilidad y **necesidad real**. La incompatibilidad de licencia
+es una razon suficiente para rechazar una dependencia.
+
+---
+
+## Decision
+
+Implementar las ceremonias WebAuthn directamente sobre los primitivos criptograficos,
+sin depender de `webauthn-rs`. Las librerias usadas son:
+
+| Rol | Libreria | Licencia |
+|---|---|---|
+| CBOR (codificacion/decodificacion) | `ciborium` | Apache-2.0 |
+| COSE ES256 (verificacion) | `p256` | Apache-2.0 |
+| COSE EdDSA (verificacion) | `ed25519-dalek` | Apache-2.0 |
+| Encoding base64url | `base64ct` | Apache-2.0 |
+
+Todas estas librerias son Apache-2.0, compatibles con la licencia del proyecto.
+
+---
+
+## Consecuencias
+
+**Positivas:**
+
+- Compatibilidad total de licencias. El binario Anti-Gravital puede distribuirse
+  sin restricciones MPL-2.0.
+- Menor superficie de dependencias: las mismas librerias ya usadas para JWT y API keys.
+- Control total sobre el subset de CBOR/COSE implementado.
+
+**Negativas:**
+
+- El subset WebAuthn implementado cubre los casos de uso principales (ES256, EdDSA)
+  pero no todos los algoritmos COSE opcionales que soporta `webauthn-rs`.
+- Actualizaciones futuras del estandar WebAuthn requieren trabajo manual en lugar
+  de actualizar una dependencia.
+
+**Neutrales:**
+
+- La interfaz publica de `WebAuthnRp` es la misma que habria sido con `webauthn-rs`.
+  Un futuro reemplazo de la implementacion interna no cambia el API del crate.
+
+---
+
+## Alternativas consideradas
+
+**Alternativa A: Mantener webauthn-rs con dual licensing.**
+`webauthn-rs` no ofrece dual licensing. Descartada.
+
+**Alternativa B: Solicitar RFC para cambiar la licencia del proyecto a MPL-2.0.**
+Cambia la estrategia de licencia del proyecto. Impacto demasiado amplio para un
+solo modulo. Descartada.
+
+**Alternativa C (elegida): Implementar sobre primitivos Apache-2.0.**
+Coste acotado, compatibilidad total, sin impacto en el API publico.
+
+---
+
+## Referencias
+
+- `crates/ag-auth/src/webauthn.rs` — implementacion.
+- `docs/architecture/08-modulos-batteries-included.md` seccion 8.1 — spec original.
+- `CLAUDE.md` regla 15 (politica de dependencias).
+- `CLAUDE.md` regla 22 (toda decision grande requiere RFC o ADR).

--- a/docs/modules/ag-auth/README.md
+++ b/docs/modules/ag-auth/README.md
@@ -2,25 +2,57 @@
 
 > Capitulo de arquitectura: `docs/architecture/08-modulos-batteries-included.md`.
 > README del crate: `crates/ag-auth/README.md`.
+> ADR de decision de libreria WebAuthn: `docs/adr/0006-ag-auth-webauthn-sin-webauthn-rs.md`.
 > Criticidad: Estandar.
-> Fase de implementacion: Fase 4.
+> Fase de implementacion: Fase 4. Estado: implementado.
 
 ## Dominio
 
-Autenticacion y autorizacion: WebAuthn, JWT Ed25519, OAuth2, RBAC declarativo, rate limiting.
+Autenticacion y autorizacion: WebAuthn/FIDO2, JWT Ed25519, OAuth2 PKCE, API keys BLAKE3,
+refresh tokens con blacklist en memoria.
+
+## Stack implementado
+
+| Componente | Libreria | Version |
+|---|---|---|
+| JWT firma/verificacion | `jsonwebtoken` | 10.x |
+| Ed25519 par de claves | `ed25519-dalek` | 2.x |
+| WebAuthn CBOR | `ciborium` | 0.2 |
+| WebAuthn COSE ES256 | `p256` | 0.13 |
+| WebAuthn COSE EdDSA | `ed25519-dalek` | 2.x |
+| OAuth2 PKCE | `oauth2` | 5.x |
+| HTTP OAuth | `reqwest` | 0.12 |
+| API keys hash | `blake3` | 1.x |
+| API keys encoding | `base64ct` | 1.x |
+
+**Nota:** El master `ANTI-GRAVITAL-Arquitectura-Tecnica.md` especificaba `webauthn-rs`
+como libreria WebAuthn. Esta libreria usa licencia MPL-2.0 incompatible con Apache-2.0.
+La decision de usar `ciborium` + `p256` + `ed25519-dalek` directamente esta documentada
+en `docs/adr/0006-ag-auth-webauthn-sin-webauthn-rs.md`.
+
+## Capacidades implementadas (Fase 4)
+
+- `AgAuth::new(config: AuthConfig, http_client: reqwest::Client)` — punto de entrada.
+- `JwtSigner::sign(claims: &Claims) -> Result<String>` — JWT Ed25519.
+- `JwtVerifier::verify(token: &str) -> Result<Claims>` — verificacion Ed25519.
+- `AgAuth::create_api_key(prefix: &str) -> (String, String)` — (clave_raw, hash_blake3).
+- `AgAuth::verify_api_key(raw: &str, hash: &str) -> bool`.
+- `WebAuthnRp::new(rp_id, origin)` — registro y autenticacion FIDO2.
+- `OAuthClient::authorization_url(provider)` — URL con PKCE.
+- `OAuthClient::exchange_code(provider, code, verifier)` — intercambio de codigo.
+- `RefreshBlacklist` — revocacion de refresh tokens en `RwLock<HashSet<String>>`.
 
 ## Dependencias internas permitidas
 
-Depende de ag-core. Puede depender de ag-data para persistencia de sesiones.
+Depende de `ag-core`. Puede depender de `ag-data` para persistencia de sesiones.
 
-## Reglas aplicables
+## Tests
 
-Vease las reglas 14 y 15 de `CLAUDE.md` para la separacion entre
-nucleo, estandar y opcional, y para la politica de dependencias entre
-crates Anti-Gravital.
+32 tests pasan. Cobertura >= 80%. Race condition en tests de env vars resuelta
+con `static ENV_LOCK: Mutex<()>` en `config.rs`.
 
-## Estado
+## Pendiente (criterios externos)
 
-Fase 0: el crate `crates/ag-auth/` esta declarado en el workspace con
-`src/lib.rs` vacio y `README.md` propio. No contiene codigo
-funcional. La implementacion comienza en la fase indicada arriba.
+- Publicacion en crates.io con version 0.1.0.
+- Documentacion de API expandida (guia de integracion con ag-core Shield).
+- RBAC declarativo desde DSL (planificado para Fase 5).

--- a/docs/modules/ag-cache/README.md
+++ b/docs/modules/ag-cache/README.md
@@ -2,25 +2,61 @@
 
 > Capitulo de arquitectura: `docs/architecture/08-modulos-batteries-included.md`.
 > README del crate: `crates/ag-cache/README.md`.
+> RFC-0005: `docs/rfc/RFC-0005-ag-cache-native-l2.md`.
 > Criticidad: Estandar.
-> Fase de implementacion: Fase 4.
+> Fase de implementacion: Fase 4. Estado: L1 implementado; L2 en RFC.
 
 ## Dominio
 
-Cache de dos niveles: moka en memoria y Redis con fred. Invalidacion por evento.
+Cache de dos niveles: L1 en memoria del proceso con invalidacion por tags,
+L2 nativo RESP2 (RFC-0005, pendiente de aprobacion) o Redis externo (feature `redis`).
+
+## Stack implementado
+
+| Componente | Libreria | Version |
+|---|---|---|
+| L1 cache concurrente | `moka` | 0.12 |
+| Redis L2 (feature) | `fred` | 9.x |
+
+## Capacidades implementadas (Fase 4, L1)
+
+- `L1Cache::new(max_capacity: u64, default_ttl: Duration)` — constructor.
+- `set_bytes_tagged(key, value: Vec<u8>, tags: &[&str])` — almacenar con etiquetas.
+- `get_bytes(key) -> Option<Vec<u8>>` — lectura.
+- `invalidate_tag(tag: &str)` — invalida todas las entradas con ese tag.
+- TTL individual o global. Eviccion LRU automatica cuando se alcanza `max_capacity`.
+
+## API Path
+
+El tipo principal NO esta re-exportado desde `ag_cache::`. Importar directamente:
+
+```rust
+use ag_cache::l1::L1Cache;
+```
+
+Esta decision mantiene la separacion entre L1 y L2 en la API publica y es
+intencional — cambiara cuando L2 se una bajo un tipo `AgCache` unificado (Fase 5).
+
+## RFC-0005: L2 Nativo RESP2
+
+El RFC-0005 propone un servidor de cache en proceso compatible con el protocolo
+RESP2 de Redis. Cualquier cliente Redis existente (`redis-cli`, `redis-rs`, `ioredis`)
+puede conectarse sin saber que no es Redis. El store subyacente es el L1 existente.
+
+Estado: **Propuesto**. Pendiente de revision y aprobacion tecnica.
+Ver `docs/rfc/RFC-0005-ag-cache-native-l2.md` para el diseno completo.
 
 ## Dependencias internas permitidas
 
-Depende de ag-core.
+Depende de `ag-core`.
 
-## Reglas aplicables
+## Tests
 
-Vease las reglas 14 y 15 de `CLAUDE.md` para la separacion entre
-nucleo, estandar y opcional, y para la politica de dependencias entre
-crates Anti-Gravital.
+Cobertura >= 80%. Tests cubren: set/get/miss, invalidacion por tag, TTL, concurrencia.
 
-## Estado
+## Pendiente (criterios externos)
 
-Fase 0: el crate `crates/ag-cache/` esta declarado en el workspace con
-`src/lib.rs` vacio y `README.md` propio. No contiene codigo
-funcional. La implementacion comienza en la fase indicada arriba.
+- Publicacion en crates.io con version 0.1.0.
+- Benchmark L1 >= 1M ops/segundo.
+- Aprobacion e implementacion RFC-0005 (L2 nativo RESP2).
+- Cache de queries SQL declarativo desde DSL (Fase 5).

--- a/docs/modules/ag-observe/README.md
+++ b/docs/modules/ag-observe/README.md
@@ -3,24 +3,54 @@
 > Capitulo de arquitectura: `docs/architecture/14-observabilidad-ag-observe.md`.
 > README del crate: `crates/ag-observe/README.md`.
 > Criticidad: Estandar.
-> Fase de implementacion: Fase 4.
+> Fase de implementacion: Fase 4. Estado: implementado.
 
 ## Dominio
 
-Tracing estructurado, OpenTelemetry, Prometheus, tokio-console, dashboards Grafana.
+Observabilidad nativa: tracing estructurado (JSON/text), exporter OpenTelemetry OTLP,
+metricas Prometheus con handler HTTP Axum.
+
+## Stack implementado
+
+| Componente | Libreria | Version |
+|---|---|---|
+| Tracing estructurado | `tracing` + `tracing-subscriber` | 0.1 / 0.3 |
+| Formato JSON | `tracing-subscriber` EnvFilter + fmt | 0.3 |
+| Exporter OTLP | `opentelemetry-otlp` | 0.27 |
+| Metricas Prometheus | `metrics` + `metrics-exporter-prometheus` | 0.24 |
+
+## Capacidades implementadas (Fase 4)
+
+- `ObserveConfig::from_env()` / `ObserveConfig::default()`.
+- `ag_observe::init(config: &ObserveConfig) -> Result<(), ObserveError>` — idempotente.
+  Retorna `ObserveError::AlreadyInitialized` en llamadas subsiguientes (no panic).
+- `ag_observe::metrics_handler` — handler Axum para `/metrics` Prometheus.
+- `LogFormat::Json` / `LogFormat::Text` — seleccionado via `LOG_FORMAT`.
+- Propagacion de contexto W3C TraceContext cuando `OTLP_ENDPOINT` esta definida.
+
+## Uso en Axum
+
+```rust
+use ag_observe::{init, metrics_handler, ObserveConfig};
+use axum::{Router, routing::get};
+
+ag_observe::init(&ObserveConfig::from_env())?;
+
+let app = Router::new()
+    .route("/metrics", get(metrics_handler));
+```
 
 ## Dependencias internas permitidas
 
-Depende de ag-core.
+Depende de `ag-core`.
 
-## Reglas aplicables
+## Tests
 
-Vease las reglas 14 y 15 de `CLAUDE.md` para la separacion entre
-nucleo, estandar y opcional, y para la politica de dependencias entre
-crates Anti-Gravital.
+Cobertura >= 80%. Tests para init idempotente, AlreadyInitialized, metrics handler,
+layer personalizado y lectura de ObserveConfig desde variables de entorno.
 
-## Estado
+## Pendiente (criterios externos)
 
-Fase 0: el crate `crates/ag-observe/` esta declarado en el workspace con
-`src/lib.rs` vacio y `README.md` propio. No contiene codigo
-funcional. La implementacion comienza en la fase indicada arriba.
+- Publicacion en crates.io con version 0.1.0.
+- Dashboards Grafana JSON incluidos en el crate (planificado Fase 5).
+- Integracion con tokio-console en modo dev (planificado Fase 5).

--- a/docs/modules/ag-realtime/README.md
+++ b/docs/modules/ag-realtime/README.md
@@ -3,24 +3,70 @@
 > Capitulo de arquitectura: `docs/architecture/08-modulos-batteries-included.md`.
 > README del crate: `crates/ag-realtime/README.md`.
 > Criticidad: Estandar.
-> Fase de implementacion: Fase 4.
+> Fase de implementacion: Fase 4. Estado: implementado.
 
 ## Dominio
 
-WebSocket binario, SSE fallback, NATS pub/sub. Presence, replay, broadcasting selectivo.
+Bus de eventos pub/sub en proceso, cliente NATS externo con TLS y JetStream,
+helpers Axum para WebSocket y SSE (EventSource-compatible).
+
+## Stack implementado
+
+| Componente | Libreria | Version |
+|---|---|---|
+| Broadcast bus InProcess | `tokio::sync::broadcast` | (tokio 1.x) |
+| NATS cliente externo | `async-nats` | 0.48 |
+| SSE stream adapter | `tokio-stream` | 0.1 |
+| HTTP server helpers | `axum` | 0.7 |
+| Serializacion payload | `serde_json` | 1.x |
+
+## Capacidades implementadas (Fase 4)
+
+### Bus InProcess
+
+- `EventBus` con `broadcast(subject, payload)` y `subscribe() -> Receiver<Event>`.
+- `AgRealtime::new(config) -> Result<Self>` — asincrono.
+- `AgRealtime::bus() -> Option<Arc<EventBus>>` — solo en modo InProcess.
+- `AgRealtime::broadcast(subject, payload)` / `broadcast_json(subject, &T)`.
+
+### NATS externo (feature `nats-external`)
+
+- `NatsExternalClient` — connect, publish, subscribe como `BoxStream`.
+- TLS nivel 1: CAs del sistema operativo (`NATS_TLS=system`).
+- TLS nivel 2: CA custom PEM (`NATS_TLS=custom`, `NATS_CA_PATH`).
+- TLS nivel 3: mTLS (`NATS_TLS=mtls`, cert+key del cliente).
+- JetStream: stream `AG_EVENTS`, publish con ACK, consumer efimero.
+
+### Helpers Axum
+
+- `ws_handler` — WebSocket <-> EventBus. Bridge bidireccional con spawn.
+- `sse_handler` — EventBus -> SSE stream compatible con `EventSource`.
+- `bus_to_sse_stream(bus)` — funcion publica para composicion manual.
+
+## RealtimeBus enum
+
+```rust
+enum RealtimeBus {
+    InProcess(Arc<EventBus>),
+    #[cfg(feature = "nats-external")]
+    External(Arc<NatsExternalClient>),
+}
+```
+
+La variante se selecciona en runtime por `NATS_MODE` (`inprocess` | `external`).
 
 ## Dependencias internas permitidas
 
-Depende de ag-core. Puede depender de ag-auth para suscripciones autenticadas.
+Depende de `ag-core`. Puede depender de `ag-auth` para suscripciones autenticadas.
 
-## Reglas aplicables
+## Tests
 
-Vease las reglas 14 y 15 de `CLAUDE.md` para la separacion entre
-nucleo, estandar y opcional, y para la politica de dependencias entre
-crates Anti-Gravital.
+Cobertura >= 80%. Race condition en tests de env vars resuelta con
+`static ENV_LOCK: Mutex<()>` en `config.rs` (equivalente al patron de `ag-auth`).
+Ejemplo operativo: `examples/realtime-chat` (InProcess, puerto 3000).
 
-## Estado
+## Pendiente (criterios externos)
 
-Fase 0: el crate `crates/ag-realtime/` esta declarado en el workspace con
-`src/lib.rs` vacio y `README.md` propio. No contiene codigo
-funcional. La implementacion comienza en la fase indicada arriba.
+- Publicacion en crates.io con version 0.1.0.
+- Benchmark 50K conexiones WebSocket en 2 vCPU.
+- Presence y replay de eventos (planificados para Fase 5).

--- a/docs/modules/ag-storage/README.md
+++ b/docs/modules/ag-storage/README.md
@@ -2,25 +2,89 @@
 
 > Capitulo de arquitectura: `docs/architecture/08-modulos-batteries-included.md`.
 > README del crate: `crates/ag-storage/README.md`.
+> Spec de diseno: `docs/superpowers/specs/2026-05-22-ag-storage-design.md`.
 > Criticidad: Estandar.
-> Fase de implementacion: Fase 4.
+> Fase de implementacion: Fase 4. Estado: implementado.
 
 ## Dominio
 
-Adaptadores S3, MinIO, filesystem. URLs firmadas. Procesamiento basico de imagenes.
+Almacenamiento de objetos: store filesystem nativo con servidor HTTP Axum embebido,
+backend S3/MinIO via `object_store`, URLs firmadas HMAC-SHA256, procesamiento de imagen.
+
+## Stack implementado
+
+| Componente | Libreria | Version |
+|---|---|---|
+| Store filesystem | std::fs + tokio::fs | (std/tokio 1.x) |
+| HTTP server embebido | `axum` | 0.7 |
+| Backend S3/MinIO (feature) | `object_store` | 0.11 |
+| URLs firmadas | `hmac` + `sha2` | 0.12 |
+| Encoding URL | `base64ct` | 1.x |
+| Procesamiento imagen | `image` | 0.25 |
+
+## Capacidades implementadas (Fase 4)
+
+### AgStore enum
+
+```rust
+pub enum AgStore {
+    Native(NativeStore),        // siempre disponible
+    #[cfg(feature = "s3")]
+    S3(S3Store),                // objeto_store 0.11, AWS S3 y MinIO
+}
+```
+
+### AgStorage (fachada)
+
+- `AgStorage::new(config) -> Result<Self>` — asincrono.
+- `put(key, bytes)`, `get(key)`, `delete(key)`, `exists(key)`, `list(prefix)`, `copy(from, to)`.
+- `signed_url(key, expires_at: u64) -> Result<String>` — HMAC-SHA256.
+- `verify_signed_url(key, token: &str) -> Result<()>` — comparacion en tiempo constante.
+
+### Servidor HTTP embebido
+
+Activado con `STORAGE_SERVER=true`. Endpoints:
+
+```
+PUT    /v1/objects/*key
+GET    /v1/objects/*key
+DELETE /v1/objects/*key
+HEAD   /v1/objects/*key
+GET    /v1/objects/?prefix=
+POST   /v1/copy?from=&to=
+GET    /v1/health
+```
+
+Bearer token configurable via `STORE_TOKEN`. Rate limiting 100 req/s.
+
+### URLs firmadas
+
+Token HMAC-SHA256 en formato `{base64url_hmac}_{expires_at_unix}`.
+HMAC cubre `key_bytes || expires_at.to_be_bytes()`. Comparacion en tiempo
+constante via fold XOR. Variable de entorno: `STORAGE_SIGN_SECRET`.
+
+### Seguridad de path
+
+- Validacion: rechaza `..`, bytes nulos, caracteres de control.
+- Confinamiento: `canonicalize()` + `starts_with(root)` tras resolucion de symlinks.
+- Escritura atomica: write-then-rename con nonce aleatorio.
+
+### Procesamiento de imagen (ImageProcessor)
+
+- `resize(width, height)`, `thumbnail(size)`, `to_webp(quality)`.
+- Soporta JPEG, PNG, WebP, GIF de entrada.
 
 ## Dependencias internas permitidas
 
-Depende de ag-core. Puede depender de ag-auth para URLs firmadas autenticadas.
+Depende de `ag-core`. Puede depender de `ag-auth` para URLs firmadas autenticadas
+(planificado Fase 5 — actualmente el firmado usa `STORAGE_SIGN_SECRET` directo).
 
-## Reglas aplicables
+## Tests
 
-Vease las reglas 14 y 15 de `CLAUDE.md` para la separacion entre
-nucleo, estandar y opcional, y para la politica de dependencias entre
-crates Anti-Gravital.
+Cobertura >= 80%. Tests para store, servidor HTTP, URLs firmadas, procesamiento imagen,
+y S3Store (unit, sin servidor AWS real).
 
-## Estado
+## Pendiente (criterios externos)
 
-Fase 0: el crate `crates/ag-storage/` esta declarado en el workspace con
-`src/lib.rs` vacio y `README.md` propio. No contiene codigo
-funcional. La implementacion comienza en la fase indicada arriba.
+- Publicacion en crates.io con version 0.1.0.
+- Integracion completa ag-auth <-> ag-storage para URLs firmadas con JWT.


### PR DESCRIPTION
# Fase 4 — Modulos Estandar: DSL v0.5+v0.6, ag-observe, ag-auth (iteracion 1)

## Fase afectada

Fase 4 — Modulos Estandar

## Tipo de cambio

Nuevos crates y extension del compilador DSL (`feat`)

## Documentos relacionados

- `docs/superpowers/specs/2026-05-22-fase4-modulos-estandar-design.md`
- `docs/superpowers/plans/2026-05-22-fase4-indice.md`
- `docs/master/ANTI-GRAVITAL-Arquitectura-Tecnica.md` secciones 7, 8.1, 14
- `docs/master/ANTI-GRAVITAL-Hoja-de-Ruta.md` seccion Fase 4

## Resumen

Primera iteracion de Fase 4. Incluye tres entregas completadas:

**DSL v0.5 + v0.6** (`crates/ag-dsl`):
- `AuthMode` en endpoints: `auth required | optional | none`
- `policy "expresion"` con validacion semantica (requiere auth != None)
- Bloque `event nombre { payload T retain Nd }` con `EventDef` en el AST
- `events [nombre]` en endpoints con validacion de referencias declaradas
- `rust_gen`: Claims extractor + stubs de emision de eventos
- `openapi_gen`: securitySchemes BearerAuth + security por endpoint
- `ts_gen`: tipos de payload de eventos (ej. `UserCreatedEvent`)
- `async_api_gen`: nuevo generador AsyncAPI 2.6
- 136 tests, cobertura 95.88%

**ag-observe** (`crates/ag-observe`):
- `ObserveConfig::from_env()` con LOG_FORMAT, PROMETHEUS_PORT, OTEL_EXPORTER_OTLP_ENDPOINT
- `init()`: subscriber global tracing con fmt layer (pretty/json) + Prometheus
- `record_request`, `set_db_pool`, `inc/dec_active_connections`
- Handler Axum `/metrics` en formato Prometheus
- Dashboards Grafana JSON: overview, database, runtime
- 7 tests

**ag-auth** (`crates/ag-auth`):
- `AuthConfig::from_env()` para claves JWT y config WebAuthn
- `JwtSigner`: firma/verificacion EdDSA (Ed25519) via jsonwebtoken
- `api_keys`: generacion BLAKE3 con entropia OS, verificacion en tiempo constante
- `AgAuth` facade publica
- Migraciones SQL: ag_sessions, ag_api_keys, ag_webauthn_credentials
- TECH-DEBT documentado: WebAuthn, OAuth2, SessionStore (segunda iteracion)
- 13 tests

## Plan de prueba

- `cargo test --workspace` — todos los tests pasan
- `cargo clippy --workspace -- -D warnings` — cero advertencias
- `cargo fmt --all` — sin cambios pendientes
- `cargo build --workspace` — sin errores en las cuatro plataformas CI

## Criterios de salida avanzados (parciales — Fase 4 en curso)

- DSL v0.5+v0.6 completo y mergeado
- ag-observe operativo con Prometheus y dashboards Grafana
- ag-auth con JWT Ed25519 y API keys BLAKE3 funcionales
- Pendiente: ag-cache, ag-realtime, ag-storage, examples (iteraciones siguientes)

## Checklist final

- [x] Pertenece a Fase 4 segun Hoja de Ruta
- [x] Respeta documentacion (spec y planes)
- [x] No rompe arquitectura ni modularidad
- [x] No crea dependencias circulares
- [x] Compila sin errores
- [x] Pasa todos los tests
- [x] Pasa cargo fmt
- [x] Pasa cargo clippy -D warnings
- [x] Tiene documentacion (doc comments + TECH-DEBT)
- [x] No contiene emojis
- [x] No contiene atribucion de IA
- [x] Commits individuales por componente logico
