### PR TITLE
Fase 4.5

### DIFF
--- a/crates/ag-domains/src/acme/mod.rs
+++ b/crates/ag-domains/src/acme/mod.rs
@@ -1,10 +1,10 @@
 //! Cliente ACME para emision y renovacion de certificados TLS.
 //!
 //! Basado en `instant-acme` contra Let's Encrypt. Soporta challenge
-//! DNS-01 (preferido, usa el `DnsProvider` para crear el TXT) y HTTP-01
-//! (alternativo).
+//! DNS-01 (preferido, usa el `DnsProvider` para crear el TXT).
 //!
-//! Skeleton de la Fase 4.5. Implementacion en la Etapa 2-4.
+//! Flujo: crear cuenta -> crear orden -> resolver DNS-01 -> esperar
+//! validacion -> generar CSR con rcgen -> finalizar -> descargar PEM.
 
 pub mod challenge;
 pub mod renewal;

--- a/crates/ag-domains/src/acme/renewal.rs
+++ b/crates/ag-domains/src/acme/renewal.rs
@@ -90,8 +90,11 @@ pub async fn issue_with_credentials<P: DnsProvider>(
     issue_order(&account, config, provider).await
 }
 
-/// Lanza una tarea Tokio que renueva el certificado cuando faltan
-/// `renew_before_days` dias para su vencimiento.
+/// Lanza una tarea Tokio que renueva el certificado periodicamente.
+///
+/// Comprueba cada dia si faltan menos de `renew_before_days` dias para el
+/// vencimiento. Mientras el parseo del `notAfter` no este implementado, renueva
+/// en cada ciclo y usa `renew_before_days` como periodo de sleep (cota conservadora).
 ///
 /// La tarea vive mientras el `JoinHandle` no sea abortado. En caso de
 /// error de renovacion, lo registra y reintenta al ciclo siguiente.
@@ -110,22 +113,17 @@ where
     let credentials_json = serde_json::to_vec(&credentials)
         .expect("AccountCredentials siempre es serializable a JSON");
 
+    // Cuantos segundos dormir entre ciclos de renovacion.
+    // TECH-DEBT: cuando se implemente el parseo de `notAfter`, usar `check_interval`
+    // (24 h) y comparar la fecha de expiracion con `renew_before_days`.
+    // motivo: simplificacion de la primera iteracion
+    // impacto: renueva cada `renew_before_days` dias en lugar de exactamente al umbral
+    // eliminacion esperada: Etapa 3 de ag-domains
+    let sleep_secs = renew_before_days.max(1) * 86_400;
+
     tokio::spawn(async move {
-        // Comprobacion inicial: renovar si procede, luego revisar cada dia.
-        let check_interval = Duration::from_secs(86_400); // 24 h
-        let renew_threshold = Duration::from_secs(renew_before_days * 86_400);
-
         loop {
-            info!(
-                domain = config.domain,
-                "comprobando vencimiento del certificado"
-            );
-
-            // TECH-DEBT: parsear `notAfter` del cert para renovar exactamente
-            // a `renew_before_days` antes del vencimiento.
-            // motivo: simplificacion de la primera iteracion
-            // impacto: puede renovar antes o despues de lo optimo si la validez no es 90 dias
-            // eliminacion esperada: Etapa 3 de ag-domains
+            info!(domain = config.domain, "renovando certificado TLS via ACME");
 
             let creds: AccountCredentials = serde_json::from_slice(&credentials_json)
                 .expect("AccountCredentials previamente serializado es siempre deserializable");
@@ -140,7 +138,7 @@ where
                 }
             }
 
-            tokio::time::sleep(check_interval - renew_threshold).await;
+            tokio::time::sleep(Duration::from_secs(sleep_secs)).await;
         }
     })
 }
@@ -310,5 +308,50 @@ mod tests {
             !url.contains("staging"),
             "production URL no debe contener 'staging'"
         );
+    }
+
+    #[test]
+    fn cert_config_staging_flag() {
+        let cfg = CertConfig {
+            domain: "ejemplo.com".to_owned(),
+            zone_id: "z123".to_owned(),
+            contact_email: "admin@ejemplo.com".to_owned(),
+            staging: true,
+        };
+        assert!(cfg.staging);
+        assert_eq!(cfg.domain, "ejemplo.com");
+    }
+
+    #[test]
+    fn cert_config_staging_default_is_false() {
+        let json = r#"{"domain":"a.com","zone_id":"z","contact_email":"e@e.com"}"#;
+        let cfg: CertConfig = serde_json::from_str(json).unwrap();
+        assert!(!cfg.staging, "staging debe ser false por defecto");
+    }
+
+    #[test]
+    fn cert_config_roundtrip_json() {
+        let cfg = CertConfig {
+            domain: "test.com".to_owned(),
+            zone_id: "zid".to_owned(),
+            contact_email: "x@x.com".to_owned(),
+            staging: false,
+        };
+        let json = serde_json::to_string(&cfg).unwrap();
+        let cfg2: CertConfig = serde_json::from_str(&json).unwrap();
+        assert_eq!(cfg.domain, cfg2.domain);
+        assert_eq!(cfg.zone_id, cfg2.zone_id);
+        assert_eq!(cfg.contact_email, cfg2.contact_email);
+        assert_eq!(cfg.staging, cfg2.staging);
+    }
+
+    #[test]
+    fn issued_cert_fields_accessible() {
+        let cert = IssuedCert {
+            cert_chain_pem: "-----BEGIN CERTIFICATE-----".to_owned(),
+            private_key_pem: "-----BEGIN PRIVATE KEY-----".to_owned(),
+        };
+        assert!(cert.cert_chain_pem.contains("CERTIFICATE"));
+        assert!(cert.private_key_pem.contains("PRIVATE KEY"));
     }
 }

--- a/crates/ag-lsp/src/backend.rs
+++ b/crates/ag-lsp/src/backend.rs
@@ -197,12 +197,14 @@ fn word_at_position<'a>(source: &'a str, pos: &Position) -> Option<&'a str> {
 
 fn hover_content_for_word(word: &str) -> Option<String> {
     let s = match word {
+        // Tipos escalares
         "UUID" => "**UUID** — Identificador unico universal v4. SQL: `UUID`.",
         "String" => "**String** — Cadena de texto UTF-8. SQL: `TEXT`.",
         "Int" => "**Int** — Entero de 64 bits con signo. SQL: `BIGINT`.",
         "Float" => "**Float** — Punto flotante 64 bits. SQL: `DOUBLE PRECISION`.",
         "Bool" => "**Bool** — Valor booleano. SQL: `BOOLEAN`.",
         "DateTime" => "**DateTime** — Fecha y hora UTC. SQL: `TIMESTAMPTZ`.",
+        // Anotaciones de modelo
         "@primary" => "**@primary** — Clave primaria de la tabla.",
         "@unique" => "**@unique** — Restriccion UNIQUE en la columna.",
         "@auto" => "**@auto** — Valor generado automaticamente (UUID o serial).",
@@ -215,6 +217,30 @@ fn hover_content_for_word(word: &str) -> Option<String> {
         "@length" => "**@length(n)** — Longitud exacta del string.",
         "@relation" => "**@relation(campo_fk)** — Relacion virtual. No genera columna SQL.",
         "@references" => "**@references(Modelo.campo)** — Clave foranea hacia otro modelo.",
+        // Bloques DSL v0.7 — correo transaccional
+        "mail" => {
+            "**mail** (DSL v0.7) — Bloque de configuracion de correo transaccional.\n\n\
+            ```ag\nmail nombre {\n    provider smtp\n    from \"noreply@ejemplo.com\"\n    template bienvenida {\n        subject \"Bienvenido {{nombre}}\"\n        vars [nombre, token]\n    }\n}\n```\n\n\
+            Proveedores soportados: `smtp`, `resend`, `ses`, `postmark`."
+        }
+        "domain" => {
+            "**domain** (DSL v0.7) — Bloque de configuracion DNS de un dominio.\n\n\
+            ```ag\ndomain mi_dominio {\n    name \"ejemplo.com\"\n    provider cloudflare\n    dkim_selector \"s1\"\n    dmarc_policy quarantine\n    dmarc_rua \"admin@ejemplo.com\"\n}\n```\n\n\
+            Gestiona registros SPF/DKIM/DMARC via `ag domains sync`."
+        }
+        "template" => {
+            "**template** (DSL v0.7) — Sub-bloque de template de correo dentro de un bloque `mail`.\n\n\
+            ```ag\ntemplate bienvenida {\n    subject \"Bienvenido {{nombre}}\"\n    vars [nombre, token]\n}\n```\n\n\
+            Las `vars` declaradas son validadas en compile-time contra el HTML del template."
+        }
+        // Propiedades de bloques mail/domain
+        "provider" => "**provider** — Proveedor del bloque. En `mail`: `smtp`, `resend`, `ses`, `postmark`. En `domain`: `cloudflare`.",
+        "from" => "**from** — Direccion de correo remitente. Debe referenciar un `domain` declarado en el mismo schema.",
+        "subject" => "**subject** — Asunto del correo. Admite variables `{{nombre}}` declaradas en `vars`.",
+        "vars" => "**vars** — Lista de variables del template de correo. Validadas en compile-time contra el HTML/texto.",
+        "dkim_selector" => "**dkim_selector** — Selector DKIM para la firma criptografica del correo. Ejemplo: `\"s1\"`.",
+        "dmarc_policy" => "**dmarc_policy** — Politica DMARC. Valores: `none`, `quarantine`, `reject`.",
+        "dmarc_rua" => "**dmarc_rua** — Direccion de correo para recibir reportes DMARC agregados (RUA).",
         _ => return None,
     };
     Some(s.to_string())
@@ -233,6 +259,10 @@ fn static_completion_items() -> Vec<CompletionItem> {
         ("PUT", "Metodo HTTP PUT"),
         ("PATCH", "Metodo HTTP PATCH"),
         ("DELETE", "Metodo HTTP DELETE"),
+        // DSL v0.7 — bloques mail/domain
+        ("mail", "Bloque de correo transaccional (DSL v0.7)"),
+        ("domain", "Bloque de configuracion DNS (DSL v0.7)"),
+        ("template", "Sub-bloque de template de correo (DSL v0.7)"),
     ];
     let types: &[(&str, &str)] = &[
         ("UUID", "Identificador unico universal"),
@@ -256,6 +286,25 @@ fn static_completion_items() -> Vec<CompletionItem> {
         ("@relation", "@relation(campo_fk) — relacion virtual"),
         ("@references", "@references(Modelo.campo) — clave foranea"),
     ];
+    // Propiedades de bloques mail/domain (DSL v0.7)
+    let mail_domain_props: &[(&str, &str)] = &[
+        (
+            "provider",
+            "Proveedor: smtp | resend | ses | postmark | cloudflare",
+        ),
+        (
+            "from",
+            "Direccion remitente del correo (debe referenciar un domain)",
+        ),
+        ("subject", "Asunto del correo. Admite {{vars}}"),
+        ("vars", "Variables del template, validadas en compile-time"),
+        (
+            "dkim_selector",
+            "Selector DKIM para firma criptografica del correo",
+        ),
+        ("dmarc_policy", "Politica DMARC: none | quarantine | reject"),
+        ("dmarc_rua", "Direccion de reporte DMARC agregado (RUA)"),
+    ];
 
     let mut items = Vec::new();
     for (label, detail) in keywords {
@@ -278,6 +327,14 @@ fn static_completion_items() -> Vec<CompletionItem> {
         items.push(CompletionItem {
             label: label.to_string(),
             kind: Some(CompletionItemKind::PROPERTY),
+            detail: Some(detail.to_string()),
+            ..Default::default()
+        });
+    }
+    for (label, detail) in mail_domain_props {
+        items.push(CompletionItem {
+            label: label.to_string(),
+            kind: Some(CompletionItemKind::FIELD),
             detail: Some(detail.to_string()),
             ..Default::default()
         });
@@ -349,6 +406,65 @@ mod tests {
         assert!(labels.contains(&"UUID"));
         assert!(labels.contains(&"@primary"));
         assert!(labels.contains(&"@references"));
+    }
+
+    #[test]
+    fn static_items_include_v07_mail_domain_keywords() {
+        let items = static_completion_items();
+        let labels: Vec<&str> = items.iter().map(|i| i.label.as_str()).collect();
+        assert!(labels.contains(&"mail"), "falta keyword 'mail'");
+        assert!(labels.contains(&"domain"), "falta keyword 'domain'");
+        assert!(labels.contains(&"template"), "falta keyword 'template'");
+        assert!(labels.contains(&"provider"), "falta prop 'provider'");
+        assert!(labels.contains(&"from"), "falta prop 'from'");
+        assert!(labels.contains(&"subject"), "falta prop 'subject'");
+        assert!(labels.contains(&"vars"), "falta prop 'vars'");
+        assert!(
+            labels.contains(&"dkim_selector"),
+            "falta prop 'dkim_selector'"
+        );
+        assert!(
+            labels.contains(&"dmarc_policy"),
+            "falta prop 'dmarc_policy'"
+        );
+    }
+
+    #[test]
+    fn hover_content_v07_mail_block() {
+        let h = hover_content_for_word("mail").unwrap();
+        assert!(
+            h.contains("DSL v0.7"),
+            "hover de 'mail' debe mencionar DSL v0.7"
+        );
+        assert!(
+            h.contains("provider"),
+            "hover de 'mail' debe mostrar ejemplo con provider"
+        );
+    }
+
+    #[test]
+    fn hover_content_v07_domain_block() {
+        let h = hover_content_for_word("domain").unwrap();
+        assert!(h.contains("DNS"), "hover de 'domain' debe mencionar DNS");
+        assert!(
+            h.contains("cloudflare"),
+            "hover de 'domain' debe mencionar cloudflare"
+        );
+    }
+
+    #[test]
+    fn hover_content_v07_template_block() {
+        let h = hover_content_for_word("template").unwrap();
+        assert!(
+            h.contains("vars"),
+            "hover de 'template' debe mencionar vars"
+        );
+    }
+
+    #[test]
+    fn hover_content_v07_dmarc_policy() {
+        let h = hover_content_for_word("dmarc_policy").unwrap();
+        assert!(h.contains("quarantine"));
     }
 
     #[test]

--- a/docs/manual/03-dominio-tls-correo.md
+++ b/docs/manual/03-dominio-tls-correo.md
@@ -1,0 +1,280 @@
+# Configurar dominio, TLS y correo transaccional con Anti-Gravital
+
+Esta guia muestra como integrar `ag-domains` y `ag-mail` en un proyecto
+Anti-Gravital para gestionar registros DNS, emitir certificados TLS via
+ACME y enviar correo transaccional desde el DSL.
+
+---
+
+## Requisitos previos
+
+- Rust 1.78 o superior.
+- Un dominio registrado con los nameservers apuntando al proveedor DNS.
+- Una cuenta en Cloudflare (o cualquier proveedor con adapter implementado).
+- Token de API de Cloudflare con permisos `Zone:DNS:Edit`.
+
+---
+
+## 1. Declarar dominio y correo en el DSL
+
+El DSL v0.7 introduce los bloques `domain`, `mail` y `template`.
+Crear o editar el archivo `schema.ag` del proyecto:
+
+```ag
+domain mi_dominio {
+    name "ejemplo.com"
+    provider cloudflare
+    dkim_selector "s1"
+    dmarc_policy quarantine
+    dmarc_rua "reportes@ejemplo.com"
+}
+
+mail transaccional {
+    provider smtp
+    from "noreply@ejemplo.com"
+
+    template bienvenida {
+        subject "Bienvenido {{nombre}}"
+        vars [nombre, token]
+    }
+
+    template recuperacion {
+        subject "Recupera tu contrasena"
+        vars [enlace]
+    }
+}
+```
+
+El compilador DSL (`ag_dsl::compile`) valida que:
+- El `from` del bloque `mail` referencia un dominio declarado.
+- Cada `vars` de un `template` coincide con los marcadores `{{var}}` del HTML.
+
+---
+
+## 2. Aplicar registros DNS (SPF, DKIM, DMARC)
+
+`ag-domains` genera y aplica los tres registros necesarios para la entregabilidad
+del correo en un upsert idempotente: si el registro ya existe con el mismo
+contenido, no se modifica.
+
+```rust
+use ag_domains::{
+    mail_records::{DkimConfig, MailRecordsConfig, apply_mail_records},
+    provider::cloudflare::CloudflareProvider,
+};
+
+#[tokio::main]
+async fn main() -> anyhow::Result<()> {
+    let provider = CloudflareProvider::new("CF_TOKEN_AQUI");
+    let zone_id = provider.zone_id("ejemplo.com").await?;
+
+    let config = MailRecordsConfig {
+        spf_includes: vec!["include:_spf.resend.com".to_owned()],
+        dkim: Some(DkimConfig {
+            selector: "s1".to_owned(),
+            public_key_base64: "MIIBIjANBgkq...".to_owned(),
+        }),
+        dmarc_policy: ag_domains::mail_records::DmarcPolicy::Quarantine,
+        dmarc_rua: Some("reportes@ejemplo.com".to_owned()),
+    };
+
+    apply_mail_records(&provider, &zone_id, "ejemplo.com", &config).await?;
+    println!("Registros SPF/DKIM/DMARC aplicados.");
+    Ok(())
+}
+```
+
+Equivalente via CLI:
+
+```sh
+ag domains sync --schema schema.ag --zone-id <ZONE_ID> --token <CF_TOKEN>
+```
+
+---
+
+## 3. Verificar propagacion DNS
+
+La propagacion puede tardar entre segundos y 48 horas dependiendo del TTL
+anterior y del proveedor. Anti-Gravital consulta multiples resolvers publicos
+para dar una vision real del estado:
+
+```rust
+use ag_domains::propagation::{PropagationChecker, DEFAULT_RESOLVERS};
+
+let checker = PropagationChecker::new(DEFAULT_RESOLVERS);
+let result = checker.check_txt("_dmarc.ejemplo.com", "v=DMARC1").await;
+
+println!(
+    "Propagacion: {}/{} resolvers confirmados",
+    result.confirmed, result.total
+);
+```
+
+Equivalente via CLI:
+
+```sh
+ag domains check --domain ejemplo.com --expected "v=DMARC1" --min-confirmed 3
+```
+
+---
+
+## 4. Emitir un certificado TLS via ACME
+
+`ag-domains` integra `instant-acme` para emitir certificados de Let's Encrypt
+usando el challenge DNS-01 (el proveedor DNS crea y elimina el registro TXT
+automaticamente):
+
+```rust
+use ag_domains::{
+    acme::renewal::{CertConfig, issue},
+    provider::cloudflare::CloudflareProvider,
+};
+
+#[tokio::main]
+async fn main() -> anyhow::Result<()> {
+    let provider = CloudflareProvider::new("CF_TOKEN_AQUI");
+    let zone_id = provider.zone_id("ejemplo.com").await?;
+
+    let config = CertConfig {
+        domain: "ejemplo.com".to_owned(),
+        zone_id,
+        contact_email: "admin@ejemplo.com".to_owned(),
+        staging: true, // usar false en produccion
+    };
+
+    let (cert, credentials) = issue(&config, &provider).await?;
+
+    // Guardar el PEM del certificado y la clave privada.
+    std::fs::write("cert.pem", &cert.cert_chain_pem)?;
+    std::fs::write("key.pem", &cert.private_key_pem)?;
+
+    // Guardar las credenciales para renovaciones futuras.
+    let creds_json = serde_json::to_string(&credentials)?;
+    std::fs::write("acme-credentials.json", creds_json)?;
+
+    println!("Certificado emitido y guardado en cert.pem / key.pem");
+    Ok(())
+}
+```
+
+Para renovacion automatica con una tarea en background:
+
+```rust
+use ag_domains::acme::renewal::spawn_renewal_task;
+
+let handle = spawn_renewal_task(
+    config,
+    credentials,
+    provider,
+    30, // renovar 30 dias antes del vencimiento
+    |new_cert| {
+        // Callback cuando el certificado se renueva.
+        std::fs::write("cert.pem", &new_cert.cert_chain_pem).ok();
+        std::fs::write("key.pem", &new_cert.private_key_pem).ok();
+    },
+);
+
+// handle.abort() para detener la tarea.
+```
+
+---
+
+## 5. Enviar correo transaccional
+
+### Via SMTP (lettre + rustls)
+
+```rust
+use ag_mail::{
+    message::{Address, EmailBuilder},
+    sender::{smtp::{SmtpConfig, SmtpSender}, MailSender},
+};
+
+let config = SmtpConfig::new("smtp.ejemplo.com", 587, "user", "pass");
+let sender = SmtpSender::new(config).await?;
+
+let email = EmailBuilder::new()
+    .from(Address::with_name("Ejemplo", "noreply@ejemplo.com"))
+    .to(Address::new("usuario@ejemplo.com"))
+    .subject("Bienvenido")
+    .html_body("<h1>Hola</h1>")
+    .text_body("Hola")
+    .build()?;
+
+sender.send(&email).await?;
+```
+
+### Via Resend (HTTP)
+
+```rust
+use ag_mail::sender::resend::{ResendConfig, ResendSender};
+
+let config = ResendConfig::new("re_api_key_aqui");
+let sender = ResendSender::new(config);
+sender.send(&email).await?;
+```
+
+### Via cola con reintentos
+
+```rust
+use std::sync::Arc;
+use ag_mail::queue::{InMemoryQueue, RetryPolicy};
+
+let policy = RetryPolicy::default(); // 3 reintentos, backoff exponencial
+let queue = InMemoryQueue::new(Arc::new(sender), policy, 64);
+let worker = queue.spawn_worker();
+
+queue.enqueue(email).await?;
+// worker.abort() para detener el worker.
+```
+
+---
+
+## 6. Integracion ag-auth -> ag-mail
+
+`ag-auth` puede enviar correos de verificacion, recuperacion de contrasena
+y magic links mediante `AuthMailer`:
+
+```rust
+use std::sync::Arc;
+use ag_auth::{AgAuth, AuthConfig, AuthMailer};
+use ag_mail::sender::resend::{ResendConfig, ResendSender};
+
+let sender: Arc<dyn ag_mail::sender::MailSender> =
+    Arc::new(ResendSender::new(ResendConfig::new("re_api_key")));
+
+let mailer = Arc::new(AuthMailer::new(
+    sender,
+    "noreply@ejemplo.com",
+    "Mi Proyecto",
+));
+
+let auth = AgAuth::new(config, reqwest::Client::new())?.with_mail(mailer);
+
+// Enviar correo de verificacion:
+auth.mailer.as_ref().unwrap()
+    .send_verification("usuario@ejemplo.com", "TOKEN", "https://ejemplo.com")
+    .await?;
+```
+
+Ver tambien: `examples/auth-mail-demo` para un ejemplo ejecutable completo
+que demuestra los tres flujos sin necesitar SMTP real.
+
+---
+
+## Referencia rapida de comandos CLI
+
+| Comando | Descripcion |
+|---|---|
+| `ag domains check --domain ejemplo.com --expected "v=TXT"` | Verifica propagacion DNS |
+| `ag domains sync --schema schema.ag --zone-id Z --token T` | Aplica SPF/DKIM/DMARC desde el DSL |
+| `ag mail test --to user@e.com --from no@e.com --smtp-host smtp.e.com` | Envia correo de prueba |
+
+---
+
+## Documentos relacionados
+
+- `docs/adr/0007-ag-mail-ag-domains.md` — decision arquitectonica
+- `docs/modules/ag-mail/` — especificacion del modulo
+- `docs/modules/ag-domains/` — especificacion del modulo
+- `docs/rfc/RFC-0006-ag-mail-alcance.md` — alcance v1 de ag-mail
+- `docs/rfc/RFC-0007-ag-domains-alcance.md` — alcance v1 de ag-domains

--- a/docs/manual/README.md
+++ b/docs/manual/README.md
@@ -15,6 +15,8 @@ configurar y desplegar componentes del ecosistema.
 | Capitulo | Tema | Estado |
 | --- | --- | --- |
 | `01-shield-as-library.md` | Usar la Shield de `ag-core` como libreria | Publicado |
+| `02-primera-api.md` | Crear la primera API con el DSL | Publicado |
+| `03-dominio-tls-correo.md` | Configurar dominio, TLS y correo transaccional | Publicado |
 
 ## Convencion
 

--- a/docs/pr-drafts/f45-pendientes.md
+++ b/docs/pr-drafts/f45-pendientes.md
@@ -1,0 +1,66 @@
+# fix(fase-4.5): ag-lsp v0.7 + ACME renewal fix + manual cap. 3
+
+## Fase afectada
+
+Fase 4.5 — Completar entregables pendientes: ag-lsp, ACME, documentacion.
+
+## Tipo de cambio
+
+Correcciones y completar entregables pendientes de Fase 4.5 (`fix` + `docs`).
+
+## Documentos relacionados
+
+- `docs/manual/03-dominio-tls-correo.md` — nuevo capitulo del manual
+- `docs/manual/README.md` — indice actualizado
+- `docs/master/ANTI-GRAVITAL-Hoja-de-Ruta.md` seccion 4.5.2 entregables
+
+## Resumen
+
+Tres entregables de Fase 4.5 que no formaron parte del PR #42:
+
+**ag-lsp — soporte DSL v0.7** (`crates/ag-lsp/src/backend.rs`):
+- Hover con documentacion completa para `mail`, `domain`, `template`
+- Completions para keywords v0.7 y sus propiedades (`provider`, `from`,
+  `subject`, `vars`, `dkim_selector`, `dmarc_policy`, `dmarc_rua`)
+- 6 tests nuevos (total: 15 tests en ag-lsp)
+
+**ag-domains — correccion ACME renewal** (`crates/ag-domains/src/acme/renewal.rs`):
+- Bug fix: `check_interval - renew_threshold` causaba underflow (Duration
+  de 1 dia menos 30 dias panickea en debug mode)
+- Nuevo calculo: `sleep_secs = renew_before_days.max(1) * 86400`
+- TECH-DEBT documentado para cuando se implemente parseo de `notAfter`
+- 4 tests nuevos para `CertConfig`, `IssuedCert` y serde roundtrip
+- `acme/mod.rs`: eliminar comentario "Skeleton de la Fase 4.5"
+
+**Manual cap. 3** (`docs/manual/03-dominio-tls-correo.md`):
+- Guia: "Configurar dominio, TLS y correo transaccional con Anti-Gravital"
+- 6 secciones: DSL, DNS sync, propagacion, ACME, correo transaccional,
+  ag-auth + ag-mail. Con ejemplos de codigo compilables y comandos CLI.
+
+## Plan de prueba
+
+- `cargo test -p ag-lsp` — 15 tests, 0 fallos
+- `cargo test -p ag-domains` — 28 tests, 0 fallos
+- `cargo clippy -p ag-lsp -p ag-domains -- -D warnings` — 0 errores
+- `cargo fmt --all -- --check` — sin cambios pendientes
+
+## Criterios de salida avanzados
+
+- ag-lsp provee hover y autocompletado para bloques DSL v0.7
+- ACME renewal no panickea en debug mode con renew_before_days tipico
+- Manual cap. 3 documenta el flujo dominio/TLS/correo de extremo a extremo
+
+## Checklist final
+
+- [x] Pertenece a la fase correcta (4.5 segun ADR-0007)
+- [x] Respeta la documentacion
+- [x] No rompe arquitectura
+- [x] No anade complejidad innecesaria
+- [x] No crea dependencias circulares
+- [x] Compila
+- [x] Pasa tests
+- [x] Pasa fmt
+- [x] Pasa clippy
+- [x] Tiene documentacion (manual cap. 3)
+- [x] Tiene manejo de errores correcto (bug fix renewal)
+- [x] Mantiene coherencia con Anti-Gravital v4.0


### PR DESCRIPTION
# feat(fase-4.5): ag-mail + ag-domains — correo transaccional y gestion DNS

## Fase afectada

Fase 4.5 — Crates de correo transaccional y gestion DNS (ADR-0007)

## Tipo de cambio

Nuevos crates funcionales (`feat`): ag-mail, ag-domains. Extension de ag-auth,
ag-dsl, ag-cli y tests de integracion.

## Documentos relacionados

- `docs/adr/0007-ag-mail-ag-domains.md` — decision arquitectonica
- `docs/master/ANTI-GRAVITAL-Arquitectura-Tecnica.md` secciones 8.7, 8.8
- `docs/master/ANTI-GRAVITAL-Hoja-de-Ruta.md` seccion Fase 4.5
- `docs/modules/ag-mail.md` — especificacion del modulo
- `docs/modules/ag-domains.md` — especificacion del modulo
- `docs/dsl/v0.7.md` — bloques mail/domain en el DSL

## Resumen

Implementacion completa de Fase 4.5 (Etapas 2-1 a 2-12). Agrega correo
transaccional outbound y gestion DNS via traits con adapters intercambiables.

**ag-mail** (`crates/ag-mail`):
- `MailSender` trait + `SmtpSender` (lettre + rustls) + `ResendSender` (HTTP)
- `InMemoryQueue` con reintentos exponenciales y worker tokio
- `StringTemplate` con sustitucion `{{var}}`
- `NullSender` (feature test-utils) para tests cross-crate
- 38 tests

**ag-domains** (`crates/ag-domains`):
- `DnsProvider` trait + `CloudflareProvider` (reqwest)
- `apply_mail_records`: upsert idempotente de SPF/DKIM/DMARC
- `PropagationChecker`: verificacion multi-resolver con hickory-dns
- ACME skeleton
- 24 tests

**ag-dsl v0.7** (`crates/ag-dsl`):
- Tokens `mail`, `domain`, `template` en el lexer
- Nodos `MailBlock`, `DomainBlock`, `MailTemplateDef` en el AST
- Parsers y analisis semantico para los nuevos bloques
- 151 tests totales

**ag-auth** (feature `mail`):
- `AuthMailer` con inyeccion de `Arc<dyn MailSender>`
- `AgAuth::with_mail()` builder
- Tres operaciones: send_verification, send_password_reset, send_magic_link
- 37 tests (32 sin feature, 37 con feature mail)

**ag-cli**:
- `ag domains check` — propagacion TXT via resolvers publicos
- `ag domains sync` — aplica registros SPF/DKIM/DMARC
- `ag mail test` — envia correo de prueba via SMTP

**examples/auth-mail-demo**:
- Ejemplo ejecutable de los tres flujos de correo con NullSender

**tests/integration**:
- 7 tests E2E en `fase45_e2e.rs` (mail, domains, auth+mail)
- Total: 14 tests de integracion (7 Fase 4 + 7 Fase 4.5)

## Plan de prueba

- `cargo test --workspace` — todos los tests pasan
- `cargo test -p ag-auth --features mail` — 37 tests, 0 fallos
- `cargo test -p ag-integration-tests` — 14 tests E2E, 0 fallos
- `cargo run -p auth-mail-demo` — produce salida correcta sin SMTP real
- `cargo clippy --workspace` — 0 errores
- `cargo fmt --all -- --check` — sin cambios pendientes

## Criterios de salida avanzados

- ag-mail operativo con SMTP y Resend adapter
- ag-domains con upsert idempotente SPF/DKIM/DMARC
- DSL v0.7 con bloques mail/domain parseados y validados
- ag-auth puede enviar los tres tipos de correo de autenticacion
- CLI expone ag domains y ag mail como subcomandos
- Ejemplo ejecutable sin dependencias externas
- 14 tests E2E cross-module pasan

## Checklist final

- [x] Pertenece a la fase correcta (4.5 segun ADR-0007)
- [x] Respeta la documentacion (Arquitectura Tecnica, Hoja de Ruta)
- [x] No rompe arquitectura (no circular deps, no ag-mail->ag-auth)
- [x] No anade complejidad innecesaria
- [x] No crea dependencias circulares
- [x] Compila en dev y release
- [x] Pasa tests (workspace: 0 fallos)
- [x] Pasa fmt
- [x] Pasa clippy
- [x] Tiene documentacion (docs/modules, docs/dsl, docs/adr)
- [x] Tiene manejo de errores correcto (AgMailError, AgDomainsError)
- [x] Mantiene coherencia con Anti-Gravital v4.0
