### PR TITLE
Docs cierre fase 4.5

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -38,17 +38,21 @@ jobs:
           # Los hashes deben mantenerse en sync con docs/master/VERSION.md.
           # Cambios a los maestros requieren ADR aprobado y actualizacion
           # coordinada de VERSION.md y este workflow en el mismo PR.
-          # Estado actual: suplemento Fase 4.5 (ADR-0007), 2026-05-23.
-          # Blueprint PDF queda en v4.0 como deuda explicita pendiente de
-          # re-export a v4.1; los maestros markdown gobiernan (VERSION.md
-          # politica #4).
-          expected_blueprint="59a1df26bd24e96067c58c142709e3cb55fc33efbb1c8f3739d9473598dfb660"
-          expected_arch="5f56cadcf03f49289b7f4a141eccf4c6289543caf65041f38b54a4830b6bd76d"
-          expected_road="ff5e322f568e2ecf416d09235c91d8f4eb004531b6844f513a68b63042b64590"
-          got_blueprint="$(sha256sum docs/master/ANTI-GRAVITAL-Blueprint-v4.0.pdf | awk '{print $1}')"
+          # Estado actual: cierre documental Fase 4.0-4.5 (ADR-0008), 2026-05-25.
+          # Arquitectura y Hoja-de-Ruta ahora bilingues (EN-primero). Se anade
+          # el Blueprint v4.1.md como fuente markdown versionable. Blueprint PDF
+          # queda en v4.0 como deuda explicita pendiente de re-export a v4.1;
+          # los maestros markdown gobiernan (VERSION.md politica #4).
+          expected_blueprint_pdf="59a1df26bd24e96067c58c142709e3cb55fc33efbb1c8f3739d9473598dfb660"
+          expected_blueprint_md="a6a1479c3586ea0bb7afeff3f801d13aebcea0f046216130358f0b897e351bc6"
+          expected_arch="d511e96b4a00a6eb2aec09efe7a7fd6c15a0cef7ff89d055f3e2f9fff7b8de31"
+          expected_road="24a5fa50a02a167d32bd2c3e650d65344a16f01735dc6a358ec5f303017cd3b9"
+          got_blueprint_pdf="$(sha256sum docs/master/ANTI-GRAVITAL-Blueprint-v4.0.pdf | awk '{print $1}')"
+          got_blueprint_md="$(sha256sum docs/master/ANTI-GRAVITAL-Blueprint-v4.1.md | awk '{print $1}')"
           got_arch="$(sha256sum docs/master/ANTI-GRAVITAL-Arquitectura-Tecnica.md | awk '{print $1}')"
           got_road="$(sha256sum docs/master/ANTI-GRAVITAL-Hoja-de-Ruta.md | awk '{print $1}')"
-          test "$got_blueprint" = "$expected_blueprint"
+          test "$got_blueprint_pdf" = "$expected_blueprint_pdf"
+          test "$got_blueprint_md" = "$expected_blueprint_md"
           test "$got_arch" = "$expected_arch"
           test "$got_road" = "$expected_road"
           echo "Maestros validos."

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,66 @@ primera version etiquetada.
 
 ## [Unreleased]
 
+### Fase 4.5 - Implementacion tecnica: ag-mail + ag-domains (2026-05-24)
+
+Anadido:
+
+- `crates/ag-mail` (estandar diferido): `MailSender` trait + `SmtpSender` (lettre + rustls)
+  + `ResendSender` (HTTP). `InMemoryQueue` con reintentos y backoff exponencial.
+  `StringTemplate` + `MailTemplate` trait. `NullSender` (feature `test-utils`). 38 tests.
+
+- `crates/ag-domains` (opcional infra): `DnsProvider` trait + `CloudflareProvider` (reqwest).
+  `apply_mail_records`: upsert idempotente de SPF/DKIM/DMARC. `PropagationChecker`
+  con hickory-resolver. Soporte ACME completo via instant-acme + rcgen (DNS-01,
+  renovacion automatica). 28 tests.
+
+- `crates/ag-dsl` v0.7: tokens `mail`, `domain`, `template` en el lexer; nodos
+  `MailBlock`, `DomainBlock`, `MailTemplateDef` en el AST; parsers y analisis
+  semantico para los nuevos bloques. 151 tests.
+
+- `crates/ag-auth` (feature `mail`): `AuthMailer` con `send_verification`,
+  `send_password_reset`, `send_magic_link`. `AgAuth::with_mail()` builder. 37 tests.
+
+- `crates/ag-cli`: subcomandos `ag domains check`, `ag domains sync`, `ag mail test`.
+
+- `examples/auth-mail-demo`: ejemplo ejecutable de los tres flujos con `NullSender`.
+
+- `tests/integration/tests/fase45_e2e.rs`: 7 tests E2E cross-module (total: 14).
+
+### Fase 4.5 - Pendientes: ag-lsp v0.7 + DSL from->domain + ACME fix + docs (2026-05-24)
+
+Anadido:
+
+- `crates/ag-lsp/src/backend.rs`: hover y completions para los bloques DSL v0.7.
+  `mail`, `domain`, `template` con ejemplos de codigo; propiedades `provider`,
+  `from`, `subject`, `vars`, `dkim_selector`, `dmarc_policy`, `dmarc_rua`. 6 tests nuevos (15 total).
+
+- `docs/manual/03-dominio-tls-correo.md`: guia completa "Configurar dominio, TLS
+  y correo transaccional con Anti-Gravital". Seis secciones: declaracion DSL,
+  DNS sync, verificacion de propagacion, ACME, correo transaccional, ag-auth+ag-mail.
+
+Corregido:
+
+- `crates/ag-dsl/src/semantic.rs`: warning cuando el hostname del campo `from` de
+  un bloque `mail` no coincide con ningun `domain_name` declarado en los bloques
+  `domain` del schema. 2 tests nuevos (153 total en ag-dsl).
+
+- `crates/ag-domains/src/acme/renewal.rs`: bug de underflow en `spawn_renewal_task`.
+  `check_interval - renew_threshold` panickea en debug mode si `renew_before_days >= 1`.
+  Nuevo calculo: `sleep_secs = renew_before_days.max(1) * 86400`. 4 tests nuevos.
+
+- `tools/vscode-anti-gravital/syntaxes/anti-gravital.tmLanguage.json`: keywords DSL v0.7
+  anadidos al resaltado de sintaxis: `mail`, `domain`, `template`, `provider`, `from`,
+  `subject`, `vars`, `dkim_selector`, `dmarc_policy`, `dmarc_rua`.
+
+Cambiado:
+
+- `docs/roadmap/STATUS.md`: Fase 4.5 marcada como completada con todos los criterios
+  de salida marcados. Commits de referencia: PR #42 (implementacion) y PR #43 (pendientes).
+
+- `README.md`: banner y tabla de calendario actualizados a "Fase 4.5 implementacion
+  tecnica completa".
+
 ### Fase 4.5 - Integracion documental: ag-mail + ag-domains (2026-05-23)
 
 Anadido:

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -920,6 +920,37 @@ que aparece cuando el autofill no encuentra descriptor.
 Si un agente o colaborador commitea sin crear o actualizar el
 descriptor correspondiente, la PR no se acepta.
 
+### Politica de idioma (ADR-0008)
+
+El ingles es el idioma canonico del codigo y de la documentacion tecnica.
+Regla fijada por `ADR-0008` (supersede el "espanol predeterminado" de
+`ADR-0002`) al cierre de la Fase 4.5.
+
+Codigo:
+
+- Todos los comentarios de codigo (`//`, `///`, `//!`) se escriben en
+  ingles. Sin excepciones para codigo nuevo.
+- Los identificadores van en ingles (ya era la practica).
+
+Documentacion:
+
+- Ingles canonico para la documentacion tecnica profunda: `docs/architecture/`,
+  `docs/modules/`, `docs/dsl/`, `docs/rfc/`, `docs/adr/`, `docs/benchmarks/`,
+  `docs/security/`, `docs/governance/`.
+- Documentos vitrina bilingues (EN+ES en el mismo archivo, seccion inglesa
+  primero y canonica, seccion espanola despues, separadas por regla
+  horizontal, con ancla `English | Espanol` al inicio):
+  - `README.md` (raiz),
+  - los tres maestros de `docs/master/`,
+  - los capitulos de `docs/manual/`.
+- Si la seccion inglesa y la espanola divergen, gana la inglesa; la espanola
+  se marca como pendiente de actualizacion.
+
+Esta regla NO se aplica retroactivamente como bloqueo: la documentacion
+tecnica preexistente en espanol se migra a ingles de forma gradual al
+tocarse. El codigo se convirtio integramente en la fase de cierre documental
+4.0-4.5.
+
 ### Prohibicion absoluta de emojis
 
 No se usan emojis en ningun lugar del proyecto: ni en documentacion, ni

--- a/README.md
+++ b/README.md
@@ -1,17 +1,225 @@
 # Anti-Gravital
 
-> Estado: Fase 4.5 implementacion tecnica completa — ag-mail (SMTP+Resend), ag-domains (Cloudflare+ACME+SPF/DKIM/DMARC), DSL v0.7, ag-lsp v0.7, 14 tests E2E cross-module.
+**[English](#in-english) | [Espanol](#en-espanol)**
+
 > Status: Phase 4.5 technical implementation complete — ag-mail (SMTP+Resend), ag-domains (Cloudflare+ACME+SPF/DKIM/DMARC), DSL v0.7, ag-lsp v0.7, 14 cross-module E2E tests.
+> Estado: Fase 4.5 implementacion tecnica completa — ag-mail (SMTP+Resend), ag-domains (Cloudflare+ACME+SPF/DKIM/DMARC), DSL v0.7, ag-lsp v0.7, 14 tests E2E cross-module.
+
+Anti-Gravital is an open source ecosystem for building high-performance
+backend applications in pure Rust, with three core properties: no
+external runtime, schema-first approach, and a modular architecture of
+independent crates.
 
 Anti-Gravital es un ecosistema de software libre para construir
 aplicaciones backend de alto rendimiento en Rust puro, con tres
 propiedades fundamentales: ausencia de runtime externo, enfoque
 schema-first y arquitectura modular de crates independientes.
 
-Anti-Gravital is an open source ecosystem for building high-performance
-backend applications in pure Rust, with three core properties: no
-external runtime, schema-first approach, and a modular architecture of
-independent crates.
+---
+
+## In English
+
+### What it is
+
+A high-performance Rust backend runtime, a domain definition language
+called Anti-DSL (`.ag` files), a unified CLI (`ag`), a set of batteries
+included modules published as independent crates, a WASI plugin
+system, a simplified deployment layer, native transactional email
+(`ag-mail`) and domain plus TLS management (`ag-domains`) introduced
+in Phase 4.5, typed SDK generators for TypeScript and Dart, and
+importers from legacy frameworks.
+
+### What it is not
+
+It does not replace Kubernetes, Flutter, React Native, Next.js, Docker,
+PostgreSQL, Redis, MinIO or NATS. It is not a game engine or a
+scientific computing framework. `ag-mail` is not a full mail server:
+it only sends outbound transactional email; it does not receive
+inbound mail, and does not implement IMAP/POP, antispam or IP
+reputation. `ag-domains` is not a domain registrar: domains are
+purchased externally. See the scope chapter at
+`docs/architecture/03-alcance-y-limites.md`.
+
+### Project status
+
+Phases 1, 2, 3 and 4 have been technically completed. There is functional,
+tested, and benchmarked code.
+
+**Phase 1 — The Shield MVP:** complete. The `ag-core` crate contains
+the operational `shield` module with HTTP/1.1, HTTP/2, TLS 1.3 (rustls),
+JWT Ed25519 authentication, rate limiting, CORS, CSRF, payload
+validation, and structured logging. Pipeline verified with E2E tests
+and criterion benchmarks.
+
+**Phase 2 — The Core MVP:** complete (technical implementation).
+Axum router integrated with the Shield, typed extractors, `AgError`
+error system, PostgreSQL connection pool via sqlx, embedded migrations,
+and the `todo-api` example app with a full CRUD. The `ag` CLI provides
+`new`, `dev`, and `build` with three templates (`rest`, `realtime`,
+`fullstack`). The `todo-api` app deploys as a `FROM scratch` image of
+2.49 MB. Benchmarks measured on real hardware: HTTP stack 89K req/s,
+CRUD with PostgreSQL 14.5K req/s reads (bottleneck is PostgreSQL,
+not the framework). Phase throughput and latency targets (40K req/s,
+p99 <= 5 ms) require hardware with more cores or pgbouncer.
+
+**Phase 3 — Anti-DSL alpha:** technical implementation complete (branch
+`fase-3`). The `ag-dsl` compiler is operational with DSL v0.1 to v0.4:
+models, endpoints, validations, and model relations (@references/@relation,
+FOREIGN KEY SQL, Option<M>/Vec<M> Rust, $ref OpenAPI). The CLI exposes
+`ag generate`, `ag schema lint`, and `ag schema diff`. LSP server
+(`ag-lsp`) with real-time diagnostics, autocompletion, and hover. VS Code
+plugin with syntax highlighting and LSP integration (`.vsix` packaged).
+cargo-fuzz harness with 3 active targets in CI. 129 green tests (119
+ag-dsl + 10 ag-lsp), 95.26% coverage. Real 2-hour benchmark against Neon
+PostgreSQL: 255,805 requests, 0 errors, peak 43 req/s. External community
+criteria pending.
+
+**Phase 4 — Standard modules:** technical implementation complete (branch
+`fase-4`). Five batteries-included modules operational as independent crates:
+
+- `ag-auth`: WebAuthn/FIDO2 (registration+authentication, COSE ES256/EdDSA
+  verification), OAuth2 PKCE (Google, GitHub), JWT Ed25519, BLAKE3 API keys,
+  refresh tokens with in-memory blacklist. 32 tests.
+- `ag-cache`: L1 in-memory cache with moka, tag-based invalidation, configurable TTL.
+  >= 80% coverage. RFC-0005 (native RESP2 server) proposed, pending approval.
+- `ag-realtime`: InProcess pub/sub event bus, external NATS client with 3-level TLS
+  (system/custom CA/mTLS) and JetStream, Axum helpers for WebSocket and SSE
+  (EventSource-compatible). `AgRealtime::new` is async. `realtime-chat` and
+  `ai-backend` examples operational.
+- `ag-storage`: native filesystem store with embedded Axum HTTP server, path-safe
+  by construction, image processing (resize/thumbnail/webp), S3/MinIO backend via
+  `object_store`, HMAC-SHA256 signed URLs. `AgStore` is a `Native | S3` enum.
+- `ag-observe`: structured tracing, OTLP exporter, Prometheus metrics via
+  `axum::Router`, custom layer, LogFormat (JSON/Text). Idempotent init.
+
+DSL extended to v0.5 (auth/policies in endpoints) and v0.6 (declared events).
+Updated generators: rust_gen (Claims extractor), openapi_gen (securitySchemes),
+ts_gen (event payloads), new async_api_gen (AsyncAPI 2.6). 136 tests in ag-dsl,
+95.88% coverage. `tests/integration` crate with 7 cross-module E2E tests
+(auth+cache+realtime+storage+observe). >= 80% coverage in all modules. External
+criteria (community, crates.io publication) pending.
+
+Detailed per-criterion status lives in `docs/roadmap/STATUS.md`.
+
+### Quick start
+
+Requires Rust 1.95+ and PostgreSQL.
+
+```sh
+# Install the CLI
+cargo install --path crates/ag-cli
+
+# Create a new project
+ag new my-api
+
+# Start in development mode
+cd my-api
+ag dev
+```
+
+The app responds at `http://localhost:8080`. The `rest` template
+generates a project with Shield, typed extractors, and a PostgreSQL
+connection ready to configure via `DATABASE_URL`.
+
+For the full CRUD example with PostgreSQL:
+
+```sh
+export DATABASE_URL="postgresql://user:pass@localhost/my_db"
+cargo run -p todo-api
+```
+
+**DSL workflow (Phase 3, operational since v0.1+v0.2):**
+
+Define your API in a `schema.ag` file and generate all artifacts:
+
+```sh
+ag generate --schema schema.ag --output ./generated
+```
+
+Produces: `src/models.rs`, `src/types.rs`, `src/handlers.rs`,
+`src/router.rs`, `migrations/0001_initial.sql`,
+`clients/typescript/types.ts`, `clients/typescript/client.ts`,
+`openapi.json`.
+
+Validate and diff schemas:
+
+```sh
+ag schema lint --schema schema.ag
+ag schema diff old-schema.ag --schema schema.ag
+```
+
+### Measured performance
+
+**Phase 2 — Ryzen 5 2500U local (2026-05-21)**
+
+Measurements on AMD Ryzen 5 2500U (4C/8T), native PostgreSQL 18.4,
+`rustc 1.95.0`, release profile with fat LTO. Full methodology in
+`docs/benchmarks/measurement-2026-05-21-fase-2-crud-ryzen5-2500u.md`.
+
+| Endpoint                     | req/s    | p99      | Notes                     |
+| ---------------------------- | -------- | -------- | ------------------------- |
+| GET /health (no DB)          | 88 930   | 3.2 ms   | Pure HTTP stack           |
+| GET /todos/:id (SELECT PK)   | 14 478   | 14.6 ms  | Bottleneck: PostgreSQL    |
+| POST /todos (INSERT)         | 8 934    | 9.4 ms   | synchronous_commit off    |
+
+The 40K req/s target requires hardware with >= 8 physical cores or
+pgbouncer in transaction mode.
+
+**Phase 3 — Neon PostgreSQL serverless (2026-05-22)**
+
+2-hour benchmark against Neon PostgreSQL (us-east-1, pooler). Mixed
+operations: POST invoices with transactions, GET by id, GET filtered
+list, PATCH status. Connection pool of 20. Full methodology in
+`docs/benchmarks/measurement-2026-05-22-neon-real.md`.
+
+| Metric                       | Value    | Notes                           |
+| ---------------------------- | -------- | ------------------------------- |
+| Total requests               | 255 805  | 120 min 11 s                    |
+| Errors                       | 0        | Error rate 0.00%                |
+| Average throughput           | 35.5 req/s | Includes cold-start           |
+| Peak throughput              | 43.0 req/s | Cooldown phase (25 workers)   |
+
+Saturation test: system stable up to 800 concurrent workers (0 errors).
+Saturation at 1600 workers due to connection pool exhaustion (Neon was
+at 10% CPU / 12% RAM throughout). See
+`docs/benchmarks/measurement-2026-05-22-neon-saturacion.md`.
+
+### Source of truth
+
+The three master documents live in `docs/master/` and govern every
+technical decision:
+
+- `ANTI-GRAVITAL-Blueprint-v4.0.pdf` — vision, positioning, scope.
+- `ANTI-GRAVITAL-Arquitectura-Tecnica.md` — how the system is built.
+- `ANTI-GRAVITAL-Hoja-de-Ruta.md` — what is built and when.
+
+These documents are decomposed into navigable files under
+`docs/architecture/`, `docs/roadmap/`, `docs/modules/`, `docs/dsl/`,
+`docs/security/`, `docs/governance/` and `docs/benchmarks/`. If a
+derivative diverges from its master, the master wins.
+
+### How to contribute
+
+See `CONTRIBUTING.md` for the full guide. Quick summary:
+
+1. Read the masters in `docs/master/` and current phase status in
+   `docs/roadmap/STATUS.md`.
+2. For architectural changes, open an RFC in `docs/rfc/` before
+   touching code.
+3. Keep pull requests small: titles up to 256 characters and a single
+   logical unit of change.
+4. Run `cargo fmt`, `cargo clippy -D warnings`, `cargo test`,
+   `cargo audit` and `cargo deny check` before submitting.
+
+### License
+
+Apache 2.0. See `LICENSE`.
+
+### Origin
+
+Project started by Gravital Labs, the open source division of Nereira
+Technology and Business Solutions, Republic of Panama. Initial
+maintainer: Angel Nereira.
 
 ---
 
@@ -245,212 +453,6 @@ Apache 2.0. Vease `LICENSE`.
 Proyecto iniciado por Gravital Labs, division open source de Nereira
 Technology and Business Solutions, Republica de Panama. Mantenedor
 inicial: Angel Nereira.
-
----
-
-## In English
-
-### What it is
-
-A high-performance Rust backend runtime, a domain definition language
-called Anti-DSL (`.ag` files), a unified CLI (`ag`), a set of batteries
-included modules published as independent crates, a WASI plugin
-system, a simplified deployment layer, native transactional email
-(`ag-mail`) and domain plus TLS management (`ag-domains`) introduced
-in Phase 4.5, typed SDK generators for TypeScript and Dart, and
-importers from legacy frameworks.
-
-### What it is not
-
-It does not replace Kubernetes, Flutter, React Native, Next.js, Docker,
-PostgreSQL, Redis, MinIO or NATS. It is not a game engine or a
-scientific computing framework. `ag-mail` is not a full mail server:
-it only sends outbound transactional email; it does not receive
-inbound mail, and does not implement IMAP/POP, antispam or IP
-reputation. `ag-domains` is not a domain registrar: domains are
-purchased externally. See the scope chapter at
-`docs/architecture/03-alcance-y-limites.md`.
-
-### Project status
-
-Phases 1, 2, 3 and 4 have been technically completed. There is functional,
-tested, and benchmarked code.
-
-**Phase 1 — The Shield MVP:** complete. The `ag-core` crate contains
-the operational `shield` module with HTTP/1.1, HTTP/2, TLS 1.3 (rustls),
-JWT Ed25519 authentication, rate limiting, CORS, CSRF, payload
-validation, and structured logging. Pipeline verified with E2E tests
-and criterion benchmarks.
-
-**Phase 2 — The Core MVP:** complete (technical implementation).
-Axum router integrated with the Shield, typed extractors, `AgError`
-error system, PostgreSQL connection pool via sqlx, embedded migrations,
-and the `todo-api` example app with a full CRUD. The `ag` CLI provides
-`new`, `dev`, and `build` with three templates (`rest`, `realtime`,
-`fullstack`). The `todo-api` app deploys as a `FROM scratch` image of
-2.49 MB. Benchmarks measured on real hardware: HTTP stack 89K req/s,
-CRUD with PostgreSQL 14.5K req/s reads (bottleneck is PostgreSQL,
-not the framework). Phase throughput and latency targets (40K req/s,
-p99 <= 5 ms) require hardware with more cores or pgbouncer.
-
-**Phase 3 — Anti-DSL alpha:** technical implementation complete (branch
-`fase-3`). The `ag-dsl` compiler is operational with DSL v0.1 to v0.4:
-models, endpoints, validations, and model relations (@references/@relation,
-FOREIGN KEY SQL, Option<M>/Vec<M> Rust, $ref OpenAPI). The CLI exposes
-`ag generate`, `ag schema lint`, and `ag schema diff`. LSP server
-(`ag-lsp`) with real-time diagnostics, autocompletion, and hover. VS Code
-plugin with syntax highlighting and LSP integration (`.vsix` packaged).
-cargo-fuzz harness with 3 active targets in CI. 129 green tests (119
-ag-dsl + 10 ag-lsp), 95.26% coverage. Real 2-hour benchmark against Neon
-PostgreSQL: 255,805 requests, 0 errors, peak 43 req/s. External community
-criteria pending.
-
-**Phase 4 — Standard modules:** technical implementation complete (branch
-`fase-4`). Five batteries-included modules operational as independent crates:
-
-- `ag-auth`: WebAuthn/FIDO2 (registration+authentication, COSE ES256/EdDSA
-  verification), OAuth2 PKCE (Google, GitHub), JWT Ed25519, BLAKE3 API keys,
-  refresh tokens with in-memory blacklist. 32 tests.
-- `ag-cache`: L1 in-memory cache with moka, tag-based invalidation, configurable TTL.
-  >= 80% coverage. RFC-0005 (native RESP2 server) proposed, pending approval.
-- `ag-realtime`: InProcess pub/sub event bus, external NATS client with 3-level TLS
-  (system/custom CA/mTLS) and JetStream, Axum helpers for WebSocket and SSE
-  (EventSource-compatible). `AgRealtime::new` is async. `realtime-chat` and
-  `ai-backend` examples operational.
-- `ag-storage`: native filesystem store with embedded Axum HTTP server, path-safe
-  by construction, image processing (resize/thumbnail/webp), S3/MinIO backend via
-  `object_store`, HMAC-SHA256 signed URLs. `AgStore` is a `Native | S3` enum.
-- `ag-observe`: structured tracing, OTLP exporter, Prometheus metrics via
-  `axum::Router`, custom layer, LogFormat (JSON/Text). Idempotent init.
-
-DSL extended to v0.5 (auth/policies in endpoints) and v0.6 (declared events).
-Updated generators: rust_gen (Claims extractor), openapi_gen (securitySchemes),
-ts_gen (event payloads), new async_api_gen (AsyncAPI 2.6). 136 tests in ag-dsl,
-95.88% coverage. `tests/integration` crate with 7 cross-module E2E tests
-(auth+cache+realtime+storage+observe). >= 80% coverage in all modules. External
-criteria (community, crates.io publication) pending.
-
-Detailed per-criterion status lives in `docs/roadmap/STATUS.md`.
-
-### Quick start
-
-Requires Rust 1.95+ and PostgreSQL.
-
-```sh
-# Install the CLI
-cargo install --path crates/ag-cli
-
-# Create a new project
-ag new my-api
-
-# Start in development mode
-cd my-api
-ag dev
-```
-
-The app responds at `http://localhost:8080`. The `rest` template
-generates a project with Shield, typed extractors, and a PostgreSQL
-connection ready to configure via `DATABASE_URL`.
-
-For the full CRUD example with PostgreSQL:
-
-```sh
-export DATABASE_URL="postgresql://user:pass@localhost/my_db"
-cargo run -p todo-api
-```
-
-**DSL workflow (Phase 3, operational since v0.1+v0.2):**
-
-Define your API in a `schema.ag` file and generate all artifacts:
-
-```sh
-ag generate --schema schema.ag --output ./generated
-```
-
-Produces: `src/models.rs`, `src/types.rs`, `src/handlers.rs`,
-`src/router.rs`, `migrations/0001_initial.sql`,
-`clients/typescript/types.ts`, `clients/typescript/client.ts`,
-`openapi.json`.
-
-Validate and diff schemas:
-
-```sh
-ag schema lint --schema schema.ag
-ag schema diff old-schema.ag --schema schema.ag
-```
-
-### Measured performance
-
-**Phase 2 — Ryzen 5 2500U local (2026-05-21)**
-
-Measurements on AMD Ryzen 5 2500U (4C/8T), native PostgreSQL 18.4,
-`rustc 1.95.0`, release profile with fat LTO. Full methodology in
-`docs/benchmarks/measurement-2026-05-21-fase-2-crud-ryzen5-2500u.md`.
-
-| Endpoint                     | req/s    | p99      | Notes                     |
-| ---------------------------- | -------- | -------- | ------------------------- |
-| GET /health (no DB)          | 88 930   | 3.2 ms   | Pure HTTP stack           |
-| GET /todos/:id (SELECT PK)   | 14 478   | 14.6 ms  | Bottleneck: PostgreSQL    |
-| POST /todos (INSERT)         | 8 934    | 9.4 ms   | synchronous_commit off    |
-
-The 40K req/s target requires hardware with >= 8 physical cores or
-pgbouncer in transaction mode.
-
-**Phase 3 — Neon PostgreSQL serverless (2026-05-22)**
-
-2-hour benchmark against Neon PostgreSQL (us-east-1, pooler). Mixed
-operations: POST invoices with transactions, GET by id, GET filtered
-list, PATCH status. Connection pool of 20. Full methodology in
-`docs/benchmarks/measurement-2026-05-22-neon-real.md`.
-
-| Metric                       | Value    | Notes                           |
-| ---------------------------- | -------- | ------------------------------- |
-| Total requests               | 255 805  | 120 min 11 s                    |
-| Errors                       | 0        | Error rate 0.00%                |
-| Average throughput           | 35.5 req/s | Includes cold-start           |
-| Peak throughput              | 43.0 req/s | Cooldown phase (25 workers)   |
-
-Saturation test: system stable up to 800 concurrent workers (0 errors).
-Saturation at 1600 workers due to connection pool exhaustion (Neon was
-at 10% CPU / 12% RAM throughout). See
-`docs/benchmarks/measurement-2026-05-22-neon-saturacion.md`.
-
-### Source of truth
-
-The three master documents live in `docs/master/` and govern every
-technical decision:
-
-- `ANTI-GRAVITAL-Blueprint-v4.0.pdf` — vision, positioning, scope.
-- `ANTI-GRAVITAL-Arquitectura-Tecnica.md` — how the system is built.
-- `ANTI-GRAVITAL-Hoja-de-Ruta.md` — what is built and when.
-
-These documents are decomposed into navigable files under
-`docs/architecture/`, `docs/roadmap/`, `docs/modules/`, `docs/dsl/`,
-`docs/security/`, `docs/governance/` and `docs/benchmarks/`. If a
-derivative diverges from its master, the master wins.
-
-### How to contribute
-
-See `CONTRIBUTING.md` for the full guide. Quick summary:
-
-1. Read the masters in `docs/master/` and current phase status in
-   `docs/roadmap/STATUS.md`.
-2. For architectural changes, open an RFC in `docs/rfc/` before
-   touching code.
-3. Keep pull requests small: titles up to 256 characters and a single
-   logical unit of change.
-4. Run `cargo fmt`, `cargo clippy -D warnings`, `cargo test`,
-   `cargo audit` and `cargo deny check` before submitting.
-
-### License
-
-Apache 2.0. See `LICENSE`.
-
-### Origin
-
-Project started by Gravital Labs, the open source division of Nereira
-Technology and Business Solutions, Republic of Panama. Initial
-maintainer: Angel Nereira.
 
 ---
 

--- a/crates/ag-ai/src/lib.rs
+++ b/crates/ag-ai/src/lib.rs
@@ -1,5 +1,5 @@
-//! Knowledge graph derivado del AST del DSL y capacidades asistidas por proveedores de IA.
+//! Knowledge graph derived from the DSL AST and AI-provider-assisted capabilities.
 //!
-//! Estado: Fase 0 (Fundaciones y Gobernanza). Este crate aun no contiene
-//! codigo funcional. La implementacion se entrega en la fase declarada
-//! en el README del crate y en la Hoja de Ruta del proyecto.
+//! Status: Phase 0 (Foundations and Governance). This crate does not yet
+//! contain functional code. The implementation is delivered in the phase
+//! declared in the crate's README and in the project's Roadmap.

--- a/crates/ag-auth/src/api_keys.rs
+++ b/crates/ag-auth/src/api_keys.rs
@@ -1,19 +1,19 @@
-//! Generacion y verificacion de API keys con hash BLAKE3.
+//! Generation and verification of API keys with BLAKE3 hashing.
 //!
-//! El flujo es:
-//! 1. [`generate`] crea 32 bytes aleatorios seguros, los codifica en Base64Url y los
-//!    prefija con `{prefix}_`. Retorna la clave en texto plano y su hash BLAKE3.
-//! 2. Solo el hash se almacena en la base de datos.
-//! 3. [`verify()`] computa el hash de la clave recibida y lo compara con el almacenado.
+//! The flow is:
+//! 1. [`generate`] creates 32 secure random bytes, encodes them in Base64Url and
+//!    prefixes them with `{prefix}_`. Returns the plaintext key and its BLAKE3 hash.
+//! 2. Only the hash is stored in the database.
+//! 3. [`verify()`] computes the hash of the received key and compares it with the stored one.
 
 use base64ct::{Base64Url, Encoding};
 
-/// Genera una nueva API key y su hash BLAKE3.
+/// Generates a new API key and its BLAKE3 hash.
 ///
-/// Retorna `(raw_key, key_hash)`. Solo `key_hash` debe almacenarse;
-/// `raw_key` se entrega al usuario una unica vez.
+/// Returns `(raw_key, key_hash)`. Only `key_hash` should be stored;
+/// `raw_key` is given to the user only once.
 ///
-/// # Ejemplo
+/// # Example
 ///
 /// ```
 /// let (raw, hash) = ag_auth::api_keys::generate("sk");
@@ -29,27 +29,27 @@ pub fn generate(prefix: &str) -> (String, String) {
     (raw_key, key_hash)
 }
 
-/// Verifica una API key contra su hash BLAKE3 almacenado.
+/// Verifies an API key against its stored BLAKE3 hash.
 ///
-/// Retorna `true` si la clave corresponde al hash; `false` en caso contrario.
+/// Returns `true` if the key matches the hash; `false` otherwise.
 ///
-/// La comparacion se realiza sobre el resultado del hash (cadena hexadecimal),
-/// por lo que no hay timing attack significativo contra la clave original.
+/// The comparison is performed over the hash result (hexadecimal string),
+/// so there is no significant timing attack against the original key.
 pub fn verify(raw_key: &str, stored_hash: &str) -> bool {
     let computed = hash_key(raw_key);
-    // Comparacion en tiempo constante para evitar timing attacks sobre el hash.
+    // Constant-time comparison to avoid timing attacks on the hash.
     constant_time_eq(&computed, stored_hash)
 }
 
-/// Computa el hash BLAKE3 de una clave y lo retorna como cadena hexadecimal.
+/// Computes the BLAKE3 hash of a key and returns it as a hexadecimal string.
 fn hash_key(key: &str) -> String {
     blake3::hash(key.as_bytes()).to_hex().to_string()
 }
 
-/// Comparacion de cadenas en tiempo constante.
+/// Constant-time string comparison.
 ///
-/// Compara byte a byte sin cortocircuito para evitar inferencia de longitud
-/// o contenido mediante medicion de tiempo de respuesta.
+/// Compares byte by byte without short-circuiting to avoid inferring length
+/// or content through response-time measurement.
 fn constant_time_eq(a: &str, b: &str) -> bool {
     if a.len() != b.len() {
         return false;

--- a/crates/ag-auth/src/config.rs
+++ b/crates/ag-auth/src/config.rs
@@ -1,34 +1,34 @@
-//! Configuracion de autenticacion leida desde variables de entorno.
+//! Authentication configuration read from environment variables.
 
-/// Configuracion del modulo de autenticacion.
+/// Configuration of the authentication module.
 #[derive(Debug, Clone)]
 pub struct AuthConfig {
-    /// Clave privada Ed25519 en formato PEM para firmar JWTs.
+    /// Ed25519 private key in PEM format for signing JWTs.
     /// Variable: `JWT_PRIVATE_KEY`
     pub jwt_private_key_pem: String,
-    /// Clave publica Ed25519 en formato PEM para verificar JWTs.
+    /// Ed25519 public key in PEM format for verifying JWTs.
     /// Variable: `JWT_PUBLIC_KEY`
     pub jwt_public_key_pem: String,
-    /// Identificador del relying party para WebAuthn (ej: `"example.com"`).
+    /// Relying party identifier for WebAuthn (e.g.: `"example.com"`).
     /// Variable: `WEBAUTHN_RP_ID`
     pub webauthn_rp_id: String,
-    /// URL de origen para WebAuthn (ej: `"https://example.com"`).
+    /// Origin URL for WebAuthn (e.g.: `"https://example.com"`).
     /// Variable: `WEBAUTHN_ORIGIN`
     pub webauthn_origin: String,
-    /// Client ID de OAuth2 Google. `None` deshabilita el provider.
+    /// Google OAuth2 client ID. `None` disables the provider.
     pub oauth_google_client_id: Option<String>,
-    /// Client secret de OAuth2 Google.
+    /// Google OAuth2 client secret.
     pub oauth_google_client_secret: Option<String>,
-    /// Client ID de OAuth2 GitHub. `None` deshabilita el provider.
+    /// GitHub OAuth2 client ID. `None` disables the provider.
     pub oauth_github_client_id: Option<String>,
-    /// Client secret de OAuth2 GitHub.
+    /// GitHub OAuth2 client secret.
     pub oauth_github_client_secret: Option<String>,
 }
 
 impl AuthConfig {
-    /// Lee la configuracion desde variables de entorno.
+    /// Reads the configuration from environment variables.
     ///
-    /// Retorna un error si las claves JWT obligatorias no estan definidas.
+    /// Returns an error if the required JWT keys are not defined.
     pub fn from_env() -> Result<Self, AuthConfigError> {
         let jwt_private_key_pem = std::env::var("JWT_PRIVATE_KEY")
             .map_err(|_| AuthConfigError::MissingVar("JWT_PRIVATE_KEY"))?;
@@ -51,10 +51,10 @@ impl AuthConfig {
     }
 }
 
-/// Error de configuracion de autenticacion.
+/// Authentication configuration error.
 #[derive(Debug)]
 pub enum AuthConfigError {
-    /// Variable de entorno obligatoria no definida.
+    /// Required environment variable not defined.
     MissingVar(&'static str),
 }
 
@@ -75,7 +75,7 @@ mod tests {
     use super::*;
     use std::sync::Mutex;
 
-    // Serializa el acceso a JWT_PRIVATE_KEY / JWT_PUBLIC_KEY entre tests paralelos.
+    // Serializes access to JWT_PRIVATE_KEY / JWT_PUBLIC_KEY across parallel tests.
     static ENV_LOCK: Mutex<()> = Mutex::new(());
 
     #[test]

--- a/crates/ag-auth/src/jwt.rs
+++ b/crates/ag-auth/src/jwt.rs
@@ -1,27 +1,27 @@
-//! Firma y verificacion de JSON Web Tokens con el algoritmo Ed25519 (EdDSA).
+//! Signing and verification of JSON Web Tokens with the Ed25519 (EdDSA) algorithm.
 //!
-//! Usa [`jsonwebtoken`] con claves en formato PEM PKCS#8. Las claves deben
-//! generarse fuera del crate (openssl, age, etc.) y pasarse via `AuthConfig`.
+//! Uses [`jsonwebtoken`] with keys in PEM PKCS#8 format. The keys must be
+//! generated outside the crate (openssl, age, etc.) and passed via `AuthConfig`.
 
 use jsonwebtoken::{Algorithm, DecodingKey, EncodingKey, Header, Validation};
 use serde::{Deserialize, Serialize};
 
-/// Claims estandar de un JWT emitido por Anti-Gravital.
+/// Standard claims of a JWT issued by Anti-Gravital.
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
 pub struct Claims {
-    /// Sujeto del token (normalmente el UUID del usuario).
+    /// Subject of the token (usually the user's UUID).
     pub sub: String,
-    /// Timestamp de expiracion (segundos desde Unix epoch).
+    /// Expiration timestamp (seconds since Unix epoch).
     pub exp: u64,
-    /// Timestamp de emision (segundos desde Unix epoch).
+    /// Issued-at timestamp (seconds since Unix epoch).
     pub iat: u64,
-    /// Identificador unico del token. Permite revocacion por JTI.
+    /// Unique identifier of the token. Allows revocation by JTI.
     pub jti: String,
-    /// Rol del usuario en el momento de la emision.
+    /// User role at the moment of issuance.
     pub role: String,
 }
 
-/// Firmador y verificador de JWTs Ed25519.
+/// Ed25519 JWT signer and verifier.
 #[derive(Clone)]
 pub struct JwtSigner {
     private_key_pem: String,
@@ -29,10 +29,10 @@ pub struct JwtSigner {
 }
 
 impl JwtSigner {
-    /// Crea un nuevo `JwtSigner` a partir de claves PEM.
+    /// Creates a new `JwtSigner` from PEM keys.
     ///
-    /// Las claves deben estar en formato PKCS#8 Ed25519.
-    /// La validacion de formato ocurre en [`JwtSigner::sign`] y [`JwtSigner::verify`], no aqui.
+    /// The keys must be in PKCS#8 Ed25519 format.
+    /// Format validation occurs in [`JwtSigner::sign`] and [`JwtSigner::verify`], not here.
     pub fn new(private_key_pem: String, public_key_pem: String) -> Self {
         Self {
             private_key_pem,
@@ -40,12 +40,12 @@ impl JwtSigner {
         }
     }
 
-    /// Firma un conjunto de claims y retorna el JWT compacto.
+    /// Signs a set of claims and returns the compact JWT.
     ///
     /// # Errors
     ///
-    /// Retorna [`JwtError::Signing`] si la clave privada es invalida o la
-    /// firma falla.
+    /// Returns [`JwtError::Signing`] if the private key is invalid or
+    /// signing fails.
     pub fn sign(&self, claims: &Claims) -> Result<String, JwtError> {
         let key = EncodingKey::from_ed_pem(self.private_key_pem.as_bytes())
             .map_err(|e| JwtError::Signing(e.to_string()))?;
@@ -53,19 +53,19 @@ impl JwtSigner {
         jsonwebtoken::encode(&header, claims, &key).map_err(|e| JwtError::Signing(e.to_string()))
     }
 
-    /// Verifica un JWT y retorna los claims si la firma y expiracion son validos.
+    /// Verifies a JWT and returns the claims if the signature and expiration are valid.
     ///
-    /// Emite un warning de tracing cuando la verificacion falla, incluyendo el motivo.
+    /// Emits a tracing warning when verification fails, including the reason.
     ///
     /// # Errors
     ///
-    /// - [`JwtError::Verification`] si la firma es invalida o el token esta expirado.
-    /// - [`JwtError::InvalidToken`] si el formato del token es incorrecto.
+    /// - [`JwtError::Verification`] if the signature is invalid or the token is expired.
+    /// - [`JwtError::InvalidToken`] if the token format is incorrect.
     pub fn verify(&self, token: &str) -> Result<Claims, JwtError> {
         let key = DecodingKey::from_ed_pem(self.public_key_pem.as_bytes())
             .map_err(|e| JwtError::Verification(e.to_string()))?;
         let mut validation = Validation::new(Algorithm::EdDSA);
-        // No validar `aud` por defecto; ag-auth no emite audiencia en los tokens.
+        // Do not validate `aud` by default; ag-auth does not emit an audience in tokens.
         validation.validate_aud = false;
         jsonwebtoken::decode::<Claims>(token, &key, &validation)
             .map(|data| data.claims)
@@ -79,16 +79,16 @@ impl JwtSigner {
     }
 }
 
-/// Errores del modulo JWT.
+/// Errors of the JWT module.
 #[derive(Debug, thiserror::Error)]
 pub enum JwtError {
-    /// Error al firmar: clave invalida o fallo interno.
+    /// Signing error: invalid key or internal failure.
     #[error("error de firma JWT: {0}")]
     Signing(String),
-    /// Token con firma incorrecta, expirado u otro problema de verificacion.
+    /// Token with an incorrect signature, expired, or another verification problem.
     #[error("verificacion JWT fallida: {0}")]
     Verification(String),
-    /// Formato del token incorrecto (no es JWT valido).
+    /// Incorrect token format (not a valid JWT).
     #[error("formato de token JWT invalido")]
     InvalidToken,
 }

--- a/crates/ag-auth/src/lib.rs
+++ b/crates/ag-auth/src/lib.rs
@@ -1,9 +1,9 @@
-//! Autenticacion y autorizacion para el ecosistema Anti-Gravital.
+//! Authentication and authorization for the Anti-Gravital ecosystem.
 //!
-//! Soporta JWT Ed25519, Passkeys/WebAuthn, OAuth2 (Google, GitHub),
-//! API keys con hash BLAKE3 y refresh tokens con rotacion.
+//! Supports JWT Ed25519, Passkeys/WebAuthn, OAuth2 (Google, GitHub),
+//! API keys with BLAKE3 hashing and refresh tokens with rotation.
 //!
-//! # Uso minimo (JWT + API keys)
+//! # Minimal usage (JWT + API keys)
 //!
 //! ```no_run
 //! use ag_auth::{AgAuth, AuthConfig};
@@ -41,28 +41,28 @@ pub use webauthn::{
     StoredCredential, WebAuthnError, WebAuthnRp,
 };
 
-/// Fachada principal del modulo de autenticacion.
+/// Main facade of the authentication module.
 pub struct AgAuth {
-    /// Firmador/verificador de JWTs.
+    /// JWT signer/verifier.
     pub jwt: JwtSigner,
-    /// Relying Party WebAuthn. None si `webauthn_rp_id` esta vacio.
+    /// WebAuthn Relying Party. None if `webauthn_rp_id` is empty.
     pub webauthn: Option<webauthn::WebAuthnRp>,
-    /// Cliente OAuth2. None si ningun proveedor esta configurado.
+    /// OAuth2 client. None if no provider is configured.
     pub oauth: Option<oauth::OAuthClient>,
-    /// Blacklist de refresh tokens.
+    /// Refresh token blacklist.
     pub refresh_blacklist: std::sync::Arc<refresh::RefreshBlacklist>,
-    /// Mailer para verificacion, recuperacion y magic links. Requiere feature `mail`.
+    /// Mailer for verification, recovery and magic links. Requires feature `mail`.
     #[cfg(feature = "mail")]
     pub mailer: Option<std::sync::Arc<mailer::AuthMailer>>,
 }
 
 impl AgAuth {
-    /// Crea una nueva instancia de `AgAuth`.
+    /// Creates a new `AgAuth` instance.
     ///
-    /// - `webauthn` se inicializa si `config.webauthn_rp_id` no esta vacio.
-    /// - `oauth` se inicializa si al menos un proveedor tiene client_id configurado.
-    /// - `http_client` se usa internamente para OAuth2 — el llamador lo provee
-    ///   para permitir configuracion de timeouts, proxies y TLS personalizado.
+    /// - `webauthn` is initialized if `config.webauthn_rp_id` is not empty.
+    /// - `oauth` is initialized if at least one provider has a client_id configured.
+    /// - `http_client` is used internally for OAuth2 — the caller provides it
+    ///   to allow configuration of timeouts, proxies and custom TLS.
     pub fn new(config: AuthConfig, http_client: reqwest::Client) -> Result<Self, AuthConfigError> {
         let jwt = JwtSigner::new(
             config.jwt_private_key_pem.clone(),
@@ -96,24 +96,24 @@ impl AgAuth {
         })
     }
 
-    /// Inyecta un `AuthMailer` en la instancia.
+    /// Injects an `AuthMailer` into the instance.
     ///
-    /// Disponible solo con la feature `mail`. Devuelve `self` para
-    /// permitir encadenamiento: `AgAuth::new(...)?.with_mail(mailer)`.
+    /// Available only with the `mail` feature. Returns `self` to
+    /// allow chaining: `AgAuth::new(...)?.with_mail(mailer)`.
     #[cfg(feature = "mail")]
     pub fn with_mail(mut self, mailer: std::sync::Arc<mailer::AuthMailer>) -> Self {
         self.mailer = Some(mailer);
         self
     }
 
-    /// Genera una nueva API key y su hash BLAKE3.
+    /// Generates a new API key and its BLAKE3 hash.
     ///
-    /// Solo el hash debe almacenarse. La raw key se entrega al usuario una unica vez.
+    /// Only the hash should be stored. The raw key is given to the user only once.
     pub fn create_api_key(&self, prefix: &str) -> (String, String) {
         api_keys::generate(prefix)
     }
 
-    /// Verifica una API key contra su hash almacenado.
+    /// Verifies an API key against its stored hash.
     pub fn verify_api_key(&self, raw_key: &str, stored_hash: &str) -> bool {
         api_keys::verify(raw_key, stored_hash)
     }

--- a/crates/ag-cache/src/config.rs
+++ b/crates/ag-cache/src/config.rs
@@ -1,16 +1,16 @@
-//! Configuracion del cache multinivel.
+//! Multilevel cache configuration.
 
-/// Configuracion del cache L1 (moka, en memoria) y L2 (Redis, opcional).
+/// Configuration for the L1 cache (moka, in memory) and L2 (Redis, optional).
 #[derive(Debug, Clone)]
 pub struct CacheConfig {
-    /// Numero maximo de entradas en L1. Default: 10_000.
+    /// Maximum number of entries in L1. Default: 10_000.
     pub l1_max_capacity: u64,
-    /// TTL por defecto para entradas L1 en segundos. Default: 300.
+    /// Default TTL for L1 entries in seconds. Default: 300.
     pub l1_ttl_secs: u64,
-    /// URL de conexion Redis para L2. None desactiva L2.
-    /// Variable de entorno: REDIS_URL
+    /// Redis connection URL for L2. None disables L2.
+    /// Environment variable: REDIS_URL
     pub redis_url: Option<String>,
-    /// Numero de conexiones en el pool Redis. Default: 10.
+    /// Number of connections in the Redis pool. Default: 10.
     pub redis_pool_size: u32,
 }
 
@@ -26,7 +26,7 @@ impl Default for CacheConfig {
 }
 
 impl CacheConfig {
-    /// Lee la configuracion desde variables de entorno.
+    /// Reads the configuration from environment variables.
     pub fn from_env() -> Self {
         Self {
             l1_max_capacity: std::env::var("CACHE_L1_MAX_CAPACITY")
@@ -61,7 +61,7 @@ mod tests {
 
     #[test]
     fn cache_config_l2_disabled_when_no_redis_url() {
-        // sin REDIS_URL en el entorno, redis_url es None
+        // without REDIS_URL in the environment, redis_url is None
         std::env::remove_var("REDIS_URL");
         let cfg = CacheConfig::from_env();
         assert!(cfg.redis_url.is_none());

--- a/crates/ag-cache/src/l1.rs
+++ b/crates/ag-cache/src/l1.rs
@@ -1,4 +1,4 @@
-//! Cache L1: moka en memoria con soporte de tags e invalidacion por grupo.
+//! L1 cache: in-memory moka with tag support and group invalidation.
 
 use crate::tags::TagIndex;
 use moka::future::Cache;
@@ -6,14 +6,14 @@ use std::sync::Arc;
 use std::time::Duration;
 use tokio::sync::Mutex;
 
-/// Cache L1 basado en moka con TinyLFU y soporte de tags.
+/// L1 cache based on moka with TinyLFU and tag support.
 pub struct L1Cache {
     inner: Cache<String, Vec<u8>>,
     tags: Arc<Mutex<TagIndex>>,
 }
 
 impl L1Cache {
-    /// Crea un nuevo [`L1Cache`] con la capacidad y TTL indicados.
+    /// Creates a new [`L1Cache`] with the given capacity and TTL.
     pub fn new(max_capacity: u64, default_ttl: Duration) -> Self {
         let inner = Cache::builder()
             .max_capacity(max_capacity)
@@ -25,29 +25,29 @@ impl L1Cache {
         }
     }
 
-    /// Obtiene los bytes crudos asociados a `key`.
+    /// Gets the raw bytes associated with `key`.
     pub async fn get_bytes(&self, key: &str) -> Option<Vec<u8>> {
         self.inner.get(key).await
     }
 
-    /// Almacena `value` bajo `key` con el TTL por defecto del cache.
+    /// Stores `value` under `key` with the cache's default TTL.
     pub async fn set_bytes(&self, key: &str, value: Vec<u8>) {
         self.inner.insert(key.to_string(), value).await;
     }
 
-    /// Almacena `value` bajo `key` y registra los `tags` para invalidacion.
+    /// Stores `value` under `key` and registers the `tags` for invalidation.
     pub async fn set_bytes_tagged(&self, key: &str, value: Vec<u8>, tags: &[&str]) {
         self.inner.insert(key.to_string(), value).await;
         self.tags.lock().await.insert(key, tags);
     }
 
-    /// Elimina la entrada con `key`.
+    /// Removes the entry with `key`.
     pub async fn delete(&self, key: &str) {
         self.inner.remove(key).await;
         self.tags.lock().await.remove(key);
     }
 
-    /// Invalida todas las entradas asociadas al `tag` dado.
+    /// Invalidates all entries associated with the given `tag`.
     pub async fn invalidate_tag(&self, tag: &str) {
         let keys = self.tags.lock().await.keys_for_tag(tag);
         for key in &keys {
@@ -118,9 +118,9 @@ mod tests {
         cache.invalidate_tag("nonexistent_tag").await;
     }
 
-    /// Throughput basico: 1_000_000 operaciones en menos de 1 segundo.
-    /// Marcado `#[ignore]` para no bloquear CI en hardware lento; ejecutar
-    /// manualmente con `cargo test -p ag-cache -- --ignored l1_ops_per_second`.
+    /// Basic throughput: 1_000_000 operations in under 1 second.
+    /// Marked `#[ignore]` to avoid blocking CI on slow hardware; run
+    /// manually with `cargo test -p ag-cache -- --ignored l1_ops_per_second`.
     #[tokio::test]
     #[ignore]
     async fn l1_ops_per_second_exceeds_1m() {

--- a/crates/ag-cache/src/lib.rs
+++ b/crates/ag-cache/src/lib.rs
@@ -1,16 +1,16 @@
-//! Cache multinivel para el ecosistema Anti-Gravital.
+//! Multilevel cache for the Anti-Gravital ecosystem.
 //!
-//! Ofrece dos niveles transparentes:
-//! - **L1**: moka en memoria (TinyLFU, sin locks contenciosos, siempre disponible).
-//! - **L2**: Redis via fred (opcional, para cache distribuida entre instancias).
+//! Offers two transparent levels:
+//! - **L1**: moka in memory (TinyLFU, no contended locks, always available).
+//! - **L2**: Redis via fred (optional, for distributed cache across instances).
 //!
-//! # Estado
+//! # Status
 //!
-//! L1 completamente operativo. L2 (Redis/fred) queda pendiente como TECH-DEBT
-//! para la segunda iteracion de ag-cache en Fase 4 — la API de fred v10
-//! requiere ajuste de features y configuracion de conexion en CI.
+//! L1 fully operational. L2 (Redis/fred) remains pending as TECH-DEBT
+//! for the second iteration of ag-cache in Phase 4 — the fred v10 API
+//! requires feature adjustments and connection configuration in CI.
 //!
-//! # Uso minimo (solo L1)
+//! # Minimal usage (L1 only)
 //!
 //! ```no_run
 //! use ag_cache::{AgCache, CacheConfig};
@@ -32,10 +32,10 @@ pub use config::CacheConfig;
 use l1::L1Cache;
 use std::time::Duration;
 
-/// Error del subsistema de cache.
+/// Error from the cache subsystem.
 #[derive(Debug)]
 pub enum CacheError {
-    /// Error de conexion o comunicacion con Redis.
+    /// Connection or communication error with Redis.
     Redis(String),
 }
 
@@ -49,25 +49,25 @@ impl std::fmt::Display for CacheError {
 
 impl std::error::Error for CacheError {}
 
-/// Cache multinivel con L1 (moka) y L2 opcional (Redis).
+/// Multilevel cache with L1 (moka) and optional L2 (Redis).
 ///
-/// Construir con [`AgCache::new`] pasando una [`CacheConfig`]. Si
-/// `config.redis_url` es `None`, solo L1 esta activo.
+/// Build with [`AgCache::new`] passing a [`CacheConfig`]. If
+/// `config.redis_url` is `None`, only L1 is active.
 pub struct AgCache {
     l1: L1Cache,
     // TECH-DEBT:
-    // motivo: L2 Redis requiere fred con conexion real; la API de fred v10
-    //         no expone las features documentadas (tokio-runtime, codec).
-    //         Se integra en la segunda iteracion de ag-cache en Fase 4.
-    // impacto: sin L2, la invalidacion distribuida entre instancias no funciona.
-    // eliminacion esperada: segunda iteracion ag-cache, Fase 4.
+    // reason: L2 Redis requires fred with a real connection; the fred v10 API
+    //         does not expose the documented features (tokio-runtime, codec).
+    //         Integrated in the second iteration of ag-cache in Phase 4.
+    // impact: without L2, distributed invalidation across instances does not work.
+    // expected removal: second iteration of ag-cache, Phase 4.
 }
 
 impl AgCache {
-    /// Crea un nuevo [`AgCache`] con la configuracion dada.
+    /// Creates a new [`AgCache`] with the given configuration.
     ///
-    /// Si `config.redis_url` es `Some`, emite un aviso en tracing pero L2
-    /// no se activa hasta que este implementado (ver TECH-DEBT en el codigo).
+    /// If `config.redis_url` is `Some`, emits a warning via tracing but L2
+    /// is not activated until it is implemented (see TECH-DEBT in the code).
     pub async fn new(config: CacheConfig) -> Result<Self, CacheError> {
         let ttl = Duration::from_secs(config.l1_ttl_secs);
         let l1 = L1Cache::new(config.l1_max_capacity, ttl);
@@ -81,10 +81,10 @@ impl AgCache {
         Ok(Self { l1 })
     }
 
-    /// Obtiene bytes crudos desde el cache.
+    /// Gets raw bytes from the cache.
     ///
-    /// Busca primero en L1. Si hay un hit, registra `cache hit L1` en tracing.
-    /// Si no hay resultado, registra `cache miss`.
+    /// Looks up L1 first. On a hit, logs `cache hit L1` via tracing.
+    /// If there is no result, logs `cache miss`.
     pub async fn get(&self, key: &str) -> Option<Vec<u8>> {
         let result = self.l1.get_bytes(key).await;
         if result.is_some() {
@@ -95,9 +95,9 @@ impl AgCache {
         result
     }
 
-    /// Almacena bytes en el cache con tags opcionales para invalidacion.
+    /// Stores bytes in the cache with optional tags for invalidation.
     ///
-    /// Escribe en L1. Si `tags` esta vacio, no registra tags.
+    /// Writes to L1. If `tags` is empty, no tags are registered.
     pub async fn set(&self, key: &str, value: Vec<u8>, tags: &[&str]) {
         if tags.is_empty() {
             self.l1.set_bytes(key, value).await;
@@ -106,12 +106,12 @@ impl AgCache {
         }
     }
 
-    /// Invalida todas las entradas asociadas al tag dado en L1.
+    /// Invalidates all entries associated with the given tag in L1.
     pub async fn invalidate_tag(&self, tag: &str) {
         self.l1.invalidate_tag(tag).await;
     }
 
-    /// Elimina la entrada con la clave dada.
+    /// Removes the entry with the given key.
     pub async fn delete(&self, key: &str) {
         self.l1.delete(key).await;
     }

--- a/crates/ag-cache/src/tags.rs
+++ b/crates/ag-cache/src/tags.rs
@@ -1,15 +1,15 @@
-//! Indice de tags para invalidacion agrupada de entradas de cache.
+//! Tag index for grouped invalidation of cache entries.
 
 use std::collections::{HashMap, HashSet};
 
-/// Mapea tags a conjuntos de keys para invalidacion por grupo.
+/// Maps tags to sets of keys for group invalidation.
 #[derive(Default)]
 pub struct TagIndex {
     tag_to_keys: HashMap<String, HashSet<String>>,
 }
 
 impl TagIndex {
-    /// Registra que `key` pertenece a los `tags` dados.
+    /// Registers that `key` belongs to the given `tags`.
     pub fn insert(&mut self, key: &str, tags: &[&str]) {
         for tag in tags {
             self.tag_to_keys
@@ -19,14 +19,14 @@ impl TagIndex {
         }
     }
 
-    /// Elimina `key` de todos los tags donde aparezca.
+    /// Removes `key` from all tags where it appears.
     pub fn remove(&mut self, key: &str) {
         for keys in self.tag_to_keys.values_mut() {
             keys.remove(key);
         }
     }
 
-    /// Retorna todos los keys asociados a `tag`.
+    /// Returns all keys associated with `tag`.
     pub fn keys_for_tag(&self, tag: &str) -> Vec<String> {
         self.tag_to_keys
             .get(tag)

--- a/crates/ag-cli/src/main.rs
+++ b/crates/ag-cli/src/main.rs
@@ -1,17 +1,17 @@
-//! Binario unificado `ag` del ecosistema Anti-Gravital.
+//! Unified `ag` binary of the Anti-Gravital ecosystem.
 //!
-//! Comandos de Fase 2:
-//! - `ag new <nombre> [--template rest|realtime|fullstack]`
+//! Phase 2 commands:
+//! - `ag new <name> [--template rest|realtime|fullstack]`
 //! - `ag dev [--bind host:port]`
 //! - `ag build [--target triple]`
 //!
-//! Comandos de Fase 3 (DSL):
+//! Phase 3 commands (DSL):
 //! - `ag generate [--schema schema.ag] [--output ./generated]`
 //! - `ag schema lint [--schema schema.ag]`
 //! - `ag schema diff <ref> [--schema schema.ag]`
 //!
-//! Comandos de Fase 4.5 (correo y dominios):
-//! - `ag domains check --domain ejemplo.com [--expected valor] [--min-confirmed N]`
+//! Phase 4.5 commands (mail and domains):
+//! - `ag domains check --domain example.com [--expected value] [--min-confirmed N]`
 //! - `ag domains sync --schema schema.ag --zone-id ZONE --token TOKEN`
 //! - `ag mail test --to dest@email.com [--from from@email.com] [--smtp-host ...]`
 
@@ -22,8 +22,8 @@ use std::process;
 
 const VERSION: &str = env!("CARGO_PKG_VERSION");
 
-// Templates embebidos en el binario al compilar. Las rutas son relativas
-// al directorio raiz del workspace (crates/ag-cli/src/../../../templates/).
+// Templates embedded in the binary at compile time. The paths are relative
+// to the workspace root directory (crates/ag-cli/src/../../../templates/).
 
 const REST_CARGO_TOML: &str = include_str!("../../../templates/rest/Cargo.toml.tmpl");
 const REST_MAIN_RS: &str = include_str!("../../../templates/rest/src/main.rs.tmpl");
@@ -53,154 +53,154 @@ struct Cli {
 
 #[derive(Subcommand)]
 enum Commands {
-    /// Crea un nuevo proyecto Anti-Gravital.
+    /// Creates a new Anti-Gravital project.
     ///
-    /// Genera la estructura de archivos a partir del template elegido
-    /// y sustituye el nombre del proyecto en todos los archivos.
+    /// Generates the file structure from the chosen template
+    /// and substitutes the project name across all files.
     New {
-        /// Nombre del nuevo proyecto (también se usa como nombre de directorio).
+        /// Name of the new project (also used as the directory name).
         name: String,
 
-        /// Template de partida.
+        /// Starting template.
         #[arg(long, short = 't', default_value = "rest",
               value_parser = ["rest", "realtime", "fullstack"])]
         template: String,
     },
 
-    /// Arranca el servidor en modo desarrollo con hot reload.
+    /// Starts the server in development mode with hot reload.
     ///
-    /// Requiere `cargo-watch` instalado (`cargo install cargo-watch`).
-    /// Si no esta disponible, ejecuta `cargo run` sin recarga automatica.
+    /// Requires `cargo-watch` to be installed (`cargo install cargo-watch`).
+    /// If it is not available, runs `cargo run` without automatic reloading.
     Dev {
-        /// Direccion de escucha del servidor.
+        /// Server listen address.
         #[arg(long, default_value = "0.0.0.0:8080")]
         bind: String,
     },
 
-    /// Compila el proyecto en modo release.
+    /// Compiles the project in release mode.
     Build {
-        /// Triple de compilacion cruzada (ej: `x86_64-unknown-linux-musl`).
+        /// Cross-compilation triple (e.g.: `x86_64-unknown-linux-musl`).
         #[arg(long)]
         target: Option<String>,
     },
 
-    /// Genera artefactos (Rust, SQL, TypeScript, OpenAPI) desde schema.ag.
+    /// Generates artifacts (Rust, SQL, TypeScript, OpenAPI) from schema.ag.
     ///
-    /// Lee el archivo DSL indicado (por defecto `schema.ag` en el directorio
-    /// actual), compila el schema y escribe los artefactos generados en el
-    /// directorio de salida.
+    /// Reads the given DSL file (by default `schema.ag` in the current
+    /// directory), compiles the schema and writes the generated artifacts to
+    /// the output directory.
     Generate {
-        /// Archivo schema DSL de entrada.
+        /// Input DSL schema file.
         #[arg(long, default_value = "schema.ag")]
         schema: PathBuf,
 
-        /// Directorio donde se escriben los artefactos generados.
+        /// Directory where the generated artifacts are written.
         #[arg(long, default_value = "generated")]
         output: PathBuf,
     },
 
-    /// Operaciones sobre el schema DSL.
+    /// Operations on the DSL schema.
     Schema {
         #[command(subcommand)]
         command: SchemaCommands,
     },
 
-    /// Operaciones sobre dominios DNS.
+    /// Operations on DNS domains.
     Domains {
         #[command(subcommand)]
         command: DomainsCommands,
     },
 
-    /// Operaciones sobre correo transaccional.
+    /// Operations on transactional mail.
     Mail {
         #[command(subcommand)]
         command: MailCommands,
     },
 }
 
-/// Sub-comandos de `ag schema`.
+/// Sub-commands of `ag schema`.
 #[derive(Subcommand)]
 enum SchemaCommands {
-    /// Verifica el schema y reporta warnings de mejores practicas.
+    /// Verifies the schema and reports best-practice warnings.
     Lint {
-        /// Archivo schema DSL.
+        /// DSL schema file.
         #[arg(long, default_value = "schema.ag")]
         schema: PathBuf,
     },
-    /// Muestra cambios breaking vs no-breaking respecto a un archivo de referencia.
+    /// Shows breaking vs non-breaking changes against a reference file.
     Diff {
-        /// Archivo de referencia (otro schema.ag, snapshot, etc.).
+        /// Reference file (another schema.ag, snapshot, etc.).
         reference: PathBuf,
-        /// Archivo schema actual.
+        /// Current schema file.
         #[arg(long, default_value = "schema.ag")]
         schema: PathBuf,
     },
 }
 
-/// Sub-comandos de `ag domains`.
+/// Sub-commands of `ag domains`.
 #[derive(Subcommand)]
 enum DomainsCommands {
-    /// Verifica la propagacion de un registro TXT en los resolvers publicos.
+    /// Verifies the propagation of a TXT record across public resolvers.
     ///
-    /// No requiere credenciales DNS. Util para verificar que los registros
-    /// SPF/DKIM/DMARC son visibles desde Internet antes de habilitar DMARC.
+    /// Does not require DNS credentials. Useful for verifying that the
+    /// SPF/DKIM/DMARC records are visible from the Internet before enabling DMARC.
     ///
-    /// Lee la variable de entorno AG_CLOUDFLARE_TOKEN si se usa --sync.
+    /// Reads the AG_CLOUDFLARE_TOKEN environment variable if --sync is used.
     Check {
-        /// Dominio a verificar (e.g., ejemplo.com).
+        /// Domain to verify (e.g., example.com).
         #[arg(long)]
         domain: String,
-        /// Valor TXT esperado (si se omite, solo muestra los registros actuales).
+        /// Expected TXT value (if omitted, only shows the current records).
         #[arg(long)]
         expected: Option<String>,
-        /// Numero minimo de resolvers que deben confirmar (por defecto 2).
+        /// Minimum number of resolvers that must confirm (default 2).
         #[arg(long, default_value = "2")]
         min_confirmed: usize,
     },
-    /// Aplica los registros SPF/DKIM/DMARC via el proveedor DNS.
+    /// Applies the SPF/DKIM/DMARC records via the DNS provider.
     ///
-    /// Lee la configuracion desde el schema.ag del proyecto y aplica los
-    /// registros con upsert idempotente. Requiere AG_CLOUDFLARE_TOKEN.
+    /// Reads the configuration from the project's schema.ag and applies the
+    /// records with an idempotent upsert. Requires AG_CLOUDFLARE_TOKEN.
     Sync {
-        /// Archivo schema DSL.
+        /// DSL schema file.
         #[arg(long, default_value = "schema.ag")]
         schema: PathBuf,
-        /// Zone ID del dominio en el proveedor DNS.
+        /// Zone ID of the domain in the DNS provider.
         #[arg(long, env = "AG_DNS_ZONE_ID")]
         zone_id: String,
-        /// Token del proveedor DNS (por defecto lee AG_CLOUDFLARE_TOKEN).
+        /// DNS provider token (defaults to reading AG_CLOUDFLARE_TOKEN).
         #[arg(long, env = "AG_CLOUDFLARE_TOKEN")]
         token: String,
     },
 }
 
-/// Sub-comandos de `ag mail`.
+/// Sub-commands of `ag mail`.
 #[derive(Subcommand)]
 enum MailCommands {
-    /// Envia un correo de prueba para verificar la configuracion SMTP.
+    /// Sends a test email to verify the SMTP configuration.
     ///
-    /// Lee la configuracion desde variables de entorno:
+    /// Reads the configuration from environment variables:
     /// AG_SMTP_HOST, AG_SMTP_PORT, AG_SMTP_USER, AG_SMTP_PASS.
     Test {
-        /// Destinatario del correo de prueba.
+        /// Recipient of the test email.
         #[arg(long)]
         to: String,
-        /// Remitente.
+        /// Sender.
         #[arg(long, env = "AG_MAIL_FROM", default_value = "test@localhost")]
         from: String,
-        /// Asunto del correo de prueba.
+        /// Subject of the test email.
         #[arg(long, default_value = "ag mail test — Anti-Gravital")]
         subject: String,
-        /// Host SMTP.
+        /// SMTP host.
         #[arg(long, env = "AG_SMTP_HOST", default_value = "localhost")]
         smtp_host: String,
-        /// Puerto SMTP.
+        /// SMTP port.
         #[arg(long, env = "AG_SMTP_PORT", default_value = "587")]
         smtp_port: u16,
-        /// Usuario SMTP (opcional).
+        /// SMTP user (optional).
         #[arg(long, env = "AG_SMTP_USER")]
         smtp_user: Option<String>,
-        /// Contrasena SMTP (opcional).
+        /// SMTP password (optional).
         #[arg(long, env = "AG_SMTP_PASS")]
         smtp_pass: Option<String>,
     },
@@ -425,7 +425,7 @@ fn scaffold_fullstack(name: &str, dir: &Path) -> Result<(), String> {
     Ok(())
 }
 
-// ---- Comandos DSL (Fase 3) ------------------------------------------
+// ---- DSL commands (Phase 3) -----------------------------------------
 
 fn cmd_generate(schema_path: &Path, output_dir: &Path) -> Result<(), String> {
     let source = read_schema(schema_path)?;
@@ -539,11 +539,11 @@ fn cmd_schema_diff(schema_path: &Path, reference_path: &Path) -> Result<(), Stri
     Ok(())
 }
 
-/// Compara dos schemas y retorna una lista de cambios legibles.
+/// Compares two schemas and returns a list of readable changes.
 ///
-/// Detecta: modelos añadidos/eliminados, campos añadidos/eliminados/cambiados.
-/// Los cambios breaking (eliminar modelo, eliminar campo, cambiar tipo) se marcan
-/// con `[BREAKING]`. Los cambios no-breaking se marcan con `[additive]`.
+/// Detects: added/removed models, added/removed/changed fields.
+/// Breaking changes (removing a model, removing a field, changing a type) are
+/// marked with `[BREAKING]`. Non-breaking changes are marked with `[additive]`.
 fn diff_schemas(old: &ag_dsl::ast::Schema, new: &ag_dsl::ast::Schema) -> Vec<String> {
     use std::collections::HashMap;
 
@@ -560,21 +560,21 @@ fn diff_schemas(old: &ag_dsl::ast::Schema, new: &ag_dsl::ast::Schema) -> Vec<Str
 
     let mut changes = Vec::new();
 
-    // Modelos eliminados (breaking)
+    // Removed models (breaking)
     for name in old_models.keys() {
         if !new_models.contains_key(name) {
             changes.push(format!("[BREAKING]  modelo '{name}' eliminado"));
         }
     }
 
-    // Modelos añadidos (no breaking)
+    // Added models (non-breaking)
     for name in new_models.keys() {
         if !old_models.contains_key(name) {
             changes.push(format!("[additive]  modelo '{name}' añadido"));
         }
     }
 
-    // Campos en modelos comunes
+    // Fields in common models
     for (name, old_model) in &old_models {
         if let Some(new_model) = new_models.get(name) {
             let old_fields: HashMap<&str, _> = old_model
@@ -635,7 +635,7 @@ fn read_schema(path: &Path) -> Result<String, String> {
 }
 
 // ============================================================
-// Comandos ag domains (Fase 4.5)
+// ag domains commands (Phase 4.5)
 // ============================================================
 
 async fn cmd_domains_check(
@@ -666,7 +666,7 @@ async fn cmd_domains_check(
             }
         }
         None => {
-            // Sin valor esperado: verifica que al menos un resolver responde.
+            // No expected value: verifies that at least one resolver responds.
             let result = checker.check_txt(domain, "").await;
             println!(
                 "Consulta completada — {}/{} resolvers respondieron",

--- a/crates/ag-cloud/src/lib.rs
+++ b/crates/ag-cloud/src/lib.rs
@@ -1,5 +1,5 @@
-//! Subsistema de despliegue simplificado: docker-compose, Fly.io, Railway y Kubernetes.
+//! Simplified deployment subsystem: docker-compose, Fly.io, Railway and Kubernetes.
 //!
-//! Estado: Fase 0 (Fundaciones y Gobernanza). Este crate aun no contiene
-//! codigo funcional. La implementacion se entrega en la fase declarada
-//! en el README del crate y en la Hoja de Ruta del proyecto.
+//! Status: Phase 0 (Foundations and Governance). This crate does not yet
+//! contain functional code. The implementation is delivered in the phase
+//! declared in the crate's README and in the project's Roadmap.

--- a/crates/ag-core/src/config/mod.rs
+++ b/crates/ag-core/src/config/mod.rs
@@ -1,12 +1,12 @@
-//! Configuracion publica del Shield.
+//! Public Shield configuration.
 //!
-//! La configuracion se deserializa desde un archivo TOML descrito en
-//! `docs/rfc/RFC-0002-diseno-shield-mvp.md` seccion 4.5. Todas las
-//! secciones aceptan defaults seguros: omitir una seccion en TOML es
-//! equivalente a usar `Default`. Las claves desconocidas se rechazan
-//! con `AgError::Config` para evitar typos silenciosos.
+//! The configuration is deserialized from a TOML file described in
+//! `docs/rfc/RFC-0002-diseno-shield-mvp.md` section 4.5. All sections
+//! accept secure defaults: omitting a section in TOML is equivalent to
+//! using `Default`. Unknown keys are rejected with `AgError::Config` to
+//! avoid silent typos.
 //!
-//! Un ejemplo documentado con todas las secciones esta en
+//! A documented example with all the sections is in
 //! `crates/ag-core/config.example.toml`.
 
 use std::net::SocketAddr;
@@ -16,35 +16,35 @@ use serde::{Deserialize, Serialize};
 
 use crate::error::{AgError, AgResult};
 
-/// Configuracion completa del Shield.
+/// Complete Shield configuration.
 #[derive(Debug, Clone, Serialize, Deserialize)]
 #[serde(deny_unknown_fields)]
 pub struct ShieldConfig {
-    /// Direccion de escucha.
+    /// Listen address.
     #[serde(default = "default_bind_addr")]
     pub bind: SocketAddr,
 
-    /// Configuracion del runtime Tokio.
+    /// Tokio runtime configuration.
     #[serde(default)]
     pub runtime: RuntimeConfig,
 
-    /// Configuracion CORS.
+    /// CORS configuration.
     #[serde(default)]
     pub cors: CorsConfig,
 
-    /// Configuracion CSRF.
+    /// CSRF configuration.
     #[serde(default)]
     pub csrf: CsrfConfig,
 
-    /// Configuracion de rate limiting por IP.
+    /// Per-IP rate limiting configuration.
     #[serde(default)]
     pub rate_limit: RateLimitConfig,
 
-    /// Configuracion de autenticacion JWT Ed25519.
+    /// Ed25519 JWT authentication configuration.
     #[serde(default)]
     pub auth: AuthConfig,
 
-    /// Configuracion TLS 1.3.
+    /// TLS 1.3 configuration.
     #[serde(default)]
     pub tls: TlsConfig,
 }

--- a/crates/ag-core/src/error.rs
+++ b/crates/ag-core/src/error.rs
@@ -1,9 +1,9 @@
-//! Sistema de errores del nucleo.
+//! Core error system.
 //!
-//! `AgError` enumera las clases de error que la pipeline Shield puede
-//! producir. Cada variante mapea a una respuesta HTTP estable con un
-//! codigo `snake_case` en el cuerpo JSON. La conversion a
-//! `axum::response::Response` es automatica via `IntoResponse`.
+//! `AgError` enumerates the error classes the Shield pipeline can
+//! produce. Each variant maps to a stable HTTP response with a
+//! `snake_case` code in the JSON body. The conversion to
+//! `axum::response::Response` is automatic via `IntoResponse`.
 
 use axum::http::StatusCode;
 use axum::response::{IntoResponse, Response};
@@ -11,67 +11,67 @@ use axum::Json;
 use serde::Serialize;
 use thiserror::Error;
 
-/// Resultado estandar del nucleo.
+/// Standard core result.
 pub type AgResult<T> = Result<T, AgError>;
 
-/// Errores producidos por el nucleo y por la pipeline Shield.
+/// Errors produced by the core and by the Shield pipeline.
 #[derive(Debug, Error)]
 pub enum AgError {
-    /// Error de carga o validacion de la configuracion.
+    /// Configuration load or validation error.
     #[error("config error: {0}")]
     Config(String),
 
-    /// Error de capa TLS.
+    /// TLS layer error.
     #[error("tls error: {0}")]
     Tls(String),
 
-    /// Error de autenticacion.
+    /// Authentication error.
     #[error("auth error: {0}")]
     Auth(String),
 
-    /// Limite de tasa excedido.
+    /// Rate limit exceeded.
     #[error("rate limit exceeded")]
     RateLimit,
 
-    /// Error de validacion de payload.
+    /// Payload validation error.
     #[error("validation error: {0}")]
     Validation(String),
 
-    /// Error de CORS.
+    /// CORS error.
     #[error("cors error: {0}")]
     Cors(String),
 
-    /// Error de CSRF.
+    /// CSRF error.
     #[error("csrf error: {0}")]
     Csrf(String),
 
-    /// Recurso no encontrado.
+    /// Resource not found.
     #[error("not found: {0}")]
     NotFound(String),
 
-    /// Solicitud incorrecta (parametros invalidos, semantica incorrecta).
+    /// Bad request (invalid parameters, incorrect semantics).
     #[error("bad request: {0}")]
     BadRequest(String),
 
-    /// Conflicto de estado (duplicado, restriccion de unicidad, etc.).
+    /// State conflict (duplicate, uniqueness constraint, etc.).
     #[error("conflict: {0}")]
     Conflict(String),
 
-    /// Error de capa de datos (base de datos, migraciones).
+    /// Data layer error (database, migrations).
     #[error("database error: {0}")]
     Database(String),
 
-    /// Error de I/O.
+    /// I/O error.
     #[error("io error: {0}")]
     Io(#[from] std::io::Error),
 
-    /// Cualquier otro error no clasificado.
+    /// Any other unclassified error.
     #[error("internal error: {0}")]
     Other(String),
 }
 
 impl AgError {
-    /// Codigo estable `snake_case` para serializacion publica.
+    /// Stable `snake_case` code for public serialization.
     #[must_use]
     pub fn code(&self) -> &'static str {
         match self {
@@ -91,7 +91,7 @@ impl AgError {
         }
     }
 
-    /// Codigo HTTP correspondiente a la variante.
+    /// HTTP code corresponding to the variant.
     #[must_use]
     pub fn status(&self) -> StatusCode {
         match self {

--- a/crates/ag-core/src/lib.rs
+++ b/crates/ag-core/src/lib.rs
@@ -1,37 +1,37 @@
-//! Nucleo de Anti-Gravital: runtime HTTP, pipeline Shield y extractores tipados.
+//! Anti-Gravital core: HTTP runtime, Shield pipeline and typed extractors.
 //!
-//! `ag-core` es la pieza obligatoria del ecosistema Anti-Gravital. Provee
-//! la pipeline de seguridad **Shield** sobre [Tower] mas la base del
-//! router **Core** sobre [Axum] + [Tokio]. Las dos capas conviven en un
-//! mismo proceso Rust, se comunican por llamada de funcion (sin IPC ni
-//! FFI) y se componen en una unica peticion HTTP de extremo a extremo.
+//! `ag-core` is the mandatory piece of the Anti-Gravital ecosystem. It
+//! provides the **Shield** security pipeline on top of [Tower] plus the
+//! base of the **Core** router on top of [Axum] + [Tokio]. The two layers
+//! coexist in a single Rust process, communicate by function call (no IPC
+//! or FFI) and compose into a single end-to-end HTTP request.
 //!
 //! [Tower]: https://docs.rs/tower
 //! [Axum]: https://docs.rs/axum
 //! [Tokio]: https://docs.rs/tokio
 //!
-//! # Pipeline Shield
+//! # Shield pipeline
 //!
-//! La pipeline se construye a partir de [`ShieldConfig`] y se aplica
-//! a cualquier [`axum::Router`] con [`Shield::apply`]. Cada capa se
-//! activa con su feature Cargo y con la seccion correspondiente del
-//! TOML de configuracion:
+//! The pipeline is built from [`ShieldConfig`] and is applied to any
+//! [`axum::Router`] with [`Shield::apply`]. Each layer is enabled with
+//! its Cargo feature and the corresponding section of the configuration
+//! TOML:
 //!
-//! | Capa            | Feature        | Seccion TOML       | Que aporta                                        |
+//! | Layer           | Feature        | TOML section       | What it provides                                  |
 //! | --- | --- | --- | --- |
-//! | Logging         | `logging`      | (siempre activa)   | Tracing estructurado, latencia por request.       |
-//! | Rate limit      | `rate-limit`   | `[rate_limit]`     | Token bucket por IP con `governor`.               |
-//! | CORS            | `cors`         | `[cors]`           | Defaults seguros sobre `tower-http`.              |
-//! | Auth JWT        | `auth-jwt`     | `[auth]`           | Verificacion `Authorization: Bearer` Ed25519.     |
-//! | CSRF            | `csrf`         | `[csrf]`           | Double-submit cookie apatrida.                    |
-//! | Validation      | `validation`   | (per-handler)      | Extractor [`ValidatedJson<T>`].                   |
-//! | TLS 1.3         | `tls`          | `[tls]`            | Terminacion con `rustls` via [`Shield::serve`].   |
+//! | Logging         | `logging`      | (always active)    | Structured tracing, per-request latency.          |
+//! | Rate limit      | `rate-limit`   | `[rate_limit]`     | Per-IP token bucket with `governor`.              |
+//! | CORS            | `cors`         | `[cors]`           | Secure defaults on top of `tower-http`.           |
+//! | Auth JWT        | `auth-jwt`     | `[auth]`           | Ed25519 `Authorization: Bearer` verification.     |
+//! | CSRF            | `csrf`         | `[csrf]`           | Stateless double-submit cookie.                   |
+//! | Validation      | `validation`   | (per-handler)      | The [`ValidatedJson<T>`] extractor.               |
+//! | TLS 1.3         | `tls`          | `[tls]`            | Termination with `rustls` via [`Shield::serve`].  |
 //!
 //! [`Shield::apply`]: crate::shield::Shield::apply
 //! [`Shield::serve`]: crate::shield::Shield::serve
 //! [`ValidatedJson<T>`]: crate::shield::validation::ValidatedJson
 //!
-//! # Ejemplo minimo
+//! # Minimal example
 //!
 //! ```no_run
 //! use ag_core::{Shield, ShieldConfig};
@@ -50,12 +50,12 @@
 //! # }
 //! ```
 //!
-//! # Cargar configuracion desde TOML
+//! # Loading configuration from TOML
 //!
-//! El operador entrega un archivo TOML con todas las secciones
-//! relevantes. Vease `crates/ag-core/config.example.toml` y el
-//! [capitulo del manual](https://github.com/anti-gravital/anti-gravital/blob/main/docs/manual/01-shield-as-library.md)
-//! para una referencia completa.
+//! The operator provides a TOML file with all the relevant sections.
+//! See `crates/ag-core/config.example.toml` and the
+//! [manual chapter](https://github.com/anti-gravital/anti-gravital/blob/main/docs/manual/01-shield-as-library.md)
+//! for a complete reference.
 //!
 //! ```no_run
 //! use ag_core::{Shield, ShieldConfig};
@@ -68,35 +68,34 @@
 //! # }
 //! ```
 //!
-//! # Tipos publicos clave
+//! # Key public types
 //!
-//! - [`Shield`]: pipeline y helper de servicio.
-//! - [`ShieldConfig`]: configuracion completa, deserializable desde
+//! - [`Shield`]: pipeline and service helper.
+//! - [`ShieldConfig`]: complete configuration, deserializable from
 //!   TOML.
-//! - [`AgError`] y [`AgResult`]: tipos de error con mapeo automatico a
-//!   respuestas HTTP via `axum::response::IntoResponse`.
-//! - [`shield::Claims<T>`]: extractor de claims JWT tipados.
-//! - [`shield::validation::ValidatedJson<T>`]: extractor JSON con
-//!   validacion declarativa via el trait [`shield::validation::Validate`].
+//! - [`AgError`] and [`AgResult`]: error types with automatic mapping to
+//!   HTTP responses via `axum::response::IntoResponse`.
+//! - [`shield::Claims<T>`]: extractor for typed JWT claims.
+//! - [`shield::validation::ValidatedJson<T>`]: JSON extractor with
+//!   declarative validation via the [`shield::validation::Validate`] trait.
 //!
-//! # Estado del crate
+//! # Crate status
 //!
-//! Fase 1 (Shield MVP) cerrada en cuanto a contenido en repositorio.
-//! Las metricas duras de cierre de fase (throughput, latencia p99,
-//! memoria idle, tiempo de arranque) requieren medicion sobre hardware
-//! de referencia y se registran en `docs/benchmarks/` siguiendo la
-//! plantilla `measurement-template.md`. Vease
-//! `docs/roadmap/fase-01-shield-mvp.md` para los criterios completos
-//! y `docs/roadmap/STATUS.md` para el estado vivo.
+//! Phase 1 (Shield MVP) closed in terms of repository content. The hard
+//! phase-closure metrics (throughput, p99 latency, idle memory, startup
+//! time) require measurement on reference hardware and are recorded in
+//! `docs/benchmarks/` following the `measurement-template.md` template.
+//! See `docs/roadmap/fase-01-shield-mvp.md` for the complete criteria and
+//! `docs/roadmap/STATUS.md` for the live status.
 //!
-//! # Reglas aplicables
+//! # Applicable rules
 //!
-//! - Sin `unsafe` en codigo propio. El lint del workspace tiene
+//! - No `unsafe` in our own code. The workspace lint has
 //!   `unsafe_code = "deny"`.
-//! - Defaults seguros: las capas que mutan estado (CORS, CSRF,
-//!   rate-limit, JWT, TLS) estan deshabilitadas hasta declaracion
-//!   explicita en la configuracion.
-//! - Claves desconocidas en TOML se rechazan con [`AgError::Config`].
+//! - Secure defaults: layers that mutate state (CORS, CSRF, rate-limit,
+//!   JWT, TLS) are disabled until explicitly declared in the
+//!   configuration.
+//! - Unknown keys in TOML are rejected with [`AgError::Config`].
 
 #![deny(missing_docs)]
 

--- a/crates/ag-data/src/lib.rs
+++ b/crates/ag-data/src/lib.rs
@@ -1,10 +1,10 @@
-//! Capa de datos de Anti-Gravital.
+//! Anti-Gravital data layer.
 //!
-//! Provee el pool de conexiones PostgreSQL, la configuracion declarativa
-//! y el helper para ejecutar migraciones embebidas. En Fase 3+ el DSL
-//! genera query builders tipados que usan este pool como backend.
+//! Provides the PostgreSQL connection pool, declarative configuration
+//! and the helper to run embedded migrations. In Phase 3+ the DSL
+//! generates typed query builders that use this pool as backend.
 //!
-//! # Ejemplo minimo
+//! # Minimal example
 //!
 //! ```no_run
 //! use ag_data::{DataConfig, connect};
@@ -21,18 +21,18 @@
 //! # }
 //! ```
 //!
-//! # Migraciones
+//! # Migrations
 //!
-//! Las migraciones se embeben en el binario con el macro `sqlx::migrate!`
-//! y se aplican en el arranque con [`run_migrations`]:
+//! Migrations are embedded in the binary with the `sqlx::migrate!` macro
+//! and applied at startup with [`run_migrations`]:
 //!
 //! ```ignore
 //! use ag_data::{DataConfig, DbPool, connect, run_migrations};
 //!
 //! # async fn run() -> Result<(), Box<dyn std::error::Error>> {
 //! # let pool = connect(&DataConfig::default()).await?;
-//! // El macro lee los archivos SQL del crate consumidor, no de ag-data.
-//! // La ruta es relativa al Cargo.toml del proyecto que llama a migrate!.
+//! // The macro reads the SQL files from the consuming crate, not from ag-data.
+//! // The path is relative to the Cargo.toml of the project calling migrate!.
 //! static MIGRATOR: sqlx::migrate::Migrator = sqlx::migrate!("./migrations");
 //! run_migrations(&pool, &MIGRATOR).await?;
 //! # Ok(())

--- a/crates/ag-dsl/src/ast.rs
+++ b/crates/ag-dsl/src/ast.rs
@@ -1,120 +1,120 @@
-//! Tipos del AST del Anti-DSL.
+//! Anti-DSL AST types.
 //!
-//! Todas las construcciones del lenguaje se representan como nodos del AST.
-//! Los nodos clave llevan informacion de span para reportar errores precisos.
-//! En DSL v0.1–v0.7 el AST cubre modelos, request/response/error types,
-//! endpoints HTTP, anotaciones, auth/policy (v0.5), declaraciones de evento (v0.6)
-//! y bloques de correo/dominio (v0.7).
+//! All language constructs are represented as AST nodes.
+//! Key nodes carry span information to report precise errors.
+//! In DSL v0.1-v0.7 the AST covers models, request/response/error types,
+//! HTTP endpoints, annotations, auth/policy (v0.5), event declarations (v0.6)
+//! and mail/domain blocks (v0.7).
 
 use crate::lexer::Span;
 
-/// Rango de bytes en el texto fuente adjunto a un valor.
+/// Byte range in the source text attached to a value.
 #[derive(Debug, Clone, PartialEq)]
 pub struct Spanned<T> {
-    /// Valor del nodo.
+    /// Node value.
     pub value: T,
-    /// Posicion en el texto fuente (bytes).
+    /// Position in the source text (bytes).
     pub span: Span,
 }
 
 impl<T> Spanned<T> {
-    /// Construye un nodo con su span.
+    /// Builds a node with its span.
     pub fn new(value: T, span: Span) -> Self {
         Self { value, span }
     }
 }
 
-/// Schema completo: punto de entrada del AST.
+/// Full schema: AST entry point.
 ///
-/// Contiene configuracion, modelos (v0.1), tipos de API y endpoints (v0.2),
-/// validaciones (v0.3), relaciones (v0.4), auth/policy (v0.5), eventos (v0.6)
-/// y bloques de correo y dominio (v0.7).
+/// Contains configuration, models (v0.1), API types and endpoints (v0.2),
+/// validations (v0.3), relations (v0.4), auth/policy (v0.5), events (v0.6)
+/// and mail and domain blocks (v0.7).
 #[derive(Debug, Clone, Default)]
 pub struct Schema {
-    /// Bloque `config { ... }` opcional.
+    /// Optional `config { ... }` block.
     pub config: Option<Config>,
-    /// Definiciones de modelo en orden de aparicion.
+    /// Model definitions in order of appearance.
     pub models: Vec<ModelDef>,
-    /// Tipos de cuerpo de peticion: `request Nombre { ... }`.
+    /// Request body types: `request Name { ... }`.
     pub requests: Vec<RequestDef>,
-    /// Tipos de cuerpo de respuesta: `response Nombre { ... }`.
+    /// Response body types: `response Name { ... }`.
     pub responses: Vec<ResponseDef>,
-    /// Tipos de error HTTP: `error Nombre { status N message "..." }`.
+    /// HTTP error types: `error Name { status N message "..." }`.
     pub errors: Vec<ErrorDef>,
-    /// Definiciones de endpoint: `endpoint Nombre { method path body response errors }`.
+    /// Endpoint definitions: `endpoint Name { method path body response errors }`.
     pub endpoints: Vec<EndpointDef>,
-    /// Declaraciones de evento (v0.6): `event nombre { payload T retain Nd }`.
+    /// Event declarations (v0.6): `event name { payload T retain Nd }`.
     pub events: Vec<EventDef>,
-    /// Bloques de correo transaccional (v0.7): `mail nombre { ... }`.
+    /// Transactional mail blocks (v0.7): `mail name { ... }`.
     pub mails: Vec<MailBlock>,
-    /// Bloques de dominio DNS (v0.7): `domain nombre { ... }`.
+    /// DNS domain blocks (v0.7): `domain name { ... }`.
     pub domains: Vec<DomainBlock>,
 }
 
-/// Bloque `config { ... }`.
+/// `config { ... }` block.
 ///
-/// Campos reconocidos en v0.1: `project_name` y `database`.
-/// Campos desconocidos se reportan como warnings en el paso semantico.
+/// Fields recognized in v0.1: `project_name` and `database`.
+/// Unknown fields are reported as warnings in the semantic pass.
 #[derive(Debug, Clone, Default)]
 pub struct Config {
-    /// Nombre del proyecto.
+    /// Project name.
     pub project_name: Option<String>,
-    /// Backend de base de datos: `"postgres"`, `"sqlite"`, etc.
+    /// Database backend: `"postgres"`, `"sqlite"`, etc.
     pub database: Option<String>,
 }
 
-/// Definicion de modelo: `model Nombre { campos... }`.
+/// Model definition: `model Name { fields... }`.
 #[derive(Debug, Clone)]
 pub struct ModelDef {
-    /// Nombre del modelo con span para reportar errores.
+    /// Model name with span for error reporting.
     pub name: Spanned<String>,
-    /// Campos del modelo en orden de aparicion.
+    /// Model fields in order of appearance.
     pub fields: Vec<FieldDef>,
-    /// Span del bloque completo (del `model` al `}`).
+    /// Span of the full block (from `model` to `}`).
     pub span: Span,
 }
 
-/// Definicion de campo dentro de un modelo.
+/// Field definition within a model.
 #[derive(Debug, Clone)]
 pub struct FieldDef {
-    /// Nombre del campo.
+    /// Field name.
     pub name: Spanned<String>,
-    /// Tipo del campo.
+    /// Field type.
     pub ty: Spanned<FieldType>,
-    /// Si el campo es opcional (`?` al final del tipo).
+    /// Whether the field is optional (`?` at the end of the type).
     pub optional: bool,
-    /// Lista de anotaciones en orden de aparicion.
+    /// List of annotations in order of appearance.
     pub annotations: Vec<Spanned<Annotation>>,
-    /// true cuando el campo es ModelRef/ModelRefList con @relation.
-    /// SQL codegen lo omite; Rust/TS/OpenAPI lo incluyen como tipo anidado.
+    /// true when the field is a ModelRef/ModelRefList with @relation.
+    /// SQL codegen omits it; Rust/TS/OpenAPI include it as a nested type.
     pub virtual_field: bool,
 }
 
-/// Tipos primitivos soportados en DSL v0.1 y referencias a modelos (v0.4).
+/// Primitive types supported in DSL v0.1 and model references (v0.4).
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub enum FieldType {
-    /// `UUID` — identificador unico universal.
+    /// `UUID` — universally unique identifier.
     Uuid,
-    /// `String` — texto sin limite definido (el limite se pone con @max).
+    /// `String` — text with no defined limit (the limit is set with @max).
     String,
-    /// `Int` — entero de 64 bits con signo.
+    /// `Int` — signed 64-bit integer.
     Int,
-    /// `Float` — punto flotante de 64 bits.
+    /// `Float` — 64-bit floating point.
     Float,
-    /// `Bool` — booleano.
+    /// `Bool` — boolean.
     Bool,
-    /// `Timestamp` — fecha y hora con zona (UTC por defecto).
+    /// `Timestamp` — date and time with zone (UTC by default).
     Timestamp,
-    /// `Decimal` — numero decimal de precision arbitraria (para dinero).
+    /// `Decimal` — arbitrary-precision decimal number (for money).
     Decimal,
-    /// Referencia a otro modelo — campo virtual N:1 o 1:1, sin columna SQL.
+    /// Reference to another model — virtual N:1 or 1:1 field, no SQL column.
     ModelRef(std::string::String),
-    /// Lista de referencias — campo virtual 1:N, sin columna SQL.
+    /// List of references — virtual 1:N field, no SQL column.
     ModelRefList(std::string::String),
 }
 
 impl FieldType {
-    /// Nombre Rust del tipo generado.
+    /// Rust name of the generated type.
     pub fn rust_type(&self, optional: bool) -> std::string::String {
         if let FieldType::ModelRef(m) | FieldType::ModelRefList(m) = self {
             return if optional {
@@ -140,7 +140,7 @@ impl FieldType {
         }
     }
 
-    /// Tipo SQL correspondiente. Vacio para campos virtuales (nunca generan columna).
+    /// Corresponding SQL type. Empty for virtual fields (they never generate a column).
     pub fn sql_type(&self) -> &'static str {
         match self {
             FieldType::Uuid => "UUID",
@@ -154,7 +154,7 @@ impl FieldType {
         }
     }
 
-    /// Tipo TypeScript correspondiente.
+    /// Corresponding TypeScript type.
     pub fn ts_type(&self) -> &'static str {
         match self {
             FieldType::Uuid => "string",
@@ -168,7 +168,7 @@ impl FieldType {
         }
     }
 
-    /// Formato OpenAPI del tipo (pares type/format).
+    /// OpenAPI format of the type (type/format pairs).
     pub fn openapi_type(&self) -> (&'static str, Option<&'static str>) {
         match self {
             FieldType::Uuid => ("string", Some("uuid")),
@@ -183,55 +183,55 @@ impl FieldType {
     }
 }
 
-/// Anotaciones DSL v0.1–v0.4.
+/// DSL v0.1-v0.4 annotations.
 #[derive(Debug, Clone, PartialEq)]
 pub enum Annotation {
-    /// `@primary` — clave primaria.
+    /// `@primary` — primary key.
     Primary,
-    /// `@unique` — restriccion UNIQUE.
+    /// `@unique` — UNIQUE constraint.
     Unique,
-    /// `@auto` — valor autogenerado (UUID, SERIAL, NOW()).
+    /// `@auto` — auto-generated value (UUID, SERIAL, NOW()).
     Auto,
-    /// `@auto_update` — actualizado en cada UPDATE.
+    /// `@auto_update` — updated on every UPDATE.
     AutoUpdate,
-    /// `@default(valor)` — valor por defecto.
+    /// `@default(value)` — default value.
     Default(DefaultValue),
-    // ---- Validaciones v0.3 ----
-    /// `@min(N)` — longitud minima (String) o valor minimo (Int/Float/Decimal).
+    // ---- v0.3 validations ----
+    /// `@min(N)` — minimum length (String) or minimum value (Int/Float/Decimal).
     Min(i64),
-    /// `@max(N)` — longitud maxima (String) o valor maximo (Int/Float/Decimal).
+    /// `@max(N)` — maximum length (String) or maximum value (Int/Float/Decimal).
     Max(i64),
-    /// `@email` — valida formato de email RFC 5321 basico.
+    /// `@email` — validates basic RFC 5321 email format.
     Email,
-    /// `@regex("patron")` — valida contra expresion regular.
+    /// `@regex("pattern")` — validates against a regular expression.
     Regex(std::string::String),
-    /// `@length(N)` — longitud exacta de caracteres (solo String).
+    /// `@length(N)` — exact character length (String only).
     Length(i64),
-    // ---- Relaciones v0.4 ----
-    /// `@references(Modelo.campo)` — clave foranea con columna SQL real.
+    // ---- v0.4 relations ----
+    /// `@references(Model.field)` — foreign key with a real SQL column.
     References {
-        /// Nombre del modelo destino.
+        /// Target model name.
         model: std::string::String,
-        /// Nombre del campo destino (normalmente la clave primaria).
+        /// Target field name (normally the primary key).
         field: std::string::String,
     },
-    /// `@relation(campo)` o `@relation(modelo.campo)` — campo virtual sin columna SQL.
+    /// `@relation(field)` or `@relation(model.field)` — virtual field with no SQL column.
     Relation {
-        /// Path de la relacion: `campo` para N:1, `modelo.campo` para 1:N.
+        /// Relation path: `field` for N:1, `model.field` for 1:N.
         path: std::string::String,
     },
 }
 
-/// Valor para la anotacion `@default(...)`.
+/// Value for the `@default(...)` annotation.
 #[derive(Debug, Clone, PartialEq)]
 pub enum DefaultValue {
-    /// Literal entero: `@default(0)`.
+    /// Integer literal: `@default(0)`.
     Int(i64),
-    /// Literal string: `@default("activo")`.
+    /// String literal: `@default("activo")`.
     String(std::string::String),
-    /// Literal booleano: `@default(true)`.
+    /// Boolean literal: `@default(true)`.
     Bool(bool),
-    /// Identificador (variante de enum u otra referencia): `@default(USER)`.
+    /// Identifier (enum variant or other reference): `@default(USER)`.
     Ident(std::string::String),
 }
 
@@ -247,62 +247,62 @@ impl std::fmt::Display for DefaultValue {
 }
 
 // ============================================================
-// DSL v0.2 — API types y endpoints
+// DSL v0.2 — API types and endpoints
 // ============================================================
 
-/// Definicion de tipo de cuerpo de peticion: `request Nombre { campos... }`.
+/// Request body type definition: `request Name { fields... }`.
 #[derive(Debug, Clone)]
 pub struct RequestDef {
-    /// Nombre del tipo con span.
+    /// Type name with span.
     pub name: Spanned<std::string::String>,
-    /// Campos del cuerpo de peticion.
+    /// Request body fields.
     pub fields: Vec<FieldDef>,
-    /// Span del bloque completo.
+    /// Span of the full block.
     pub span: Span,
 }
 
-/// Definicion de tipo de cuerpo de respuesta: `response Nombre { campos... }`.
+/// Response body type definition: `response Name { fields... }`.
 #[derive(Debug, Clone)]
 pub struct ResponseDef {
-    /// Nombre del tipo con span.
+    /// Type name with span.
     pub name: Spanned<std::string::String>,
-    /// Campos del cuerpo de respuesta.
+    /// Response body fields.
     pub fields: Vec<FieldDef>,
-    /// Span del bloque completo.
+    /// Span of the full block.
     pub span: Span,
 }
 
-/// Definicion de error HTTP: `error Nombre { status N message "texto" }`.
+/// HTTP error definition: `error Name { status N message "text" }`.
 #[derive(Debug, Clone)]
 pub struct ErrorDef {
-    /// Nombre del tipo de error con span.
+    /// Error type name with span.
     pub name: Spanned<std::string::String>,
-    /// Codigo de estado HTTP (ej. 409, 422).
+    /// HTTP status code (e.g. 409, 422).
     pub status: Spanned<u16>,
-    /// Mensaje legible para el cliente.
+    /// Client-readable message.
     pub message: Spanned<std::string::String>,
-    /// Span del bloque completo.
+    /// Span of the full block.
     pub span: Span,
 }
 
 // ============================================================
-// DSL v0.5 — auth/policy en endpoints
+// DSL v0.5 — auth/policy on endpoints
 // ============================================================
 
-/// Modo de autenticacion declarado en un endpoint (DSL v0.5).
+/// Authentication mode declared on an endpoint (DSL v0.5).
 #[derive(Debug, Clone, PartialEq, Eq, Default)]
 pub enum AuthMode {
-    /// Sin autenticacion requerida (valor por defecto).
+    /// No authentication required (default value).
     #[default]
     None,
-    /// El token JWT es requerido; la Shield rechaza requests sin token.
+    /// The JWT token is required; the Shield rejects requests without a token.
     Required,
-    /// El token JWT es opcional; el handler decide como tratar la ausencia.
+    /// The JWT token is optional; the handler decides how to treat its absence.
     Optional,
 }
 
 impl AuthMode {
-    /// Representacion textual del modo tal como aparece en el schema.
+    /// Textual representation of the mode as it appears in the schema.
     pub fn as_str(&self) -> &'static str {
         match self {
             AuthMode::None => "none",
@@ -313,23 +313,23 @@ impl AuthMode {
 }
 
 // ============================================================
-// DSL v0.6 — declaracion de eventos
+// DSL v0.6 — event declaration
 // ============================================================
 
-/// Declaracion de evento en DSL v0.6: `event nombre { payload T retain Nd }`.
+/// Event declaration in DSL v0.6: `event name { payload T retain Nd }`.
 #[derive(Debug, Clone)]
 pub struct EventDef {
-    /// Nombre del evento en formato `entidad.accion`.
+    /// Event name in `entity.action` format.
     pub name: Spanned<std::string::String>,
-    /// Nombre del tipo de payload (referencia a model/request/response).
+    /// Payload type name (reference to model/request/response).
     pub payload: Spanned<std::string::String>,
-    /// Retencion en dias. `None` si no se declara.
+    /// Retention in days. `None` if not declared.
     pub retain_days: Option<u32>,
-    /// Span del bloque completo.
+    /// Span of the full block.
     pub span: Span,
 }
 
-/// Definicion de endpoint HTTP.
+/// HTTP endpoint definition.
 ///
 /// ```text
 /// endpoint CreateUser {
@@ -342,45 +342,45 @@ pub struct EventDef {
 /// ```
 #[derive(Debug, Clone)]
 pub struct EndpointDef {
-    /// Nombre del endpoint con span.
+    /// Endpoint name with span.
     pub name: Spanned<std::string::String>,
-    /// Metodo HTTP.
+    /// HTTP method.
     pub method: Spanned<HttpMethod>,
-    /// Path HTTP (ej. `/users/{id}`).
+    /// HTTP path (e.g. `/users/{id}`).
     pub path: Spanned<std::string::String>,
-    /// Nombre del tipo de cuerpo de peticion (referencia a `RequestDef`).
+    /// Request body type name (reference to `RequestDef`).
     pub body: Option<Spanned<std::string::String>>,
-    /// Nombre del tipo de respuesta (referencia a `ResponseDef`).
+    /// Response type name (reference to `ResponseDef`).
     pub response: Option<Spanned<std::string::String>>,
-    /// Nombres de tipos de error (referencias a `ErrorDef`).
+    /// Error type names (references to `ErrorDef`).
     pub errors: Vec<Spanned<std::string::String>>,
-    /// Modo de autenticacion del endpoint (v0.5). Default: None.
+    /// Endpoint authentication mode (v0.5). Default: None.
     pub auth: AuthMode,
-    /// Expresion de politica RBAC (v0.5). Solo valida cuando auth != None.
+    /// RBAC policy expression (v0.5). Only valid when auth != None.
     pub policy: Option<Spanned<std::string::String>>,
-    /// Nombres de eventos emitidos por este endpoint (v0.6).
+    /// Names of events emitted by this endpoint (v0.6).
     pub emits: Vec<Spanned<std::string::String>>,
-    /// Span del bloque completo.
+    /// Span of the full block.
     pub span: Span,
 }
 
-/// Metodo HTTP soportado en DSL v0.2.
+/// HTTP method supported in DSL v0.2.
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub enum HttpMethod {
-    /// HTTP GET — lectura.
+    /// HTTP GET — read.
     Get,
-    /// HTTP POST — creacion.
+    /// HTTP POST — create.
     Post,
-    /// HTTP PUT — reemplazo completo.
+    /// HTTP PUT — full replacement.
     Put,
-    /// HTTP PATCH — actualizacion parcial.
+    /// HTTP PATCH — partial update.
     Patch,
-    /// HTTP DELETE — eliminacion.
+    /// HTTP DELETE — removal.
     Delete,
 }
 
 impl HttpMethod {
-    /// Retorna la representacion textual del metodo en mayusculas.
+    /// Returns the uppercase textual representation of the method.
     pub fn as_str(&self) -> &'static str {
         match self {
             HttpMethod::Get => "GET",

--- a/crates/ag-dsl/src/lib.rs
+++ b/crates/ag-dsl/src/lib.rs
@@ -1,6 +1,6 @@
-//! Compilador del Anti-DSL: lexer, parser, AST, analisis semantico y generadores de codigo.
+//! Anti-DSL compiler: lexer, parser, AST, semantic analysis and code generators.
 //!
-//! # Uso
+//! # Usage
 //!
 //! ```rust
 //! use ag_dsl::{compile, generate};
@@ -32,10 +32,10 @@
 //! # Pipeline
 //!
 //! ```text
-//! texto .ag
-//!   -> lexer (logos)      tokens + errores de lex
-//!   -> parser (chumsky)   AST parcial + errores de parse
-//!   -> semantic           errores/warnings semanticos
+//! .ag text
+//!   -> lexer (logos)      tokens + lex errors
+//!   -> parser (chumsky)   partial AST + parse errors
+//!   -> semantic           semantic errors/warnings
 //!   -> codegen            GeneratedFiles { rust, sql, typescript, openapi }
 //! ```
 
@@ -49,14 +49,14 @@ mod semantic;
 pub use codegen::{generate, GeneratedFiles};
 pub use diagnostics::Diagnostic;
 
-/// Compila texto fuente DSL y retorna el AST si no hay errores de lex, parse o semantica.
+/// Compiles DSL source text and returns the AST if there are no lex, parse or semantic errors.
 ///
-/// Los warnings (como un modelo sin @primary) no bloquean la compilacion.
-/// Solo los errores de severidad `Error` producen `Err`.
+/// Warnings (such as a model without @primary) do not block compilation.
+/// Only diagnostics with `Error` severity produce `Err`.
 ///
 /// # Errors
 ///
-/// Retorna `Err(Vec<Diagnostic>)` si hay errores de lex, parse o semanticos.
+/// Returns `Err(Vec<Diagnostic>)` if there are lex, parse or semantic errors.
 pub fn compile(source: &str) -> Result<ast::Schema, Vec<Diagnostic>> {
     let (tokens, lex_spans) = lexer::tokenize(source);
 
@@ -88,10 +88,10 @@ pub fn compile(source: &str) -> Result<ast::Schema, Vec<Diagnostic>> {
     }
 }
 
-/// Analiza el fuente DSL y retorna todos los diagnosticos (errores y warnings).
+/// Analyzes the DSL source and returns all diagnostics (errors and warnings).
 ///
-/// A diferencia de `compile()`, siempre retorna la lista completa: no descarta
-/// warnings cuando no hay errores. Usar en el servidor LSP y en `ag schema lint`.
+/// Unlike `compile()`, it always returns the full list: it does not discard
+/// warnings when there are no errors. Used in the LSP server and in `ag schema lint`.
 pub fn lint(source: &str) -> Vec<Diagnostic> {
     let (tokens, lex_spans) = lexer::tokenize(source);
     let mut all_diags: Vec<Diagnostic> = lex_spans.into_iter().map(Diagnostic::lex_error).collect();
@@ -263,12 +263,12 @@ model User {
         assert!(errors.is_empty(), "schema limpio no debe tener errores");
     }
 
-    // ---- Tests DSL v0.5 + v0.6 ----
+    // ---- DSL v0.5 + v0.6 tests ----
 
     #[test]
     fn policy_without_auth_is_error() {
-        // auth se omite: el default es AuthMode::None.
-        // policy con auth None debe producir error semantico.
+        // auth is omitted: the default is AuthMode::None.
+        // a policy with auth None must produce a semantic error.
         let src = r#"
 endpoint GetProfile {
     method GET
@@ -326,11 +326,11 @@ response UserResponse { id UUID }
 
     #[test]
     fn fuzz_crash_repro_tab_comment_number() {
-        // Crash encontrado por cargo-fuzz: \t#\n11111111111111111111,\n#\n#
-        // El compilador no debe entrar en panico con ningun input UTF-8 valido.
+        // Crash found by cargo-fuzz: \t#\n11111111111111111111,\n#\n#
+        // The compiler must not panic on any valid UTF-8 input.
         let input = "\t#\n11111111111111111111,\n#\n#";
         let diags = lint(input);
-        // No importa el resultado, solo que no haya panic
+        // The result does not matter, only that there is no panic
         let _ = diags;
         if let Ok(schema) = compile(input) {
             let _ = generate(&schema);

--- a/crates/ag-lsp/src/backend.rs
+++ b/crates/ag-lsp/src/backend.rs
@@ -1,7 +1,7 @@
-//! Backend del servidor LSP Anti-Gravital.
+//! Backend of the Anti-Gravital LSP server.
 //!
-//! Implementa el trait `LanguageServer` de tower-lsp. Cada documento `.ag`
-//! abierto se mantiene en memoria para publicar diagnostics en tiempo real.
+//! Implements tower-lsp's `LanguageServer` trait. Each open `.ag` document
+//! is kept in memory to publish diagnostics in real time.
 
 use std::collections::HashMap;
 
@@ -17,15 +17,15 @@ use tower_lsp::lsp_types::{
 };
 use tower_lsp::{Client, LanguageServer};
 
-/// Estado interno del servidor LSP.
+/// Internal state of the LSP server.
 pub struct Backend {
     client: Client,
-    /// Texto actual de cada documento abierto, indexado por URI.
+    /// Current text of each open document, indexed by URI.
     documents: Mutex<HashMap<Url, String>>,
 }
 
 impl Backend {
-    /// Crea un nuevo Backend con el cliente LSP dado.
+    /// Creates a new Backend with the given LSP client.
     pub fn new(client: Client) -> Self {
         Self {
             client,
@@ -139,7 +139,7 @@ impl LanguageServer for Backend {
     }
 }
 
-// ---- helpers internos ------------------------------------------------
+// ---- internal helpers ------------------------------------------------
 
 fn ag_diag_to_lsp(source: &str, d: &AgDiag) -> Diagnostic {
     let range = span_to_range(source, d.span.start, d.span.end);
@@ -197,14 +197,14 @@ fn word_at_position<'a>(source: &'a str, pos: &Position) -> Option<&'a str> {
 
 fn hover_content_for_word(word: &str) -> Option<String> {
     let s = match word {
-        // Tipos escalares
+        // Scalar types
         "UUID" => "**UUID** — Identificador unico universal v4. SQL: `UUID`.",
         "String" => "**String** — Cadena de texto UTF-8. SQL: `TEXT`.",
         "Int" => "**Int** — Entero de 64 bits con signo. SQL: `BIGINT`.",
         "Float" => "**Float** — Punto flotante 64 bits. SQL: `DOUBLE PRECISION`.",
         "Bool" => "**Bool** — Valor booleano. SQL: `BOOLEAN`.",
         "DateTime" => "**DateTime** — Fecha y hora UTC. SQL: `TIMESTAMPTZ`.",
-        // Anotaciones de modelo
+        // Model annotations
         "@primary" => "**@primary** — Clave primaria de la tabla.",
         "@unique" => "**@unique** — Restriccion UNIQUE en la columna.",
         "@auto" => "**@auto** — Valor generado automaticamente (UUID o serial).",
@@ -217,7 +217,7 @@ fn hover_content_for_word(word: &str) -> Option<String> {
         "@length" => "**@length(n)** — Longitud exacta del string.",
         "@relation" => "**@relation(campo_fk)** — Relacion virtual. No genera columna SQL.",
         "@references" => "**@references(Modelo.campo)** — Clave foranea hacia otro modelo.",
-        // Bloques DSL v0.7 — correo transaccional
+        // DSL v0.7 blocks — transactional mail
         "mail" => {
             "**mail** (DSL v0.7) — Bloque de configuracion de correo transaccional.\n\n\
             ```ag\nmail nombre {\n    provider smtp\n    from \"noreply@ejemplo.com\"\n    template bienvenida {\n        subject \"Bienvenido {{nombre}}\"\n        vars [nombre, token]\n    }\n}\n```\n\n\
@@ -233,7 +233,7 @@ fn hover_content_for_word(word: &str) -> Option<String> {
             ```ag\ntemplate bienvenida {\n    subject \"Bienvenido {{nombre}}\"\n    vars [nombre, token]\n}\n```\n\n\
             Las `vars` declaradas son validadas en compile-time contra el HTML del template."
         }
-        // Propiedades de bloques mail/domain
+        // Properties of mail/domain blocks
         "provider" => "**provider** — Proveedor del bloque. En `mail`: `smtp`, `resend`, `ses`, `postmark`. En `domain`: `cloudflare`.",
         "from" => "**from** — Direccion de correo remitente. Debe referenciar un `domain` declarado en el mismo schema.",
         "subject" => "**subject** — Asunto del correo. Admite variables `{{nombre}}` declaradas en `vars`.",
@@ -259,7 +259,7 @@ fn static_completion_items() -> Vec<CompletionItem> {
         ("PUT", "Metodo HTTP PUT"),
         ("PATCH", "Metodo HTTP PATCH"),
         ("DELETE", "Metodo HTTP DELETE"),
-        // DSL v0.7 — bloques mail/domain
+        // DSL v0.7 — mail/domain blocks
         ("mail", "Bloque de correo transaccional (DSL v0.7)"),
         ("domain", "Bloque de configuracion DNS (DSL v0.7)"),
         ("template", "Sub-bloque de template de correo (DSL v0.7)"),
@@ -286,7 +286,7 @@ fn static_completion_items() -> Vec<CompletionItem> {
         ("@relation", "@relation(campo_fk) — relacion virtual"),
         ("@references", "@references(Modelo.campo) — clave foranea"),
     ];
-    // Propiedades de bloques mail/domain (DSL v0.7)
+    // Properties of mail/domain blocks (DSL v0.7)
     let mail_domain_props: &[(&str, &str)] = &[
         (
             "provider",

--- a/crates/ag-lsp/src/main.rs
+++ b/crates/ag-lsp/src/main.rs
@@ -1,7 +1,7 @@
-//! Binario del servidor LSP Anti-Gravital.
+//! Anti-Gravital LSP server binary.
 //!
-//! Escucha en stdin/stdout con el protocolo LSP. El cliente (VS Code, etc.)
-//! lanza este proceso como hijo y se comunica por stdio.
+//! Listens on stdin/stdout with the LSP protocol. The client (VS Code, etc.)
+//! launches this process as a child and communicates over stdio.
 
 mod backend;
 

--- a/crates/ag-migrate/src/lib.rs
+++ b/crates/ag-migrate/src/lib.rs
@@ -1,5 +1,5 @@
-//! Importadores de migracion desde frameworks legacy hacia esquemas Anti-DSL.
+//! Migration importers from legacy frameworks into Anti-DSL schemas.
 //!
-//! Estado: Fase 0 (Fundaciones y Gobernanza). Este crate aun no contiene
-//! codigo funcional. La implementacion se entrega en la fase declarada
-//! en el README del crate y en la Hoja de Ruta del proyecto.
+//! Status: Phase 0 (Foundations and Governance). This crate does not yet
+//! contain functional code. The implementation is delivered in the phase
+//! declared in the crate's README and in the project's Roadmap.

--- a/crates/ag-mobile/src/lib.rs
+++ b/crates/ag-mobile/src/lib.rs
@@ -1,5 +1,5 @@
-//! Puente de aplicaciones nativas: generador Dart con freezed, dio y clientes WebSocket/SSE.
+//! Native application bridge: Dart generator with freezed, dio and WebSocket/SSE clients.
 //!
-//! Estado: Fase 0 (Fundaciones y Gobernanza). Este crate aun no contiene
-//! codigo funcional. La implementacion se entrega en la fase declarada
-//! en el README del crate y en la Hoja de Ruta del proyecto.
+//! Status: Phase 0 (Foundations and Governance). This crate does not yet
+//! contain functional code. The implementation is delivered in the phase
+//! declared in the crate's README and in the project's Roadmap.

--- a/crates/ag-ui/src/lib.rs
+++ b/crates/ag-ui/src/lib.rs
@@ -1,5 +1,5 @@
-//! Renderizado del lado del servidor con askama e integracion progresiva HTMX.
+//! Server-side rendering with askama and progressive HTMX integration.
 //!
-//! Estado: Fase 0 (Fundaciones y Gobernanza). Este crate aun no contiene
-//! codigo funcional. La implementacion se entrega en la fase declarada
-//! en el README del crate y en la Hoja de Ruta del proyecto.
+//! Status: Phase 0 (Foundations and Governance). This crate does not yet
+//! contain functional code. The implementation is delivered in the phase
+//! declared in the crate's README and in the project's Roadmap.

--- a/crates/ag-wasm-host/src/lib.rs
+++ b/crates/ag-wasm-host/src/lib.rs
@@ -1,5 +1,5 @@
-//! Host de plugins WASI: descubrimiento, validacion, sandbox y ciclo de vida.
+//! WASI plugin host: discovery, validation, sandbox and lifecycle.
 //!
-//! Estado: Fase 0 (Fundaciones y Gobernanza). Este crate aun no contiene
-//! codigo funcional. La implementacion se entrega en la fase declarada
-//! en el README del crate y en la Hoja de Ruta del proyecto.
+//! Status: Phase 0 (Foundations and Governance). This crate does not yet
+//! contain functional code. The implementation is delivered in the phase
+//! declared in the crate's README and in the project's Roadmap.

--- a/docs/adr/0002-bilingual-documentation.md
+++ b/docs/adr/0002-bilingual-documentation.md
@@ -1,10 +1,18 @@
 # ADR-0002 - Documentacion bilingue espanol e ingles
 
-- Estado: aceptado
+- Estado: superseded por ADR-0008 (2026-05-24)
 - Fecha: 2026-05-19
 - RFC origen: ninguna; decision fundacional alineada con la seccion 1
   del maestro de arquitectura ("documentacion bilingue desde el dia
   cero").
+
+> **Nota de supersesion (2026-05-24).** El aspecto de "espanol como
+> predeterminado" de esta ADR fue revisado al cierre de la Fase 4.5,
+> en el punto de revision que esta misma ADR dejo anticipado. `ADR-0008`
+> establece el ingles como idioma canonico del codigo y de la documentacion
+> tecnica profunda, manteniendo bilingue (EN+ES, mismo archivo) solo la
+> vitrina: README raiz, maestros y manual. La estructura de carpetas
+> `docs/es/` y `docs/en/` se conserva. Lo que sigue es el texto original.
 
 ## Contexto
 

--- a/docs/adr/0008-politica-de-idioma.md
+++ b/docs/adr/0008-politica-de-idioma.md
@@ -1,0 +1,76 @@
+# ADR-0008 - Politica de idioma: ingles canonico y vitrina bilingue
+
+- Estado: aceptado
+- Fecha: 2026-05-24
+- RFC origen: RFC-0008
+- Supersede: ADR-0002 (parcialmente; ver Contexto)
+
+## Contexto
+
+`ADR-0002` (2026-05-19) establecio documentacion bilingue con espanol como
+predeterminado y dejo registrado que la decision "se revisa cuando el comite
+tecnico se forme en Fase 4". El proyecto cierra la Fase 4.5 y se prepara para
+Fase 5 (`ag-cloud`), donde el objetivo es ampliar la adopcion.
+
+Dos hechos fuerzan la revision:
+
+1. ADR-0002 no legislo el idioma de los comentarios de codigo. El vacio se
+   lleno por defecto con espanol: ~3200 lineas de comentarios en 118 archivos
+   `.rs`.
+2. La documentacion crecio a 147 archivos markdown. Hacerla toda bilingue
+   inline duplicaria el volumen y garantizaria desincronizacion.
+
+`RFC-0008` analiza las alternativas y propone la politica que esta ADR
+registra.
+
+## Decision
+
+El **ingles es el idioma canonico** del codigo y de la documentacion tecnica
+profunda. Los **documentos vitrina** (README raiz, los tres maestros de
+`docs/master/`, y los capitulos del manual) son **bilingues en el mismo
+archivo**, con la seccion en ingles primero (canonica) y la seccion en
+espanol despues. Todos los comentarios de codigo (`//`, `///`, `//!`) se
+escriben en ingles.
+
+## Consecuencias
+
+Positivas:
+
+- El codigo y los docs tecnicos quedan accesibles a contribuidores globales,
+  alineados con la norma del open source de infraestructura.
+- La vitrina bilingue preserva la accesibilidad para el foco inicial
+  latinoamericano: lo primero que ve un recien llegado sigue estando en
+  espanol.
+- Un solo idioma canonico de codigo elimina ambiguedad para futuros
+  contribuidores.
+
+Negativas:
+
+- Costo puntual de convertir ~3200 comentarios a ingles. Mitigacion: se hace
+  una sola vez en la fase de cierre documental, crate por crate, con
+  verificacion `cargo`.
+- La seccion espanola de la vitrina puede desincronizarse de la inglesa.
+  Mitigacion: la inglesa es canonica; si avanza, la espanola se marca
+  pendiente.
+
+## Alternativas consideradas
+
+- Mantener espanol por defecto: rechazada por perpetuar la barrera de entrada
+  internacional.
+- Todo en ingles sin espanol: rechazada por contradecir el posicionamiento
+  del proyecto.
+- Todo bilingue inline: rechazada como mala practica para 147 archivos
+  (duplicacion, desincronizacion, diffs ruidosos).
+- Carpetas espejo `es/` + `en/` completas: rechazada por costo de
+  mantenimiento desproporcionado.
+
+Detalle completo en `RFC-0008`.
+
+## Notas
+
+- Supersede el aspecto de "espanol predeterminado" de `ADR-0002`; la
+  estructura de carpetas `docs/es/` y `docs/en/` como indices se conserva.
+- Cumple el punto de revision que `ADR-0002` dejo anticipado para Fase 4.
+- Regla operativa registrada en `CLAUDE.md`.
+- Maestro de arquitectura, seccion 1: "documentacion bilingue desde el dia
+  cero" se reinterpreta como "vitrina bilingue, tecnica en ingles canonico".

--- a/docs/master/ANTI-GRAVITAL-Arquitectura-Tecnica.md
+++ b/docs/master/ANTI-GRAVITAL-Arquitectura-Tecnica.md
@@ -1,3 +1,1248 @@
+# Anti-Gravital Framework — Technical Architecture and Implementation
+
+**[English](#english) | [Espanol](#espanol)**
+
+> This is a bilingual document. English is the canonical, normative version. The Spanish section that follows is a faithful counterpart. Per ADR-0008, when the two diverge, the English text governs.
+
+---
+
+## English
+
+# Anti-Gravital Framework — Technical Architecture and Implementation
+
+**Version:** 4.0 — May 2026
+**Organization:** Gravital Labs — Nereira Technology and Business Solutions
+**Origin:** Republic of Panama
+**License:** Apache 2.0
+**Status:** Pre-launch. Active roadmap.
+
+> Master technical document. It specifies the architecture, the components, the implementation contracts, the DSL type system, the plugin model, the security guarantees, and the performance objectives of the Anti-Gravital framework. This document supersedes Blueprint v3.0 and consolidates the architectural decisions derived from the critical external review analysis.
+
+---
+
+## Table of contents
+
+1. Executive summary
+2. Manifesto and positioning
+3. What Anti-Gravital is and is not (scope and limits)
+4. Analysis of the state of the art
+5. Ecosystem architecture: modules and responsibilities
+6. Core architecture (`ag-core`): Shield and Core
+7. The Anti-DSL language (`ag-dsl`): specification and incremental implementation
+8. Batteries-included modules
+9. WASI plugin system (`ag-wasm-host`)
+10. Deployment subsystem (`ag-cloud`)
+11. Artificial Intelligence integration (`ag-ai`) and the Knowledge Graph
+12. Migration framework (`ag-migrate`): importers
+13. Native application bridge (`ag-mobile`): Flutter and generated clients
+14. Observability (`ag-observe`)
+15. Security model
+16. Performance objectives and validation methodology
+17. Open Source governance model
+18. Risk analysis and mitigations
+19. Technical glossary
+20. Appendix: market comparison
+
+---
+
+## 1. Executive summary
+
+Anti-Gravital is a free software ecosystem for building high-performance backend applications, written in pure Rust, with three fundamental properties that distinguish it from the rest of the current web framework market.
+
+The first is the total absence of an external runtime: the result of an Anti-Gravital project is a self-contained static binary that runs on the operating system without an interpreter or virtual machine in between. This eliminates the JVM, CPython, Node.js, and the CLR from the execution path and, with them, the garbage collection pauses, the cold-start seconds, and the hundreds of megabytes of base memory that those runtimes consume before processing the first request.
+
+The second is the schema-first approach supported by a domain definition language called Anti-DSL, files with the `.ag` extension. A single file describes models, endpoints, policies, validations, errors, and relationships; the DSL compiler derives from there the Rust code, the typed clients for frontend and mobile applications, the OpenAPI documentation, and the database migrations. The contract is a single source of truth, and schema drift ceases to be a possible class of problem by construction.
+
+The third is a modular architecture conceived as an ecosystem, not as a monolithic framework. The core is deliberately small and is composed with independently published modules. Each module (`ag-auth`, `ag-data`, `ag-realtime`, `ag-cache`, `ag-storage`, `ag-observe`, `ag-cloud`, `ag-ai`, `ag-mobile`, `ag-migrate`) has its own domain, its own versioning, and can be used in isolation in any Rust project. This separation makes the ecosystem sustainable at community scale and eliminates the "framework that tries to solve everything" syndrome.
+
+The project is born in Panama, with bilingual Spanish/English documentation from day zero. The first adoption focus is Latin America; the horizon is global. The Apache 2.0 license guarantees that there will never be a closed Enterprise version or features reserved for paying customers: the entirety of the ecosystem is and will be open source.
+
+This document describes in detail each component, each architectural decision, and the technical commitments that underpin the project. The complementary document *Roadmap and Verification Gates* defines the temporal sequence of deliverables and the blocking criteria between phases.
+
+---
+
+## 2. Manifesto and positioning
+
+For the last twenty years, the software industry has accepted a trade-off that is no longer necessary: choosing between performance and productivity. The world's most widely adopted frameworks thrived by solving only one of the two extremes. Spring Boot and .NET imposed enterprise structure at the price of heavy virtual machines and multi-second startups. Django and FastAPI made it possible for small teams to build APIs in hours, at the price of the GIL and an interpreter that places an invisible ceiling on performance. Node.js brought isomorphic development at the price of a single-threaded event loop and an npm ecosystem chronically vulnerable to supply chain attacks.
+
+None of these frameworks is bad. They all solve real problems. But they were all designed in an era prior to three converging phenomena that change the calculation: the production maturity of the Rust ecosystem, the arrival of AI agents capable of writing quality code at superhuman speeds, and the industry's disenchantment with the operational complexity of multi-language stacks.
+
+Anti-Gravital is built on the premise that systems performance and developer productivity are not opposing forces, but design problems. A correctly designed framework can offer both simultaneously without hidden trade-offs.
+
+The name describes the thesis. Current frameworks have *gravity*: they tie you to interpreters, virtual machines, external runtimes, and abstraction layers that charge in latency, memory, and operational complexity. Anti-Gravital breaks with that gravity from the foundations: no JVM, no GC, no interpreter, no external runtime. Only native machine code, memory safety guaranteed at compile time, and massive concurrency without garbage collection cost.
+
+**Explicit positioning.** Anti-Gravital does not position itself against any language or any framework. It positions itself as the modern unified backend and runtime layer for applications that need three things simultaneously: systems performance, high-level framework productivity, and operational deployment simplicity. The target audience is not the team that already has a Spring stack running in production and has no pain — it is the team that is starting a new project, or that has reached the structural limits of Python/Node.js, or that needs to reduce the memory footprint of its service fleet.
+
+The adoption strategy is built on interoperability and gradual migration, not on the aggressive replacement of existing stacks. The official importers (OpenAPI, Prisma, Sequelize, Django ORM, FastAPI/Pydantic models) are first-class citizens, not an afterthought.
+
+---
+
+## 3. What Anti-Gravital is and is not (scope and limits)
+
+The clear definition of scope is probably the most important architectural decision of this project. A framework that tries to be everything ends up being nothing. This section establishes the explicit limits of the project.
+
+### 3.1 What Anti-Gravital is
+
+Anti-Gravital is:
+
+- A high-performance **Rust backend runtime** for HTTP, WebSocket, and SSE services.
+- A **domain definition language** (Anti-DSL, `.ag` files) and its compiler.
+- A **unified CLI** (`ag`) for creation, generation, development, build, deployment, and administration.
+- A **set of optional modules** published as independent Rust crates (auth, data, realtime, cache, storage, observe, mail —deferred standard—).
+- A **domain and TLS management layer** (`ag-domains`, optional infra) that integrates DNS via adapters, ACME for certificates, and SPF/DKIM/DMARC for transactional mail.
+- A **WASI plugin system** for isolated multi-language extensibility.
+- A **deployment orchestration layer** simplified in the Railway/Fly.io style for common cases (not a Kubernetes replacement).
+- A **typed SDK generator** for TypeScript, Dart, and other client languages.
+- A **set of migration importers** from legacy frameworks.
+- An auto-generated **knowledge graph** that keeps the architectural documentation synchronized with the code.
+
+### 3.2 What Anti-Gravital is NOT
+
+This list is equally important. Anti-Gravital does **not** intend and will not intend to:
+
+- **Replace Kubernetes.** For workloads that justify Kubernetes, Anti-Gravital deploys *on top of* Kubernetes like any other containerized binary. `ag-cloud` covers the range from Docker Compose up to Fly.io. When a team needs orchestration at the scale of hundreds of nodes, it uses Kubernetes and that is that.
+- **Replace Flutter or React Native.** Anti-Gravital is not a cross-platform UI framework. It is the ideal native backend *for* Flutter and React Native applications, with automatic generation of typed client SDKs, native authentication, realtime, offline sync, and streaming.
+- **Replace React, Vue, Svelte, or Next.js.** The `ag-ui` module offers SSR + HTMX for cases where a full JS stack is excessive, but it does not compete with established frontend frameworks. For SPA or rich SSR applications, the recommended pattern is Anti-Gravital as backend + Next.js (or equivalent) as frontend, communicating via the generated TypeScript client.
+- **Replace Docker.** It generates Dockerfiles. It runs in containers. It does not reinvent the OCI format.
+- **Replace PostgreSQL, Redis, MinIO, or NATS.** It integrates with them as standard external dependencies.
+- **Replace Terraform or Pulumi.** `ag-cloud` orchestrates simple deployments; for complex multi-cloud infrastructure with policies, declarative IaC, and shared modules, Terraform remains the correct tool. `ag-domains` (Phase 4.5) also does not replace Terraform: it orchestrates DNS and TLS for the domains declared in the project's `schema.ag`, it does not manage arbitrary DNS zones or shared infrastructure.
+- **Be a complete mail server.** `ag-mail` (Phase 4.5) sends outbound transactional mail (verification, recovery, magic links, alerts) via native SMTP or provider adapters (Resend, SES, Postmark). It is NOT an MTA, it does NOT receive mail (no IMAP/POP), it does NOT offer mailboxes, it does NOT implement antispam or IP reputation management. For inbound or a complete mail server, use Postfix, Stalwart, or another specialized project.
+- **Be a domain registrar.** `ag-domains` (Phase 4.5) consumes the domain that the operator already bought (Namecheap, Cloudflare Registrar, etc.) and configures it through an adapter (Cloudflare initially). It does NOT register domains, it does NOT act as a domain marketplace.
+- **Be a game engine, a scientific computing framework, or an alternative to Unreal Engine, Unity, NumPy, PyTorch, or TensorFlow.** These domains have specialized tools that Anti-Gravital does not intend to replicate.
+
+### 3.3 The interoperability rule
+
+When a dominant tool exists in an adjacent domain, the strategy is to integrate, not to replace. This rule prevents the project from growing in unmanageable directions and keeps the scope defensible.
+
+---
+
+## 4. Analysis of the state of the art
+
+This section documents the competitive context in technical terms, without adversarial rhetoric. Each framework analyzed solves a real set of problems; the analysis identifies the structural limitations that Anti-Gravital intends to address.
+
+### 4.1 Spring Boot and the JVM ecosystem
+
+Spring Boot dominates enterprise Java and Kotlin development with two decades of mature ecosystem. Its structural weaknesses derive from the JVM: a base memory consumption of 256-512 MB before serving the first request, startup times of 6-8 seconds incompatible with serverless computing, and configuration verbosity. GraalVM Native Image partially mitigates startup and memory, but introduces its own limitations (limited reflection, incomplete library compatibility, long compilation times). The fundamental trade-off — a managed runtime with GC — remains.
+
+### 4.2 ASP.NET Core and .NET
+
+Technically one of the fastest managed frameworks on the market, with modern and expressive C#. The CLR with GC keeps measurable pauses at p99 under sustained load. The technical direction of the ecosystem is unilaterally Microsoft's. Memory safety is not guaranteed by the compiler; race condition bugs and null reference exceptions are possible. Adoption outside the Microsoft ecosystem remains limited for cultural rather than technical reasons.
+
+### 4.3 Django and FastAPI
+
+Django maintains the best prototyping experience in the Python world, with a rich ecosystem for administration, authentication, and templates. FastAPI raised the DX standard for Python APIs with Pydantic types, automatic OpenAPI generation, and native async support. Both share the structural ceiling of CPython: the Global Interpreter Lock prevents real CPU-bound concurrency within a process, which forces scaling with multiple processes (Gunicorn, Uvicorn workers) multiplying memory consumption. Django's async support remains partial; many libraries in the ecosystem remain synchronous.
+
+### 4.4 Node.js, Express, and NestJS
+
+Node.js brought JavaScript to the server and the npm ecosystem is the broadest in the industry. V8's single-threaded event loop is optimal for concurrent I/O but degrades with any CPU-bound work. The npm supply chain is chronically vulnerable: the average transitive dependency of a modern Node.js project exceeds 200 libraries, and incidents of compromised packages are recurrent. TypeScript adds type safety in development, but at runtime it remains JavaScript.
+
+### 4.5 Next.js and the JS fullstack frameworks
+
+Next.js represents the frontend/backend convergence in JavaScript. Server Components and Server Actions reduce the boilerplate of internal APIs. The structural weaknesses are inherited from Node.js: serverless cold starts, de facto coupling with Vercel, inadequacy for persistent WebSockets, shared state, and long-running processing. Next.js is an excellent presentation layer; it is not a robust backend.
+
+### 4.6 Axum, Actix-Web, Rocket (Rust)
+
+The current Rust frameworks are technically excellent in performance (consistently in the TechEmpower top 10) but offer what the community calls a *low-level* experience: the developer builds authentication, the data layer, observability, client generation, and the migration system from scratch. Anti-Gravital is built on Axum, Tokio, and Tower as internal dependencies — it does not compete with them, but packages them into a complete framework experience with DSL, CLI, and opinionated modules.
+
+### 4.7 Conclusion of the analysis
+
+There is a real market space: a dominant enterprise-grade Rust framework does not yet exist. Spring Boot pays the historical cost of the JVM. Node.js has structural event loop limits. Python has concurrency problems. Go sacrifices the type system. Rust has runtime and performance, but lacks a complete framework experience. Anti-Gravital intends to fill that gap.
+
+---
+
+## 5. Ecosystem architecture: modules and responsibilities
+
+The most important architectural decision derived from the critical analysis of v3.0 was to separate the core from the ecosystems. The v3.0 tried to be simultaneously a backend framework, an SSR engine, a DevOps platform, an AI orchestrator, an observability layer, a mobile framework, and a plugin system. This is unmanageable. The v4.0 reorganizes the project as an ecosystem of independent Rust crates, each with its own domain, a responsible maintainer, independent semantic versioning, and a minimal API surface.
+
+### 5.1 Ecosystem map
+
+| Crate              | Domain                                                           | Criticality status |
+|--------------------|------------------------------------------------------------------|----------------------|
+| `ag-core`          | HTTP runtime, router, extractors, error types, Shield/Core       | Core                 |
+| `ag-dsl`           | Lexer, parser, AST, semantic analysis and codegen of the Anti-DSL | Core                |
+| `ag-cli`           | `ag` binary: new, generate, dev, build, deploy, migrate          | Core                 |
+| `ag-auth`          | WebAuthn, JWT Ed25519, OAuth2, RBAC, rate limiting               | Standard             |
+| `ag-data`          | sqlx with compile-time verification, migrations, typed ORM       | Standard             |
+| `ag-realtime`      | WebSocket, SSE, embedded NATS, pub/sub                           | Standard             |
+| `ag-cache`         | in-memory moka, Redis adapter, event-based invalidation          | Standard             |
+| `ag-storage`       | S3, MinIO, local filesystem, signed URLs, image processing       | Standard             |
+| `ag-observe`       | tracing, OpenTelemetry, Prometheus, Grafana dashboards           | Standard             |
+| `ag-mail`          | outbound SMTP, typed templates, send queues with retries, adapters (Resend/SES/Postmark), SPF/DKIM/DMARC helpers | Deferred standard |
+| `ag-ui`            | SSR with askama, selective hydration, HTMX integration           | Optional             |
+| `ag-cloud`         | Railway-like deployment orchestration, Dockerfile gen            | Optional             |
+| `ag-domains`       | DNS management via `DnsProvider` trait, adapters (Cloudflare), ACME certificates, deployment domains | Optional infra |
+| `ag-ai`            | Doc generation, schema suggestions, knowledge graph              | Optional             |
+| `ag-mobile`        | Dart SDK generation, native Flutter auth, offline sync           | Optional             |
+| `ag-migrate`       | OpenAPI, Prisma, Django, FastAPI, Sequelize importers            | Optional             |
+| `ag-wasm-host`     | WASI plugin runtime on wasmtime                                  | Core                 |
+
+The distinction between **core**, **standard**, **deferred standard**, and **optional** is important. The core is the minimal set that defines what Anti-Gravital is. The standard modules cover 90% of the production needs of any backend service and are installed by default in the official templates. A **deferred standard** module (introduced by `ADR-0007`) has the maturity and scope of a standard but is NOT installed by default in the templates: it is incorporated when the project explicitly needs it. `ag-mail` is a deferred standard because most backends end up sending transactional mail (verification, recovery, magic links via `ag-auth`), but not every project uses it from minute zero. The optional modules are added when the project needs them; `ag-domains` is an infrastructure optional (it is consumed by `ag-cloud` during deployment) and `ag-cloud -> ag-domains` is a dependency documented in section 5.3. The ecosystem reaches **17 crates** with the introduction of Phase 4.5.
+
+### 5.2 Ecosystem diagram
+
+```
+┌──────────────────────────────────────────────────────────────────┐
+│                       Anti-Gravital Ecosystem                    │
+├──────────────────────────────────────────────────────────────────┤
+│                                                                  │
+│   ┌───────────────────────┐    ┌───────────────────────┐         │
+│   │       ag-cli          │    │       ag-dsl          │         │
+│   │  new · generate · dev │◄──►│  lexer · parser · AST │         │
+│   │  build · deploy       │    │  semantic · codegen   │         │
+│   └───────────┬───────────┘    └───────────┬───────────┘         │
+│               │                            │                     │
+│               ▼                            ▼                     │
+│   ┌──────────────────────────────────────────────────┐           │
+│   │                    ag-core                       │           │
+│   │  Shield (Tower middleware) + Core (Axum router)  │           │
+│   │  Extractores · Error types · Runtime Tokio       │           │
+│   └────────┬───────────────────────┬─────────────────┘           │
+│            │                       │                             │
+│   ┌────────▼─────────┐    ┌────────▼─────────┐                   │
+│   │  Módulos estándar │    │ ag-wasm-host    │                   │
+│   │  ag-auth ────────►│    │ wasmtime + WASI │                   │
+│   │  ag-data         │    │ plugin lifecycle│                   │
+│   │  ag-realtime     │    └─────────────────┘                   │
+│   │  ag-cache        │                                          │
+│   │  ag-storage      │                                          │
+│   │  ag-observe      │                                          │
+│   └────────┬─────────┘                                          │
+│            │                                                    │
+│   ┌────────▼─────────────────┐                                  │
+│   │  Estándar diferido       │                                  │
+│   │  ag-mail (◄── ag-auth)   │ ──► cooperación SPF/DKIM/DMARC   │
+│   │  outbound + adapters     │                                  │
+│   │  (Resend/SES/Postmark)   │                                  │
+│   └────────┬─────────────────┘                                  │
+│            │                                                    │
+│   ┌────────▼──────────────────────────────────────────┐         │
+│   │              Módulos opcionales                   │         │
+│   │  ag-ui    ag-cloud ─► ag-domains    ag-ai         │         │
+│   │  ag-mobile    ag-migrate                          │         │
+│   │                                                   │         │
+│   │  ag-domains: DnsProvider + ACME + adapters        │         │
+│   └───────────────────────────────────────────────────┘         │
+└─────────────────────────────────────────────────────────────────┘
+```
+
+### 5.3 Dependency rules between crates
+
+To keep the ecosystem healthy, strict dependency rules apply:
+
+First rule: `ag-core` does not depend on any other crate of the Anti-Gravital ecosystem. It is the base on which everything else is built. Any functionality considered sufficiently generic that needs another module must be extracted to `ag-core` or turned into a trait that the module implements.
+
+Second rule: the standard modules can depend on `ag-core` and on other standard modules as long as there are no cycles. For example, `ag-auth` can depend on `ag-data` for session persistence, but `ag-data` cannot depend on `ag-auth`.
+
+Third rule: the optional modules can depend on any core or standard crate. They cannot depend on each other except in explicitly justified cases (for example, `ag-mobile` can depend on `ag-ai` for assisted code generation).
+
+Fourth rule: `ag-cli` depends on all the other crates (it is the orchestrator), but only through Cargo features, so that the `ag` binary can be compiled with a reduced subset.
+
+Fifth rule: all crates publish independent semantic versions. A breaking change in `ag-cache` does not force `ag-core` to bump major. This is essential for the sustainability of an open source project.
+
+Sixth rule (introduced by `ADR-0007`, Phase 4.5): the direction of the `ag-auth <-> ag-mail` dependency is strictly unidirectional. `ag-auth` **consumes** `ag-mail` to send verification, password recovery, and magic link emails, defining a small trait that `ag-auth` invokes. `ag-mail` does **NOT** depend on `ag-auth`. This directionality preserves the second rule (no cycles) and keeps `ag-mail` reusable in isolation in any Rust project. The `ag-mail <-> ag-domains` cooperation (to materialize SPF/DKIM/DMARC) is optional, via a Cargo feature: if a project uses `ag-mail` with a managed adapter (Resend) and does not administer its own DNS, `ag-domains` is not necessary.
+
+Seventh rule (introduced by `ADR-0007`, Phase 4.5): the optional module `ag-cloud` **consumes** `ag-domains` during `ag deploy` to configure DNS and TLS, without the dependency being rigid in all targets. If the project does not declare domains in its `schema.ag`, the flow is omitted. `ag-domains` can be used independently from the CLI without `ag-cloud`.
+
+### 5.4 Monorepo structure
+
+```
+anti-gravital/
+├── Cargo.toml                  # Workspace root
+├── LICENSE                     # Apache 2.0
+├── README.md                   # Español + Inglés
+├── CONTRIBUTING.md
+├── CODE_OF_CONDUCT.md
+├── SECURITY.md                 # Política de divulgación responsable
+├── crates/
+│   ├── ag-core/
+│   │   ├── Cargo.toml
+│   │   └── src/
+│   │       ├── lib.rs
+│   │       ├── shield/         # Middleware Tower
+│   │       │   ├── tls.rs
+│   │       │   ├── auth.rs
+│   │       │   ├── rate_limit.rs
+│   │       │   ├── validation.rs
+│   │       │   ├── rbac.rs
+│   │       │   └── cors.rs
+│   │       ├── core/           # Router y handlers
+│   │       │   ├── router.rs
+│   │       │   ├── extractors.rs
+│   │       │   ├── error.rs
+│   │       │   └── state.rs
+│   │       └── runtime/        # Configuración Tokio
+│   │           └── mod.rs
+│   ├── ag-dsl/
+│   │   └── src/
+│   │       ├── lexer.rs
+│   │       ├── parser.rs
+│   │       ├── ast.rs
+│   │       ├── semantic.rs
+│   │       ├── diagnostics.rs
+│   │       └── codegen/
+│   │           ├── rust_gen.rs
+│   │           ├── ts_gen.rs
+│   │           ├── dart_gen.rs
+│   │           ├── openapi_gen.rs
+│   │           └── sql_gen.rs
+│   ├── ag-cli/
+│   ├── ag-auth/
+│   ├── ag-data/
+│   ├── ag-realtime/
+│   ├── ag-cache/
+│   ├── ag-storage/
+│   ├── ag-observe/
+│   ├── ag-mail/                # Fase 4.5 — estándar diferido
+│   ├── ag-ui/
+│   ├── ag-cloud/
+│   ├── ag-domains/             # Fase 4.5 — opcional infra
+│   ├── ag-ai/
+│   ├── ag-mobile/
+│   ├── ag-migrate/
+│   └── ag-wasm-host/
+├── docs/                       # Documentación bilingüe
+│   ├── es/
+│   └── en/
+├── examples/
+│   ├── todo-api/
+│   ├── ecommerce-api/
+│   ├── realtime-chat/
+│   ├── ai-backend/
+│   └── flutter-fullstack/
+├── templates/                  # Templates de `ag new`
+│   ├── rest/
+│   ├── realtime/
+│   ├── fullstack/
+│   └── mobile-backend/
+├── plugins/                    # Plugins WASM oficiales
+│   ├── prometheus-exporter/
+│   ├── datadog-exporter/
+│   └── sentry/
+└── benchmarks/                 # Suite TechEmpower + comparaciones
+    ├── hello-world/
+    ├── json-crud/
+    └── plaintext/
+```
+
+---
+
+## 6. Core architecture (`ag-core`): Shield and Core
+
+The core of Anti-Gravital is organized into two conceptual layers within a single Rust process. The separation is not physical: there is no IPC, no FFI, no shared memory between runtimes. The two layers communicate through ordinary Rust function calls, with zero measurable overhead. The separation is logical and exists for two reasons: architectural clarity for the developer, and the future possibility of extracting the Shield as an independent gateway if a use case justifies it.
+
+### 6.1 Core diagram
+
+```
+┌─────────────────────────────────────────────────────────────┐
+│                  ag-core · Single Process                   │
+├─────────────────────────────────────────────────────────────┤
+│                                                             │
+│   ┌─────────────────────────────────────────────────┐       │
+│   │            CAPA A — The Shield                  │       │
+│   │  (Tower middleware composable pipeline)         │       │
+│   │                                                 │       │
+│   │   ┌─────────┐  ┌─────────┐  ┌─────────────┐     │       │
+│   │   │ TLS 1.3 │─►│   JWT   │─►│ Rate Limit  │     │       │
+│   │   │ rustls  │  │ Ed25519 │  │  governor   │     │       │
+│   │   └─────────┘  └─────────┘  └──────┬──────┘     │       │
+│   │                                    │            │       │
+│   │   ┌─────────┐  ┌─────────┐  ┌──────▼──────┐     │       │
+│   │   │  CORS   │◄─│  RBAC   │◄─│ Validación  │     │       │
+│   │   │  CSRF   │  │ Guards  │  │  Schema     │     │       │
+│   │   └─────────┘  └─────────┘  └─────────────┘     │       │
+│   └─────────────────────┬───────────────────────────┘       │
+│                         │                                   │
+│              Llamada de función Rust (0ns)                  │
+│                         ▼                                   │
+│   ┌─────────────────────────────────────────────────┐       │
+│   │            CAPA B — The Core                    │       │
+│   │  (Axum router · Handlers · Estado)              │       │
+│   │                                                 │       │
+│   │   ┌────────────┐   ┌─────────────────────┐      │       │
+│   │   │  Router    │   │  Business handlers  │      │       │
+│   │   │  Axum      │──►│  (generados por DSL)│      │       │
+│   │   └────────────┘   └──────────┬──────────┘      │       │
+│   │                               │                 │       │
+│   │   ┌────────────┐   ┌──────────▼──────────┐      │       │
+│   │   │ Extractores│   │  Estado compartido  │      │       │
+│   │   │  tipados   │   │  AppState           │      │       │
+│   │   └────────────┘   └─────────────────────┘      │       │
+│   └─────────────────────────────────────────────────┘       │
+│                                                             │
+└─────────────────────────────────────────────────────────────┘
+                            │
+                  cargo build --release
+                            ▼
+                ┌────────────────────────┐
+                │  Single Static Binary  │
+                │  FROM scratch Docker   │
+                └────────────────────────┘
+```
+
+### 6.2 The Shield: the trust layer
+
+The Shield is responsible for everything that happens before a request is considered trusted and delivered to the business code. It is implemented as a pipeline of Tower layers, the same composable model that Axum uses internally. Each layer is optional and is configured from the project's `schema.ag`.
+
+The technical stack of the Shield is: Tokio as the M:N async runtime (it multiplexes millions of tasks over a fixed thread pool of size equal to available CPUs), Tower as the composable middleware model, rustls for TLS 1.3 without an OpenSSL dependency, serde and serde_json for zero-copy serialization where possible, ring for low-level cryptographic primitives, governor for rate limiting with a lock-free token bucket algorithm.
+
+The standard layers of the Shield, in execution order over an incoming request:
+
+The first layer is TLS termination, managed by rustls. It supports TLS 1.3 with modern cipher suites, OCSP stapling, and ALPN for HTTP/1.1 vs HTTP/2 negotiation. For environments where TLS termination is performed by an external load balancer (Cloudflare, AWS ALB, Nginx), this layer is disabled with an option in the schema.
+
+The second layer is payload deserialization and validation. For requests with a body, the contract defined in the `.ag` is applied: types, length constraints, email format, regex, numeric ranges. A violation produces a 422 error with structured detail about which field failed and why.
+
+The third layer is authentication. It supports JWT signed with Ed25519 (Edwards25519 curve, faster and more secure than RS256), Passkeys/WebAuthn (FIDO2), API keys, and cookie-based sessions. Verification is eager for endpoints marked as `auth required`.
+
+The fourth layer is rate limiting. Implemented with governor over a token bucket algorithm, it supports limits per IP, per authenticated user, per endpoint, and per combinations. The limits are declared in the schema.
+
+The fifth layer is RBAC authorization. The policies are declared in the `.ag` as expressions that are evaluated against the JWT claims and the request parameters. For example: `policy "user.role == ADMIN || user.id == params.id"`.
+
+The sixth layer is CORS and CSRF. Configured by default with secure values (no wildcard); any deviation requires explicit declaration.
+
+### 6.3 The Core: the business logic layer
+
+The Core is where 80% of the application code that the developer writes lives. It is Axum with a thin layer of conventions on top.
+
+The handlers have a signature generated by the DSL compiler from the declared endpoint:
+
+```rust
+// Generado automáticamente por `ag generate` desde schema.ag
+// El desarrollador solo escribe el cuerpo del handler.
+pub async fn create_user(
+    State(state): State<AppState>,
+    ValidatedBody(req): ValidatedBody<CreateUserRequest>,
+    Claims(claims): Claims<AuthClaims>,
+) -> Result<Json<User>, AgError> {
+    // El desarrollador solo escribe esto:
+    let user = state.db.users()
+        .create(CreateUserParams {
+            email: req.email,
+            name: req.name,
+            created_by: claims.user_id,
+        })
+        .await?;
+
+    state.events.emit("user.created", &user).await?;
+    Ok(Json(user))
+}
+```
+
+The type `ValidatedBody<T>` guarantees that the body already passed the Shield's validation. The type `Claims<T>` guarantees that the JWT was already verified. The type `AgError` is an enum that covers all the errors declared in the endpoint, and the conversion to an HTTP response is automatic via `IntoResponse`.
+
+The application state (`AppState`) is a generated struct that contains clients to the project's resources: the database pool, the NATS client, the Redis client, the S3 client. It is built at binary startup and shared by reference (cheap `Arc` clones) among all handlers.
+
+### 6.4 Error handling
+
+The Anti-Gravital error system follows three principles. The first: each endpoint explicitly declares which errors it can produce in its `.ag` definition. This produces a typed `EndpointError` enum in which each variant is a specific error. The second: errors propagate with Rust's `?` operator, and the conversion to an HTTP response is automatic and consistent. The third: no error is silently discarded. Unexpected errors produce a structured 500 with a correlation ID that is linked to the stack trace in the tracing system.
+
+### 6.5 Runtime and Tokio configuration
+
+Anti-Gravital uses Tokio in multi-thread mode with default configuration: one worker per available CPU, a blocking pool of 512 threads. For standard IO-bound workloads this configuration is optimal. The schema allows adjustments:
+
+```yaml
+runtime:
+  workers: auto              # Por defecto = núm CPUs
+  blocking_threads: 512
+  thread_stack: 2MB
+  shutdown_timeout: 30s
+```
+
+---
+
+## 7. The Anti-DSL language (`ag-dsl`): specification and incremental implementation
+
+The DSL compiler is, together with the runtime, the technically most demanding component of the project. It is essentially a complete compiler: lexer, parser, semantic analysis, type system, code generation to multiple targets, formatter, linter, and LSP server. This section defines the language specification and the incremental implementation strategy.
+
+### 7.1 Language philosophy
+
+The Anti-DSL is declarative, not imperative. It describes contracts, not flows. The premise is that most of the value of a backend framework resides in the consistency of its external contract: which models exist, which endpoints expose them, which rules apply, which errors are returned. The internal logic stays in pure Rust.
+
+The language draws inspiration from Prisma for the model syntax, from GraphQL SDL for the clarity of definitions, from sqlc for the integration with SQL, and from protobuf for the multi-target codegen. It is not a Turing-complete language and does not intend to be.
+
+### 7.2 Incremental implementation by DSL versions
+
+Probably the most important decision for making the compiler viable is to admit that the complete language cannot be delivered in the first version. The specification is delivered in incremental phases, each with a stable grammar that does not break the previous one. The DSL versions are independent of the framework versions and follow their own semver.
+
+| DSL version | Grammatical capability                                                                                              | Milestone                  |
+|-------------|-------------------------------------------------------------------------------------------------------------------|----------------------------|
+| v0.1        | Basic models: fields, primitive types, annotations `@primary`, `@unique`, `@auto`                                  | End of Phase 3 (delivered) |
+| v0.2        | Endpoints: method, path, body, response, errors                                                                    | End of Phase 3 (delivered) |
+| v0.3        | Validations: `@min`, `@max`, `@email`, `@regex`, `@length`                                                         | End of Phase 3 (delivered) |
+| v0.4        | Relationships between models: `1:1`, `1:N`, `N:M`, cascades                                                        | End of Phase 3 (delivered) |
+| v0.5        | Authentication and authorization: `auth required`, `policy "..."`                                                  | End of Phase 4 (delivered) |
+| v0.6        | Events: declaration of events emitted per endpoint, subscribers                                                    | End of Phase 4 (delivered) |
+| v0.7        | Mail and declarative domains: `mail`, `domain`, `dns`, `tls`                                                       | End of Phase 4.5           |
+| v0.8        | Plugin hooks (lifecycle, decorators)                                                                               | End of Phase 9             |
+| v1.0        | Stable grammar, frozen under semver. Any subsequent extension will be additive.                                    | End of Phase 10            |
+
+This table is realigned by `ADR-0007` (Phase 4.5). The multi-tenancy and data migration capabilities planned for intermediate versions of the DSL in earlier revisions are deferred: they will be specified in their own RFCs when the scope justifies it, without occupying a fixed numbered slot until then. This avoids promising features that do not have verified traction.
+
+### 7.3 Complete schema example (v1.0 target)
+
+```ag
+# schema.ag — Ejemplo completo objetivo de la v1.0
+
+config {
+    project_name "fintech-api"
+    database "postgres"
+    runtime { workers auto, blocking_threads 512 }
+}
+
+enum UserRole {
+    ADMIN
+    USER
+    BANNED
+}
+
+model User {
+    id           UUID       @primary @auto
+    email        String     @unique @max(255) @email
+    password_hash String    @max(255)
+    name         String     @max(100) @min(2)
+    role         UserRole   @default(USER)
+    created      Timestamp  @auto
+    updated      Timestamp  @auto_update
+
+    accounts     Account[]  @relation(name: "owner")
+}
+
+model Account {
+    id        UUID      @primary @auto
+    owner_id  UUID      @references(User.id) @on_delete(cascade)
+    balance   Decimal   @precision(18,2) @default(0)
+    currency  String    @length(3)
+    created   Timestamp @auto
+}
+
+request CreateUserRequest {
+    email     String @email
+    password  String @min(12) @max(128)
+    name      String @min(2) @max(100)
+}
+
+response UserResponse {
+    id        UUID
+    email     String
+    name      String
+    role      UserRole
+    created   Timestamp
+}
+
+error EmailTaken      { status 409 message "Email already registered" }
+error WeakPassword    { status 422 message "Password does not meet policy" }
+error InsufficientFunds { status 402 message "Insufficient balance" }
+
+endpoint CreateUser {
+    method   POST
+    path     /users
+    auth     optional
+    body     CreateUserRequest
+    response UserResponse
+    errors   [EmailTaken, WeakPassword]
+    events   [user.created]
+    rate_limit "5/min per_ip"
+}
+
+endpoint TransferFunds {
+    method   POST
+    path     /accounts/{from}/transfer
+    auth     required
+    policy   "user.id == params.from.owner_id"
+    body     TransferRequest
+    response TransferReceipt
+    errors   [InsufficientFunds]
+    events   [account.debited, account.credited, transfer.completed]
+    rate_limit "10/min per_user"
+}
+
+event user.created {
+    payload UserResponse
+    retain  30d
+}
+
+event account.debited {
+    payload AccountDelta
+    retain  7y
+}
+```
+
+### 7.4 Artifacts generated from a single schema
+
+A single `schema.ag` produces, via `ag generate`:
+
+| Artifact                           | Path                                | Purpose                                      |
+|------------------------------------|-------------------------------------|----------------------------------------------|
+| Rust structs with serde and validators | `src/models.rs`                 | Domain types                                 |
+| Typed handler stubs                | `src/handlers/*.rs`                 | Ready signatures; the dev writes the body    |
+| Compile-time checked sqlx queries  | `src/db/queries.rs`                 | Type-safe database access                    |
+| Versioned SQL migrations           | `migrations/NNNN_*.sql`             | Database schema                              |
+| TypeScript types                   | `clients/typescript/types.ts`       | Types shared with the frontend               |
+| TypeScript HTTP client             | `clients/typescript/client.ts`      | Typed SDK for the frontend                   |
+| Dart types                         | `clients/dart/lib/types.dart`       | Types shared with Flutter applications       |
+| Dart client with Dio               | `clients/dart/lib/client.dart`      | Typed SDK for Flutter                        |
+| OpenAPI 3.1 documentation          | `openapi.yaml`                      | Interactive documentation (Swagger UI)       |
+| AsyncAPI specification             | `asyncapi.yaml`                     | Event documentation                          |
+| JSON knowledge graph               | `.ag/knowledge-graph.json`          | Input for `ag-ai` and dashboards             |
+
+### 7.5 Compiler architecture
+
+The DSL compiler is organized in a traditional pipeline with well-defined stages:
+
+The **lexer** phase tokenizes the `.ag` input. It is implemented with `logos` (a Rust crate that generates tokenizers from declarative definitions with derive macros). It produces a stream of positional tokens for error reporting with lines and columns.
+
+The **parser** phase consumes tokens and produces an AST. It is implemented with `chumsky` (a parser combinator library with error recovery support), chosen over `nom` for its better handling of error messages readable by the end user.
+
+The **semantic analysis** phase validates the AST: it checks that the references between models exist, that the types are consistent, that the RBAC policies refer to valid fields, that there are no cycles in the relationships, that the names do not collide with reserved words of Rust or SQL. It produces structured diagnostics with suggestions.
+
+The **codegen** phase takes the validated AST and emits code to multiple targets. Each target (Rust, TypeScript, Dart, OpenAPI, SQL) is an independent module. The emission is done with `askama` templates for the textual outputs and with `quote` for the Rust code (which benefits from having a native Rust AST for emission).
+
+### 7.6 Language server (LSP)
+
+From version 0.3 of the DSL, an LSP server is included that offers autocompletion, live diagnostics, go-to-definition, find-references, hover types, and rename. It is distributed as an `ag-lsp` binary and integrates with any editor compatible with the protocol (VS Code, Neovim, Helix, Zed, IntelliJ via plugin).
+
+The official plugin for VS Code is published in the marketplace under the name `Anti-Gravital`.
+
+### 7.7 DSL tooling
+
+The CLI offers three specific commands for the DSL:
+
+`ag schema lint` reviews the `.ag` file and reports warnings about bad practices (models without indexes on foreign key fields, endpoints without rate limit, tautological policies, unhandled errors).
+
+`ag schema diff <ref>` compares the current schema against a reference (git commit, tag, file) and reports breaking vs non-breaking changes. Essential for pull request reviews.
+
+`ag schema migrate` generates the SQL migration needed to bring the database from the current state to the schema state. It includes a safety analysis: it detects destructive operations (drop column, drop table) and demands explicit confirmation.
+
+---
+
+## 8. Batteries-included modules
+
+This section specifies each of the standard modules of the ecosystem. Each subsection documents the purpose, the technical stack, the design decisions, and the extension points.
+
+### 8.1 `ag-auth` — Authentication and authorization
+
+The authentication module implements the modern identity schemes. The central architectural decision is to support Passkeys/WebAuthn as first-class, not as an afterthought; passwords are a legacy mechanism that is supported but not recommended.
+
+The technical stack implemented is custom WebAuthn with `ciborium` (CBOR) and COSE verification (`p256` for ES256, `ed25519-dalek` for EdDSA) instead of `webauthn-rs`, for Apache-2.0 license compatibility (see `ADR-0006`); `jsonwebtoken` for JWT, `argon2` for password hashing (when used), and `oauth2` as the OAuth2 client (Google, GitHub) with the PKCE flow.
+
+The supported flows are: registration and authentication with passkey, authentication with email + password (legacy), OAuth2 with preconfigured providers (Google, GitHub, Microsoft, Gravital ID), API keys for server-to-server integrations, and refresh tokens with rotation.
+
+JWTs are signed with Ed25519 by default (Edwards25519 curve, faster than RSA and more secure than ECDSA-P256 against side-channel attacks). The private key lives in an external secret manager (HashiCorp Vault, AWS Secrets Manager, GCP Secret Manager) or in environment variables with documented rotation.
+
+The RBAC is declared in the schema and compiled to evaluable expressions. The policy is evaluated once per request in the Shield, before reaching the handler. Policies can reference JWT claims, path parameters, and query the database if explicitly declared (with caching to avoid the N+1).
+
+### 8.2 `ag-data` — Data access and migrations
+
+The data module is built on sqlx, with compile-time verification of SQL queries. This means that when `cargo build` runs, sqlx connects to a development database (configurable by environment variable) and verifies that each query is syntactically valid and that the types of the returned columns match the Rust structs that receive them. A SQL error ceases to be a runtime error; it becomes a compile error.
+
+The supported backends are PostgreSQL (recommended for production), SQLite (for development, tests, and edge applications), and MySQL (for legacy environments).
+
+Migrations are embedded in the binary with `sqlx::migrate!`. This means that the binary itself contains the complete history of migrations, and at startup it can automatically apply the pending ones. For environments where this is not desirable (blue-green deployments with migration as a separate step), the `ag migrate apply` command runs the migrations without bringing up the server.
+
+For multi-tenant architectures, `ag-data` natively supports schema-per-tenant in PostgreSQL: each tenant has its own schema with the same tables, and the connection router selects the schema based on the JWT claim. It also supports Row-Level Security (RLS) for cases where schema isolation is excessive.
+
+Read replicas are configured declaratively; the module routes read-only queries to the nearest replica and write queries to the primary.
+
+### 8.3 `ag-realtime` — Events and real-time communication
+
+`ag-realtime` offers three modalities of bidirectional communication: binary WebSocket, Server-Sent Events for unidirectional streams, and a pub/sub event bus.
+
+The event bus uses NATS as the broker. For small cases, NATS runs embedded in the same Anti-Gravital binary (edge mode). For cases at scale, the binary connects to an external NATS cluster. This duality allows starting simple and scaling without rewriting.
+
+For WebSocket, the internal binary protocol (based on msgpack) reduces the overhead compared to JSON. The WebSocket handlers are declared in the schema and receive messages already deserialized to Rust structs.
+
+For SSE, it is used as an automatic fallback in browsers that do not support WebSocket or are behind proxies that block it. The negotiation is transparent.
+
+Event persistence uses JetStream (a component of NATS) when available, which allows event replay for new consumers and durability against broker crashes.
+
+### 8.4 `ag-cache` — Multi-level cache
+
+The cache module offers two levels. The L1 level, already implemented, is an in-memory cache with `moka`, a concurrent implementation without contended locks based on TinyLFU, with tag-based invalidation. The L2 level (distributed cache between instances) is not yet implemented: `RFC-0005` proposes a native L2 compatible with the RESP2 protocol, without a dependency on Redis as an external service, and remains pending approval and implementation.
+
+Invalidation is done by events. When an endpoint emits an event (`user.updated`), `ag-cache` automatically invalidates the related entries at both levels. The invalidation policy is declared in the schema.
+
+The SQL query cache is automatic: queries marked with `@cache(ttl: 5m)` in the schema are cached transparently, and invalidation is triggered when an event touches any of the involved tables.
+
+### 8.5 `ag-storage` — Object storage
+
+`ag-storage` offers an abstraction over three backends: S3 (AWS and compatibles), MinIO (self-hosted), and local filesystem (for development). The backend is selected by configuration; the application code does not notice.
+
+Signed URLs for download and direct upload are generated with a single call: `storage.signed_url(key, Duration::from_mins(15), Permission::Write)`.
+
+Image processing (resize, compress, format conversion) is done with the `image` crate, supporting JPEG, PNG, WebP, and AVIF. Thumbnails are generated automatically on upload if the policy is declared in the schema.
+
+### 8.6 `ag-observe` — Traceability, metrics, and logging
+
+Observability is a first-level concern and not an optional module for production. Its stack is `tracing` for structured spans, `opentelemetry-rust` for export to compatible backends (Jaeger, Tempo, Datadog, Honeycomb), `metrics` for metrics with a Prometheus backend, and pre-configured Grafana dashboards that are included as JSON in the repository.
+
+Each request traverses the whole system with a unique correlation ID that appears in all structured logs, all tracing spans, and all errors returned to the client. This solves the problem of debugging in production: given a support ticket with a correlation ID, the operator can reconstruct the complete path of the request.
+
+`tokio-console` is integrated in development mode for live inspection of the Tokio tasks.
+
+### 8.7 `ag-ui` — Optional Server-Side Rendering
+
+The SSR module exists for cases where a SPA frontend is excessive: internal dashboards, marketing pages, simple forms, and administrative interfaces. It is based on `askama` (build-time compiled templating, with verified types) and native integration with HTMX for interactivity without heavy JavaScript frameworks.
+
+This module is explicitly *not* a competitor of React, Vue, Svelte, or Next.js. For SPA or rich SSR applications, the recommended pattern is Anti-Gravital as backend with a Next.js (or other) frontend that consumes the generated TypeScript client.
+
+### 8.8 `ag-mail` — Transactional communication (deferred standard)
+
+Introduced by `ADR-0007` in Phase 4.5. `ag-mail` is a **deferred** standard module: it has the maturity and scope of a standard, but is NOT installed by default in the official templates. It is incorporated when the project requires outbound transactional mail (account verification, magic links, password recovery, alerts, notifications).
+
+The v1 scope is **exclusively outbound**. `ag-mail` is NOT an MTA, it does NOT receive mail (no IMAP/POP), it does NOT offer persistent mailboxes, it does NOT implement antispam, filtering, or IP reputation management. This restriction is deliberate and is fixed in the ADR: the inbound and complete mail server capabilities are the work of a different project, not of Anti-Gravital.
+
+The technical stack is `lettre` with async Tokio transport and `rustls` for the native SMTP sender (coherent with The Shield). The provider adapters are declared as Cargo features (`--features resend,ses,postmark`) and each one implements the same `MailSender` trait:
+
+```rust
+#[async_trait::async_trait]
+pub trait MailSender: Send + Sync {
+    async fn send(&self, msg: &Email) -> Result<MessageId, AgMailError>;
+    fn provider_name(&self) -> &'static str;
+    fn dns_requirements(&self, domain: &str) -> Vec<DnsRecordSpec>;
+}
+
+pub enum AgMail {
+    Native(SmtpSender),                // lettre + rustls
+    Adapter(Box<dyn MailSender>),      // Resend, SES, Postmark, ...
+}
+```
+
+The Native | Adapter pattern is identical to the one used by `ag-storage` (`Native | S3`) and to the one planned for the L2 of `ag-cache` (L1 `moka` native today; L2 RESP2 native proposed in `RFC-0005`), reinforcing the project's interoperability rule: integrate dominant providers, do not replace them.
+
+The **templates** are modeled with the `MailTemplate` trait and a `StringTemplate` implementation of `{{var}}` substitution; any external engine (askama, minijinja) can be plugged in by implementing the trait. Variable validation is done against the `schema.ag`: the DSL compiler emits a warning when the `from` of a `mail` block does not reference a declared `domain`, and verifies that the typed `vars` of the template match the markers used. A malformed email ceases to be a runtime bug and approaches a build-detectable error. This is the **real differentiator** versus Resend, not deliverability: deliverability is the provider's job; the correctness of the contract is the framework's job.
+
+The **async queue** accepts jobs with retries and exponential backoff. Default backend in memory (Tokio task + channel). Optional persistent backend via `ag-data` (jobs table) to survive restarts. Optional integration with `ag-realtime` for event fan-out. Each job emits metrics towards `ag-observe`: `ag_mail_sent_total`, `ag_mail_failed_total`, `ag_mail_retry_total`, latency histogram.
+
+The **integration with `ag-auth`** is strictly unidirectional: `ag-auth` consumes `ag-mail` by invoking a small trait that `ag-auth` defines. `ag-mail` does NOT know about `ag-auth`. The sixth rule of section 5.3 documents this directionality.
+
+`mail` block of DSL v0.7 (example):
+
+```ag
+mail WelcomeEmail {
+    from "hello@plenty.market"      # debe referenciar un bloque domain
+    subject "Welcome to Plenty"
+    template "emails/welcome.html"  # debe existir
+    vars {
+        name String
+        activation_url String        # debe usarse en el HTML
+    }
+}
+```
+
+### 8.9 `ag-domains` — Domain and TLS management (optional infra)
+
+Introduced by `ADR-0007` in Phase 4.5. `ag-domains` is an **infrastructure optional** module: not every backend administers DNS (many deploy behind a proxy or PaaS that already resolves it), but when a project wants `ag deploy` to deliver a URL `https://miapi.example.com` with a valid certificate in a single command, `ag-domains` is the responsible module.
+
+The module is **NOT a domain registrar**: the domain is bought externally (Namecheap, Cloudflare Registrar, etc.) and delegated via nameservers to the configured provider. `ag-domains` also does not replace Terraform or Pulumi: for complex multi-cloud infrastructure or centralized management of arbitrary DNS zones, the project should use the dominant tools. The boundary is fixed in the ADR.
+
+The core of the module is the `DnsProvider` trait:
+
+```rust
+#[async_trait::async_trait]
+pub trait DnsProvider: Send + Sync {
+    async fn list_records(&self, zone: &str) -> Result<Vec<DnsRecord>, AgDomainsError>;
+    async fn upsert_record(&self, zone: &str, record: &DnsRecord) -> Result<(), AgDomainsError>;
+    async fn delete_record(&self, zone: &str, id: &str) -> Result<(), AgDomainsError>;
+    fn provider_name(&self) -> &'static str;
+}
+```
+
+Small, versioned, with **contract tests** that every adapter must pass. The initial adapter is Cloudflare (authentication by API token). The trait is designed to add Route53, Namecheap, DigitalOcean, etc. in later iterations without touching the public surface.
+
+The **ACME client** (`instant-acme`) issues and renews Let's Encrypt certificates. It supports the DNS-01 challenge (preferred, uses the `DnsProvider` itself to create the required TXT) and HTTP-01 (alternative). The renewal runs as a background Tokio task, watching expiration and renewing before the configured threshold. Certificate storage is filesystem by default, or optional `ag-storage`.
+
+The cooperation with `ag-mail` materializes in `generate_mail_records`: `ag-mail` declares its requirements via `MailSender::dns_requirements` and `ag-domains` materializes them as records (SPF, DKIM, DMARC). This is a **cooperation** relationship, not a control one: `ag-mail` does not depend on `ag-domains`; a project can use `ag-mail` with a managed adapter (Resend) without `ag-domains` participating.
+
+The **propagation verification** uses `hickory-resolver` to query multiple public resolvers and confirm that the records propagated before marking an operation as successful. This blocks `ag deploy` until the domain responds, avoiding delivering URLs that the operator promised but that do not resolve yet.
+
+`domain` block of DSL v0.7 (example):
+
+```ag
+domain plenty.market {
+    provider "cloudflare"
+    tls { mode auto  acme true }
+    dns {
+        CNAME "api"     -> "ag-cloud-target"
+        TXT   "_dmarc"  -> "v=DMARC1; p=quarantine"
+    }
+    mail { spf auto  dkim auto  dmarc quarantine }
+}
+```
+
+
+---
+
+## 9. WASI plugin system (`ag-wasm-host`)
+
+The extensibility of Anti-Gravital is built on the WebAssembly System Interface (WASI), not on the ecosystem of native Rust crates. This decision has three reasons that make it non-negotiable.
+
+The first reason is security. Plugins are third-party code that the server operator runs. If they were native code, a malicious or defective plugin could corrupt the process memory, escape to arbitrary syscalls, or leak secrets. WASI modules run in a sandbox with explicit permissions declared in the plugin manifest; the plugin cannot access the filesystem, the network, or syscalls that are not declared.
+
+The second reason is multi-language. A WASI plugin can be written in Rust, Go (TinyGo), C, C++, AssemblyScript, Zig, or any language that compiles to WebAssembly. This democratizes the ecosystem: a security expert who writes in Go can contribute an exporter for Datadog without having to learn Rust.
+
+The third reason is ABI stability. The interface between the host and the plugin is defined with `wit-bindgen` and the Component Model, which allows a plugin compiled for one version of Anti-Gravital to keep working with future versions without recompilation, as long as the ABI does not change.
+
+### 9.1 Plugin runtime
+
+The runtime is `wasmtime`, embedded as a Rust crate. Each plugin is loaded into an isolated store with memory limits (256 MB by default, configurable), fuel limits (instruction consumption), and execution timeout.
+
+### 9.2 Plugin lifecycle
+
+The lifecycle of a plugin has five states. The first is **discovered**: the `.wasm` file is in the project's plugins directory and appears in the manifest. The second is **validated**: the host inspects the binary, verifies that the component model is compatible, reads the manifest, and confirms that the requested permissions are authorized. The third is **loaded**: the module is compiled ahead-of-time with Cranelift and stored in memory. The fourth is **active**: the plugin receives events and responds to invocations. The fifth is **unloaded**: the plugin is released, whether by server shutdown or by dynamic reload.
+
+### 9.3 Plugin manifest
+
+Each plugin brings a `plugin.toml` file with its metadata and requested permissions:
+
+```toml
+[plugin]
+name = "datadog-exporter"
+version = "1.2.0"
+author = "Gravital Labs"
+license = "Apache-2.0"
+description = "Exports metrics and traces to Datadog"
+
+[abi]
+anti_gravital_version = ">= 1.0.0, < 2.0.0"
+component_model = "0.5"
+
+[permissions]
+network = ["api.datadoghq.com:443", "api.datadoghq.eu:443"]
+env = ["DD_API_KEY", "DD_SITE"]
+filesystem = []
+clock = "read"
+
+[capabilities]
+exports = ["metrics_exporter", "trace_exporter"]
+imports = ["host_logger", "host_clock"]
+
+[limits]
+max_memory = "64MB"
+max_execution_time = "5s"
+fuel = 100_000_000
+```
+
+### 9.4 Host API exposed to plugins
+
+The host exposes a reduced set of capabilities to plugins, defined in WIT (WebAssembly Interface Types) interfaces. The main ones are: logger (write messages to the host's tracing system), clock (get the current time and measure intervals), metrics (register additional metrics), KV (persistent key-value storage per plugin), HTTP client (with an allowlist of hosts from the manifest), and events (subscription to the internal bus).
+
+### 9.5 Framework extension points
+
+Plugins can extend Anti-Gravital at five points: additional middleware in the Shield (request hooks), custom handlers registered in the router, observability exporters (metrics, traces, logs), event processors (subscribers to the internal bus), and custom CLI commands (`ag <plugin-cmd>`).
+
+### 9.6 Official plugins
+
+The repository maintains a set of official plugins under `plugins/`, each with its own crate and release cycle: `prometheus-exporter`, `datadog-exporter`, `sentry`, `honeycomb-exporter`, `slack-notifier`, `discord-webhook`. The existence of official plugins serves as a technical reference and as an implementation example for third parties.
+
+### 9.7 Plugin registry
+
+Starting from version 1.0 of the framework, an official registry is published at `plugins.antigravital.dev`. The registry indexes plugins with verified metadata, basic security scanning, and community reviews. Installation is done with `ag plugin add <name>`. Plugins are downloaded, validated, and registered in the project manifest.
+
+---
+
+## 10. Deployment subsystem (`ag-cloud` + `ag-domains`)
+
+One of the most important structural corrections derived from the critical analysis is that `ag-cloud` is not a competitor of Terraform or of Kubernetes. Its target range is the same one covered by Railway, Fly.io, Render, and Coolify: simplify the deployment of backend applications to typical environments without forcing the team to operate complete infrastructure. Since Phase 4.5 (`ADR-0007`), `ag-cloud` cooperates with `ag-domains` to resolve domain, TLS, and mail records within the `ag deploy` flow itself, without replacing the dominant providers (Let's Encrypt, Cloudflare, Resend) and without becoming a hosting panel.
+
+### 10.1 Philosophy of `ag-cloud`
+
+The typical operator of an Anti-Gravital project, especially in its first years of life, does not need or want to operate a Kubernetes cluster. They need to bring up their API on a VPS, connect it to a database, put it behind TLS, and forget about it. `ag-cloud` solves this case.
+
+For more complex cases (multi-region deployments, high availability, centralized secret management, IAM policies, infrastructure shared between multiple applications), `ag-cloud` is not the correct tool and the project must declare it openly: use Terraform, Pulumi, or Helm.
+
+### 10.2 The `deploy.ag` file
+
+The deployment subsystem is controlled with a declarative `deploy.ag` file separate from the project schema:
+
+```yaml
+app:
+  name: payments-api
+  domain: api.example.com
+
+runtime:
+  replicas: 3
+  port: 8080
+  health_check: /health
+  resources:
+    cpu: 1
+    memory: 512MB
+
+database:
+  type: postgres
+  version: "16"
+  size: 20GB
+  backup_schedule: "daily"
+
+cache:
+  type: redis
+  version: "7"
+  size: 1GB
+
+storage:
+  type: s3
+  bucket: payments-api-uploads
+
+secrets:
+  source: vault
+  path: secret/payments-api
+
+observability:
+  metrics: prometheus
+  traces: tempo
+  logs: loki
+
+deployment:
+  target: docker-compose      # opciones: docker-compose, fly, railway, k8s
+  strategy: rolling
+  max_surge: 1
+  max_unavailable: 0
+```
+
+### 10.3 Supported deployment targets
+
+`ag-cloud` supports four deployment targets, each with a different level of abstraction.
+
+The **docker-compose** target generates a complete `docker-compose.yml` with services, networks, volumes, healthchecks, secrets loaded from `.env` files or from a secret manager, a reverse proxy (Caddy by default) with automatic TLS via Let's Encrypt, and backup scripts for the database. It is the recommended target for self-hosting on a single VPS.
+
+The **fly** target generates a `fly.toml` and runs the `flyctl` commands needed to deploy to Fly.io. It is the recommended target for global edge computing with low operational overhead.
+
+The **railway** target generates the configuration for Railway and triggers the deployment via its API. It is the recommended target for teams that prefer PaaS without operation.
+
+The **k8s** target generates standard Kubernetes manifests (Deployment, Service, Ingress, ConfigMap, Secret, HorizontalPodAutoscaler) with reasonable values. For advanced configurations, this target is a starting point that the team customizes, not a complete solution.
+
+### 10.4 Deployment pipeline
+
+The `ag deploy` command runs a standardized pipeline: schema validation, compilation with `cargo build --release --target <target>`, construction of the Docker image from a `scratch` or `distroless` base, execution of smoke tests, push of the image to a registry, application of database migrations in order, rolling deployment with healthchecks, and post-deployment verification.
+
+### 10.5 Reverse proxy and TLS
+
+For docker-compose deployments, `ag-cloud` configures Caddy as a reverse proxy with automatic TLS. Caddy obtains and renews Let's Encrypt certificates without explicit configuration. For environments where TLS is managed by an external load balancer (Cloudflare, AWS ALB), Caddy is disabled.
+
+### 10.6 Integration with `ag-domains`
+
+Introduced by `ADR-0007`. When a project declares domains in its `.ag` contract (`domain` block of DSL v0.7), `ag deploy` resolves a six-step flow coordinated with `ag-domains`:
+
+1. **Validate domain control.** Insertion of a verification TXT record via the configured `DnsProvider` and confirmation of its presence.
+2. **Configure application DNS.** `upsert_record` to point the domain to the deployment target (CNAME to the Fly/Railway host, or A/AAAA records in docker-compose).
+3. **Issue or renew TLS.** ACME client against Let's Encrypt (DNS-01 preferred). The certificate is stored in filesystem or `ag-storage`.
+4. **Associate the domain to the target.** Configure the reverse proxy (Caddy in docker-compose, fly cert in Fly, etc.) to serve the domain with the issued certificate.
+5. **Materialize SPF/DKIM/DMARC** that `ag-mail` has declared in its `MailSender::dns_requirements`.
+6. **Verify propagation** against multiple public resolvers before marking the deployment as successful.
+
+`ag-cloud` does **NOT depend rigidly** on `ag-domains` in all targets: if the project does not declare domains, the flow is omitted. If the target is one where TLS is managed by an external load balancer (Cloudflare in front, AWS ALB), `ag-cloud` can skip step 3 without affecting the rest of the pipeline. This flexibility is what keeps `ag-domains` as an optional module, not as a mandatory piece of the runtime.
+
+---
+
+## 11. Artificial Intelligence integration (`ag-ai`) and the Knowledge Graph
+
+The `ag-ai` module is probably the most significant differentiator of the project in the 2026 context, where AI agents are everyday collaborators in software development. The module has two complementary components.
+
+### 11.1 The Anti-DSL as a contract for agents
+
+The first component is not code: it is the architectural decision that the `schema.ag` serves as a perfect contract for AI agents. An agent that receives an endpoint declared in `.ag` has exactly what it needs to generate a correct handler: precise types, defined errors, access policies, validations, events to emit. And, a critical difference with any other framework, the Rust compiler then verifies that the code generated by the agent is type-safe before it reaches production.
+
+This turns the development flow into a structured collaboration. The engineer designs the schema. The agent implements the handlers. The compiler acts as an automatic second reviewer that rejects any desynchronization. The operator supervises and approves.
+
+### 11.2 The Knowledge Graph
+
+The second component is the project's knowledge graph. `ag-ai` maintains a directed graph that indexes all the project's entities and their relationships: models, endpoints, events, policies, dependencies between handlers, database calls, calls to external services, configurations, installed plugins.
+
+The graph is automatically rebuilt on each `ag generate` and serialized to `.ag/knowledge-graph.json`. From this input the following are automatically produced: architectural documentation in Markdown, C4 diagrams (Context, Container, Component) in Mermaid format, suggested architectural decision records (ADRs), critical dependency lists, impact maps for proposed changes, and an interactive dashboard in the dev server.
+
+### 11.3 Assisted AI capabilities
+
+The module exposes three additional capabilities accessible from the CLI:
+
+`ag ai suggest-schema` analyzes a domain described in natural language and proposes a first draft of `schema.ag`. The engineer refines from there.
+
+`ag ai review-migration` analyzes a proposed SQL migration and reports risks: locks, downtime, data loss, slow queries during the transition. It suggests alternatives with a two-step migration when necessary.
+
+`ag ai analyze-architecture` produces a report on the project's knowledge graph: identification of hotspots (models with too many dependencies), endpoints without tests, events emitted but without consumers, dead code, antipatterns.
+
+### 11.4 Connection with model providers
+
+The module does not embed any language model. It connects to external providers via API: Anthropic Claude, OpenAI, local models served by Ollama or vLLM. The connection is configurable and the operator can choose or self-host. For sensitive environments, an offline mode is supported where the AI functions are disabled but the rest of the framework works normally.
+
+---
+
+## 12. Migration framework (`ag-migrate`): importers
+
+The real adoption of any successful backend framework has always passed through the possibility of migrating from the incumbent. The industry hates rewrites. The `ag-migrate` module is not an afterthought; it is a first-class citizen of the project.
+
+### 12.1 Supported importers
+
+`ag-migrate` offers official importers for the most adopted frameworks on the market.
+
+The **OpenAPI** importer consumes any OpenAPI 3.0 or 3.1 spec and produces a `schema.ag` with models, endpoints, errors, and validations. It is the most generic importer and serves to migrate from any service that documents an OpenAPI, regardless of the language it is written in.
+
+The **Prisma** importer consumes a `schema.prisma` file and translates models, relationships, and migrations to Anti-Gravital. It covers migration from TypeScript applications that use Prisma as an ORM.
+
+The **Django** importer reads Django models (defined as Python classes) and produces the equivalent Anti-Gravital models. It includes translation of relationships, managers, signals, and migrations.
+
+The **FastAPI** importer consumes FastAPI applications by examining the routers and the Pydantic models. It produces Anti-Gravital endpoints and models. It is probably the most natural migration case due to the philosophical similarity between FastAPI and Anti-Gravital.
+
+The **Sequelize** importer reads models from Node.js applications that use the Sequelize ORM. It covers the Express + Sequelize case, very common in the market.
+
+The **GraphQL** importer consumes a GraphQL SDL schema and produces its equivalent in Anti-Gravital.
+
+### 12.2 Honest limitations
+
+The importers cover the translation of the contract (models, endpoints, validations), not the business logic. The logic of the handlers must be written manually or with the assistance of an AI agent. This is documented clearly to avoid erroneous expectations.
+
+### 12.3 Official migration guides
+
+For each supported framework, an official guide is published in the documentation: recommended strategy (big bang vs strangler fig), patterns for coexistence during the transition (reverse proxy that splits traffic between the legacy system and the new one), comparative testing, and real case studies when available.
+
+---
+
+## 13. Native application bridge (`ag-mobile`): Flutter and generated clients
+
+The most important repositioning derived from the critical analysis is that Anti-Gravital does not compete with Flutter. It positions itself as **the ideal native backend for Flutter applications**. This multiplies the strategic value of the project: instead of competing with a mature and very well designed cross-platform UI framework, Anti-Gravital becomes its natural companion.
+
+### 13.1 Dart SDK generation
+
+`ag-mobile` generates a complete Dart package from the `schema.ag`. The package includes types generated with freezed for immutability, an HTTP client based on dio with interceptors for authentication, a WebSocket client for realtime, Server-Sent Events support, and mocks for tests.
+
+### 13.2 Native Flutter authentication
+
+The module includes widgets and services ready for the authentication flows. The WebAuthn integration leverages the native platforms (Android Credential Manager API, iOS Passkeys via AuthenticationServices). The OAuth2 flow uses `flutter_appauth` with auto-generated configuration.
+
+### 13.3 Offline-first and synchronization
+
+`ag-mobile` offers an optional offline synchronization layer. Operations are queued locally in a SQLite database, replicated to the server when there is connectivity, and conflicts are resolved with declarative policies in the schema (last-write-wins, custom merge, server-wins). It is an ambitious functionality that is implemented in a late phase of the roadmap.
+
+### 13.4 Other generated clients
+
+Although Flutter is the priority target for mobile, the codegen system is extensible. Version 1.0 includes generators for Dart (Flutter), TypeScript (React, Vue, Svelte, Next.js), and Kotlin (native Android, optionally Kotlin Multiplatform). A later version may include Swift and Python.
+
+---
+
+## 14. Observability (`ag-observe`)
+
+Although already covered briefly as a standard module, observability deserves its own section because it is probably the most visible difference between a toy framework and a production framework.
+
+### 14.1 Three pillars
+
+`ag-observe` covers the three classic pillars: metrics, traces, and logs. The stack is OpenTelemetry as the abstraction layer, with configurable exporters.
+
+Metrics are exposed at `/metrics` in Prometheus format by default. They include latency per endpoint (p50, p95, p99, p999), throughput, error rate per HTTP code, database pool usage, Redis pool usage, active WebSocket connections, and custom metrics registered by the application.
+
+Traces are exported via OTLP to any compatible backend (Tempo, Jaeger, Datadog, Honeycomb, Lightstep). Each request generates a trace with spans for the Shield, the handlers, the SQL queries, the external calls, and the event emission.
+
+Logs are structured (JSON by default) and always include the correlation ID. They are exported to stdout (standard for cloud-native environments) and optionally to backends such as Loki or Datadog.
+
+### 14.2 Included Grafana dashboards
+
+The repository includes pre-configured Grafana dashboards in JSON that the operator imports directly. They cover: service overview, latency and throughput per endpoint, errors and exceptions, database health, cache health, and Rust runtime metrics (memory usage, number of Tokio tasks, GC pauses — which will always be zero, but the dashboard confirms it).
+
+### 14.3 Live inspection with tokio-console
+
+In development mode, `tokio-console` is enabled automatically. It allows the developer to connect to the process and see in real time which tasks are running, which are blocked, where resources are being consumed. It is a tremendously useful debugging tool that exists only in Rust with Tokio.
+
+---
+
+## 15. Security model
+
+Security is a cross-cutting concern, not a module. This section documents the project's guarantees and practices.
+
+### 15.1 Guarantees by construction
+
+Rust eliminates by construction four categories of bugs that historically represent more than 70% of the critical vulnerabilities in systems software: use-after-free, buffer overflows, data races, and null pointer dereferences. These guarantees are at the compiler level, not at runtime; they do not require GC or runtime checks.
+
+Anti-Gravital prohibits the use of `unsafe` in all the framework code except in blocks that are explicitly justified, documented, and reviewed by at least two maintainers. Each `unsafe` block comes accompanied by a comment that explains why it is necessary and which invariants it preserves.
+
+### 15.2 Cryptography practices
+
+The cryptographic primitives are imported from the `ring` crate, maintained by members of Google's BoringSSL team. No custom cryptography is rolled. The default algorithms are Ed25519 for signatures, ChaCha20-Poly1305 for AEAD, Argon2id for password hashing, and TLS 1.3 for transport. Legacy algorithms (RSA, AES-CBC, SHA-1) are available only for explicit interoperability.
+
+### 15.3 Responsible disclosure policy
+
+The repository maintains a `SECURITY.md` file with contact addresses (primary `anti@gravitalcloud.com`, backup `angelnereira@gravitalcloud.com`) and a clear policy: vulnerabilities are reported privately, the team confirms receipt within 48 hours, publishes a patch within 30 days for critical vulnerabilities, and a CVE with credit to the reporter.
+
+### 15.4 Audits
+
+Before the stable 1.0 version, the Shield component of the framework undergoes an external audit by a company specialized in Rust systems security (Trail of Bits, NCC Group, or equivalent). The audit report is published with the release.
+
+### 15.5 Continuous fuzzing
+
+The DSL parser and the HTTP parser undergo continuous fuzzing with `cargo-fuzz`. The CI runs fuzzing corpora on each PR; before 1.0, at least 72 hours of fuzzing without crashes are completed on each parser.
+
+---
+
+## 16. Performance objectives and validation methodology
+
+This section replaces the absolute benchmarks of v3.0. The previous figures were presented as facts when in reality they are extrapolations of individual components. This version rephrases them honestly as **design objectives**, against which the project will measure itself publicly.
+
+### 16.1 Design objectives
+
+| Metric                                                     | Objective                 | Extrapolation basis                          |
+|------------------------------------------------------------|---------------------------|----------------------------------------------|
+| Hello World throughput (plaintext)                         | >= 300 K req/s            | Axum + Tokio in TechEmpower                  |
+| Simple JSON throughput                                     | >= 150 K req/s            | Axum + serde_json in public benchmarks       |
+| CRUD throughput with PostgreSQL                            | >= 40 K req/s             | sqlx + connection pool                       |
+| p99 latency with DB query                                  | <= 5 ms                   | Measurements of Tokio services in production |
+| Base memory (idle process, no traffic)                     | <= 15 MB                  | Size of Rust + Tokio binaries                |
+| Cold start time                                            | <= 100 ms                 | Static Rust binaries on Linux                |
+| Release binary size with all standard modules              | <= 20 MB                  | Compilations of similar projects             |
+| Concurrent WebSocket connections on a 2 vCPU instance      | >= 50 000                 | Tokio stackless tasks                        |
+
+These figures are technical objectives. The project specification requires that they be measured with the `ag bench` suite in the repository, and that each release publish the reproducible results. If a metric is not reached, it is published as such and the deficit is documented. The technical credibility of the project depends on not exaggerating.
+
+### 16.2 Measurement methodology
+
+Any comparison with competing frameworks is done under the TechEmpower Framework Benchmarks, run by the team or by independent third parties. The comparisons published in the documentation include: the exact version of the compared framework, the configuration used, the benchmark hardware, the number of runs, and the standard deviation. Comparisons that do not comply with these rules are not published.
+
+### 16.3 Validation milestones for v1.0
+
+The stable 1.0 version is released only when the following milestones are met:
+
+- Top-10 position in a TechEmpower Round (Plaintext and JSON Serialization categories)
+- External security audit without unresolved critical findings
+- 72 hours of fuzzing of the DSL parser and the HTTP parser without crashes
+- Load test of 500 K req/s sustained for 30 minutes without degradation >5%
+- 24 hours of continuous load without detectable memory growth
+- Binaries verified on Linux x86-64, Linux ARM64, macOS ARM64, Windows x64
+- At least one service in production on Gravital Cloud for 30 days without incidents
+- At least three external projects using Anti-Gravital in production
+
+---
+
+## 17. Open Source governance model
+
+### 17.1 License and promise
+
+The license is Apache 2.0 for the entire ecosystem. There is not and will not be a closed Enterprise version with features reserved for paying customers. The commitment is explicit and is documented in the README. Any future license change would require the approval of the entire community of maintainers, and the ecosystem remains forkable.
+
+### 17.2 Maintenance model
+
+The project adopts an initial BDFL model with a transition plan to explicit meritocracy. In the initial phase (0.x versions), Angel Nereira is the principal maintainer. Starting from version 1.0, a technical committee of five people elected among the contributors with the greatest track record is established. The committee approves RFCs (Request For Comments) for major changes.
+
+### 17.3 RFCs
+
+Any change that affects the public API, the DSL, the plugin architecture, or the security model requires an RFC. The process is: the proposer opens an issue in `anti-gravital-rfcs/`, the community debates for at least two weeks, the technical committee votes. Once approved, the RFC is moved to the "Accepted" state and is implemented in a specific version.
+
+### 17.4 Compatibility
+
+After version 1.0, the project commits to strict semver in the public API. Breaking changes only in majors. The LTS versions are announced with a public calendar, with at least 18 months of security support.
+
+### 17.5 Economic sustainability
+
+The project is sustained on three legs. The first is Gravital Labs (Nereira Technology and Business Solutions), which finances the initial development as a strategic investment. The second is professional services: adoption consulting, training, and premium support for companies that want an SLA, without this closing product features. The third, in the future, are corporate sponsors (GitHub Sponsors, Open Collective) of companies that depend on the project.
+
+---
+
+## 18. Risk analysis and mitigations
+
+This section documents the real risks of the project and the planned mitigations. It is deliberately honest; a project that does not enumerate its risks does not deserve trust.
+
+### 18.1 Risk: DSL compiler complexity
+
+The DSL compiler is a several-year project on its own. The mitigation is the incremental implementation by DSL versions described in section 7. Version 0.1 covers only basic models and is deliverable in two months. Each version adds a well-defined subset. The stable 1.0 version of the DSL is the highest-risk milestone of the project and is planned for the end of the schedule.
+
+### 18.2 Risk: Rust learning curve
+
+Rust has a real learning curve. The mitigation is threefold. First, the DSL generates 80% of the scaffolding, so that the handlers the developer writes are simple Rust: a few `await`s, access to shared state, returning a `Result`. Second, the documentation includes a "Rust for Python/Node.js developers" guide with the minimum necessary concepts. Third, the integrated AI assistant can generate handlers that the developer supervises.
+
+### 18.3 Risk: competition with big players
+
+Spring, .NET, Express, and FastAPI have decades-old ecosystems. Anti-Gravital cannot compete frontally with them in breadth. The mitigation is to focus on niches where the incumbents have structural weaknesses: high-load applications, edge services, backends for Flutter, backends for AI applications with streaming.
+
+### 18.4 Risk: bus factor
+
+The initial project has a worryingly low bus factor (one maintainer). The mitigation is active: complete internal documentation from day one, incorporation of external contributors from phase 1, and transition to a technical committee before 1.0.
+
+### 18.5 Risk: changes in the Rust ecosystem
+
+The Rust ecosystem continues to evolve rapidly. Axum, Tokio, and sqlx may make breaking changes in future versions. The mitigation is conservative version pinning, exhaustive integration tests against each new version of the core dependencies, and active participation in their communities to anticipate changes.
+
+### 18.6 Risk: community fragmentation
+
+If the Anti-Gravital community fragments (for example, competing forks with divergent features emerge), the ecosystem weakens. The mitigation is an open RFC process that gives a real voice to the community, predictable releases, and a public roadmap.
+
+### 18.7 Risk: post-launch security vulnerabilities
+
+Although Rust eliminates many categories of vulnerabilities, it does not eliminate the logical ones (broken authorization, information leaks, application-level races). The mitigation is the external audit before 1.0, the responsible disclosure program, continuous fuzzing, and CI with static analysis (clippy, cargo-audit, cargo-deny).
+
+---
+
+## 19. Technical glossary
+
+| Term                          | Definition                                                                                                                |
+|-------------------------------|--------------------------------------------------------------------------------------------------------------------------|
+| Anti-DSL (.ag)                | Domain definition language of the framework. Schema-first.                                                                |
+| Axum                          | Rust HTTP framework built on Tokio and Tower. Base of the Core.                                                           |
+| Backpressure                  | Mechanism by which the system rejects new work when it is saturated. Implemented natively in Tower.                       |
+| Cargo                         | Rust's build system and package manager.                                                                                  |
+| Cargo-fuzz                    | Fuzzing tool integrated with Cargo.                                                                                        |
+| Core (layer B)                | Business logic layer of the core. Axum router, handlers, shared state.                                                    |
+| Correlation ID                | Unique identifier per request that traverses all the logs, traces, and errors.                                            |
+| Ed25519                       | Digital signature algorithm based on the Edwards25519 curve. Default for JWT in Anti-Gravital.                            |
+| Flamegraph                    | CPU profiling visualization. With pure Rust it covers the whole application without gaps.                                 |
+| Fuel (wasmtime)               | Quota of instructions that a WASM plugin can execute before being interrupted.                                            |
+| GIL                           | Global Interpreter Lock. CPython mechanism that prevents real parallel execution.                                         |
+| Governor                      | Rust crate for rate limiting based on token bucket. Thread-safe without contended locks.                                  |
+| HTMX                          | Small JavaScript library that allows interactivity without SPA frameworks.                                                |
+| JetStream                     | NATS message persistence system. Allows replay and durability.                                                            |
+| Knowledge Graph               | Directed graph of the Anti-Gravital project. Indexes models, endpoints, events, dependencies.                             |
+| LSP                           | Language Server Protocol. The `.ag` DSL offers LSP for autocompletion in editors.                                         |
+| Moka                          | Concurrent Rust cache with TinyLFU. Thread-safe without contended locks.                                                  |
+| NATS                          | pub/sub messaging system used by `ag-realtime`.                                                                           |
+| OpenAPI                       | Standard specification to describe HTTP APIs. Anti-Gravital generates it automatically.                                   |
+| Passkeys                      | FIDO2/WebAuthn standard for passwordless authentication.                                                                  |
+| Ring                          | Low-level cryptography Rust crate. Maintained by members of the BoringSSL team.                                           |
+| Rustls                        | TLS 1.3 implementation in pure Rust, without OpenSSL.                                                                     |
+| Schema drift                  | Condition where the definition of a schema becomes desynchronized between layers. Anti-Gravital eliminates it by design.  |
+| Schema-per-tenant             | Multi-tenant architecture where each client has its own schema in PostgreSQL.                                             |
+| Shield (layer A)              | Trust layer of the core. Tower middleware pipeline: TLS, auth, validation, rate limit, RBAC, CORS.                        |
+| sqlx                          | Rust database access crate with compile-time query verification.                                                          |
+| TechEmpower                   | Industry-standard benchmark suite for comparing web frameworks.                                                           |
+| Tokio                         | Rust async runtime. Provides M:N concurrency through lightweight tasks without GC.                                        |
+| tokio-console                 | Live diagnostic tool for Tokio applications.                                                                              |
+| Tower                         | Rust crate for composable services and middleware. Architectural base of the Shield.                                     |
+| WASI                          | WebAssembly System Interface. Standard for WebAssembly modules with controlled access to the system.                     |
+| wasmtime                      | WebAssembly runtime embeddable in Rust. Host of the plugin system.                                                        |
+| WebAuthn                      | W3C standard for authentication with hardware factors (passkeys, security keys).                                          |
+| Zero-copy                     | Data transfer without copying it in memory. Reduces CPU overhead.                                                         |
+| Zero-overhead abstraction     | Rust principle: an abstraction must not cost performance versus the equivalent manual code.                               |
+| ACME                          | Automatic Certificate Management Environment. Protocol for automatic issuance and renewal of TLS certificates (Let's Encrypt). Used by `ag-domains` since Phase 4.5. |
+| DKIM                          | DomainKeys Identified Mail. Mail authentication mechanism by cryptographic signature of the sender domain. Generated by `ag-domains` for `ag-mail`. |
+| SPF                           | Sender Policy Framework. DNS record that enumerates the servers authorized to send mail on behalf of the domain. Generated by `ag-domains` for `ag-mail`. |
+| DMARC                         | Domain-based Message Authentication, Reporting and Conformance. Policy that indicates how to treat mail that fails SPF or DKIM. Generated by `ag-domains`. |
+| MTA                           | Mail Transfer Agent. Complete mail server (Postfix, Stalwart). `ag-mail` v1 is **NOT an MTA**: it only sends outbound, it does not receive inbound. |
+| DnsProvider                   | `ag-domains` trait that abstracts DNS providers through adapters. Initial adapter: Cloudflare. Designed to add Route53, Namecheap, etc. with contract tests. |
+| Deferred standard             | Crate classification introduced by `ADR-0007`. Crate with standard maturity that is NOT installed by default in official templates. `ag-mail` is the first case. |
+
+---
+
+## 20. Appendix: market comparison
+
+This comparison is offered as a technical reference. The figures for the competitors are based on verifiable public benchmarks (TechEmpower, GitHub issues, official documentation). Those of Anti-Gravital are design objectives, not measurements.
+
+| Criterion                      | Spring Boot   | .NET Core     | FastAPI      | NestJS       | Anti-Gravital (objective)   |
+|--------------------------------|---------------|---------------|--------------|--------------|-----------------------------|
+| Runtime                        | JVM           | CLR           | CPython      | Node.js V8   | None (native binary)        |
+| Base memory                    | ~350 MB       | ~120 MB       | ~60 MB       | ~80 MB       | <= 15 MB                    |
+| Startup time                   | ~6 s          | ~0.8 s        | ~0.8 s       | ~1.2 s       | <= 0.1 s                    |
+| Hello World throughput         | ~75 K req/s   | ~200 K req/s  | ~28 K req/s  | ~45 K req/s  | >= 300 K req/s              |
+| CRUD + DB throughput           | ~15 K req/s   | ~30 K req/s   | ~5 K req/s   | ~8 K req/s   | >= 40 K req/s               |
+| Memory safety                  | Partial       | Partial       | Yes          | No           | Total (Rust compiler)       |
+| GC pauses                      | Yes (JVM GC)  | Yes (CLR GC)  | Not applicable | Yes (V8 GC) | No (no GC)                  |
+| Deployment as single binary    | No            | Partial       | No           | No           | Yes                         |
+| Schema-first DX                | No            | No            | Partial      | No           | Yes (Anti-DSL)              |
+| Compile-time verified queries   | No           | No            | No           | No           | Yes (sqlx)                  |
+| Native DX for AI agents        | No            | No            | Partial      | No           | Yes                         |
+| Native cross-compilation       | No            | No            | No           | No           | Yes                         |
+| License                        | Apache 2.0    | MIT           | MIT          | MIT          | Apache 2.0                  |
+
+---
+
+**End of the Technical Architecture document.**
+Complementary document: *Roadmap and Verification Gates.*
+Unified PDF version: *Anti-Gravital Blueprint v4.0 — Master Document.*
+
+---
+
+## Espanol
+
 # Anti-Gravital Framework — Arquitectura Técnica e Implementación
 
 **Versión:** 4.0 — Mayo 2026

--- a/docs/master/ANTI-GRAVITAL-Arquitectura-Tecnica.md
+++ b/docs/master/ANTI-GRAVITAL-Arquitectura-Tecnica.md
@@ -630,7 +630,7 @@ Esta sección especifica cada uno de los módulos estándar del ecosistema. Cada
 
 El módulo de autenticación implementa los esquemas modernos de identidad. La decisión arquitectónica central es soportar Passkeys/WebAuthn como primera clase, no como afterthought; las passwords son un mecanismo legacy soportado pero no recomendado.
 
-El stack técnico es `webauthn-rs` para FIDO2, `jsonwebtoken` para JWT, `ring` para criptografía, `argon2` para hashing de passwords (cuando se usan), y `oauth2` como cliente OAuth2.
+El stack técnico implementado es WebAuthn propio con `ciborium` (CBOR) y verificación COSE (`p256` para ES256, `ed25519-dalek` para EdDSA) en lugar de `webauthn-rs`, por compatibilidad de licencia Apache-2.0 (vease `ADR-0006`); `jsonwebtoken` para JWT, `argon2` para hashing de passwords (cuando se usan), y `oauth2` como cliente OAuth2 (Google, GitHub) con flujo PKCE.
 
 Los flujos soportados son: registro y autenticación con passkey, autenticación con email + password (legacy), OAuth2 con providers preconfigurados (Google, GitHub, Microsoft, Gravital ID), API keys para integraciones servidor-servidor, y refresh tokens con rotación.
 
@@ -664,7 +664,7 @@ La persistencia de eventos usa JetStream (componente de NATS) cuando está dispo
 
 ### 8.4 `ag-cache` — Caché multinivel
 
-El módulo de caché ofrece dos niveles. El nivel L1 es caché en memoria con `moka`, una implementación concurrente sin locks contenciosos basada en TinyLFU. El nivel L2 es Redis (con `fred` como cliente), opcional, para caché distribuida entre instancias.
+El módulo de caché ofrece dos niveles. El nivel L1, ya implementado, es caché en memoria con `moka`, una implementación concurrente sin locks contenciosos basada en TinyLFU, con invalidación por tags. El nivel L2 (caché distribuida entre instancias) aún no está implementado: `RFC-0005` propone un L2 nativo compatible con el protocolo RESP2, sin dependencia de Redis como servicio externo, y queda pendiente de aprobación e implementación.
 
 La invalidación se hace por eventos. Cuando un endpoint emite un evento (`user.updated`), `ag-cache` invalida automáticamente las entradas relacionadas en ambos niveles. La política de invalidación se declara en el schema.
 
@@ -726,16 +726,19 @@ pub enum AgMail {
 ```
 
 El patrón Native | Adapter es idéntico al usado por `ag-storage`
-(`Native | S3`) y `ag-cache` (`moka | Redis`), reforzando la regla de
+(`Native | S3`) y al previsto para el L2 de `ag-cache` (L1 `moka` nativo
+hoy; L2 RESP2 nativo propuesto en `RFC-0005`), reforzando la regla de
 interoperabilidad del proyecto: integrar proveedores dominantes, no
 reemplazarlos.
 
-Los **templates** se construyen con `askama` (ya utilizado por `ag-ui`) y se
-validan en build-time contra el `schema.ag`: si el `from` declarado no
-referencia un `domain` válido, si el archivo del template no existe o si
-las variables del HTML no coinciden con las `vars` tipadas declaradas, el
-compilador del DSL rechaza el build. Un correo mal formado deja de ser un
-bug de runtime y se convierte en un error de compilación. Este es el
+Los **templates** se modelan con el trait `MailTemplate` y una
+implementación `StringTemplate` de sustitución `{{var}}`; cualquier motor
+externo (askama, minijinja) puede conectarse implementando el trait. La
+validación de variables se hace contra el `schema.ag`: el compilador del
+DSL emite un aviso cuando el `from` de un bloque `mail` no referencia un
+`domain` declarado, y verifica que las `vars` tipadas del template
+coincidan con los marcadores usados. Un correo mal formado deja de ser un
+bug de runtime y se acerca a un error detectable en build. Este es el
 **diferenciador real** frente a Resend, no la entregabilidad: la
 entregabilidad es trabajo del proveedor; la corrección del contrato es
 trabajo del framework.

--- a/docs/master/ANTI-GRAVITAL-Blueprint-v4.1.md
+++ b/docs/master/ANTI-GRAVITAL-Blueprint-v4.1.md
@@ -1,0 +1,239 @@
+# Anti-Gravital — Blueprint v4.1
+
+**[English](#in-english) | [Espanol](#en-espanol)**
+
+- Version: 4.1 (markdown source)
+- Organization: Gravital Labs — Nereira Technology and Business Solutions
+- Origin: Republic of Panama
+- License: Apache 2.0
+- Status: living document; markdown source of record for the Blueprint.
+
+> This markdown file is the versionable source of the Anti-Gravital
+> Blueprint. The legacy `ANTI-GRAVITAL-Blueprint-v4.0.pdf` is the
+> presentation artifact and is registered as explicit debt pending
+> re-export (see `VERSION.md`). When the markdown and the PDF diverge,
+> the markdown governs.
+
+---
+
+## In English
+
+### 1. Vision
+
+Anti-Gravital is an open source ecosystem for building high-performance
+backend applications in pure Rust. It rests on three non-negotiable
+properties:
+
+1. **No external runtime.** Applications compile to a single static
+   binary. No interpreter, no language VM, no mandatory sidecar.
+2. **Schema-first.** A domain definition language (Anti-DSL, `.ag` files)
+   is the source of truth. Rust, SQL, OpenAPI, TypeScript and Dart
+   artifacts are generated from it.
+3. **Modular crates.** Capabilities ship as independent, separately
+   versioned crates so a project only depends on what it uses.
+
+The guiding sentence of the project: build Anti-Gravital as real,
+modular, verifiable and sustainable infrastructure; never as a demo
+inflated by technical hype.
+
+### 2. Positioning
+
+Anti-Gravital is infrastructure, not a framework that tries to solve
+everything. Where a dominant tool already exists (Kubernetes, Docker,
+PostgreSQL, Redis, NATS, MinIO, Terraform, React, Next.js, Flutter),
+Anti-Gravital integrates with it rather than reinventing it. The strategy
+is intelligent integration through small traits with swappable adapters.
+
+The project is born in Panama and targets Latin America as its first
+adoption focus, while keeping English as the canonical language of code
+and technical documentation to remain open to global contributors
+(see `ADR-0008`).
+
+### 3. Scope
+
+In scope:
+
+- A high-performance Rust backend runtime (the Shield + Core of `ag-core`).
+- The Anti-DSL and its compiler (`ag-dsl`) with multi-target codegen.
+- A unified CLI (`ag`).
+- Batteries-included standard modules: `ag-auth`, `ag-data`,
+  `ag-realtime`, `ag-cache`, `ag-storage`, `ag-observe`.
+- Deferred-standard modules: `ag-mail` (transactional outbound email).
+- Optional infrastructure modules: `ag-domains` (DNS, ACME, SPF/DKIM/DMARC).
+- Optional modules planned for later phases: `ag-ui`, `ag-cloud`, `ag-ai`,
+  `ag-mobile`, `ag-migrate`.
+- A WASI plugin system.
+
+Explicitly out of scope:
+
+- `ag-mail` is not a full MTA: no inbound, no IMAP/POP, no mailboxes, no
+  antispam, no IP reputation.
+- `ag-domains` is not a registrar and does not replace Terraform.
+- Anti-Gravital does not reinvent dominant infrastructure tools.
+
+### 4. Ecosystem at a glance
+
+The ecosystem comprises 17 crates in four tiers:
+
+- **Core:** `ag-core`, `ag-dsl`, `ag-cli`, `ag-wasm-host`.
+- **Standard:** `ag-auth`, `ag-data`, `ag-realtime`, `ag-cache`,
+  `ag-storage`, `ag-observe`.
+- **Deferred standard:** `ag-mail` (standard maturity, not installed by
+  default in official templates; added when a project needs it). `ag-mail`
+  does not depend on `ag-auth`.
+- **Optional:** `ag-ui`, `ag-cloud`, `ag-ai`, `ag-mobile`, `ag-migrate`,
+  and the optional-infrastructure crate `ag-domains` (consumed optionally
+  by `ag-cloud` during `ag deploy`).
+
+Dependency rules: `ag-core` depends on no Anti-Gravital crate; no circular
+dependencies; `ag-auth -> ag-mail` (not the reverse); `ag-cloud ->
+ag-domains` (non-rigid).
+
+### 5. Delivery state (close of Phase 4.5)
+
+Phases 1 through 4.5 have their technical implementation complete and
+merged to `main`:
+
+- Phase 1 — Shield MVP.
+- Phase 2 — Core MVP + full request roundtrip + PostgreSQL CRUD.
+- Phase 3 — Anti-DSL alpha (v0.1-v0.4), `ag-lsp`, VS Code plugin, fuzzing.
+- Phase 4 — standard modules (`ag-auth`, `ag-cache`, `ag-realtime`,
+  `ag-storage`, `ag-observe`) plus DSL v0.5-v0.6.
+- Phase 4.5 — `ag-mail` and `ag-domains`, DSL v0.7 (mail/domain/template),
+  `ag-auth -> ag-mail` integration, CLI subcommands, cross-module E2E tests.
+
+Practical implementation decisions worth recording at blueprint level:
+
+- WebAuthn in `ag-auth` is implemented with `ciborium` + `p256` +
+  `ed25519-dalek` instead of `webauthn-rs`, for license compatibility
+  (Apache-2.0). See `ADR-0006`.
+- Mail templating ships as a `MailTemplate` trait plus a `StringTemplate`
+  implementation, allowing any engine (askama, minijinja) to be plugged in.
+- `ag-cache` ships L1 (moka); the native L2 (RESP2) is proposed in
+  `RFC-0005` and not yet implemented.
+
+Phase 5 (`ag-cloud`) is next. The public beta (v0.5) milestone remains at
+the end of Phase 5.
+
+### 6. Governance and source of truth
+
+Documentation is the contract. The order of authority is: the Hoja de
+Ruta (roadmap) defines what may be built and when; the Arquitectura
+Tecnica defines how; this Blueprint defines vision, positioning and scope.
+If code contradicts the documentation, the code is wrong. Large decisions
+require an RFC; architectural decisions are recorded as ADRs.
+
+---
+
+## En espanol
+
+### 1. Vision
+
+Anti-Gravital es un ecosistema de software libre para construir
+aplicaciones backend de alto rendimiento en Rust puro. Se apoya en tres
+propiedades no negociables:
+
+1. **Sin runtime externo.** Las aplicaciones compilan a un unico binario
+   estatico. Sin interprete, sin VM de lenguaje, sin sidecar obligatorio.
+2. **Schema-first.** Un lenguaje de definicion de dominio (Anti-DSL,
+   archivos `.ag`) es la fuente de verdad. De el se generan los
+   artefactos Rust, SQL, OpenAPI, TypeScript y Dart.
+3. **Crates modulares.** Las capacidades se publican como crates
+   independientes y versionados por separado, de modo que un proyecto
+   solo depende de lo que usa.
+
+La frase rectora del proyecto: construir Anti-Gravital como infraestructura
+real, modular, verificable y sostenible; nunca como una demo inflada por
+hype tecnico.
+
+### 2. Posicionamiento
+
+Anti-Gravital es infraestructura, no un framework que intenta resolverlo
+todo. Donde ya existe una herramienta dominante (Kubernetes, Docker,
+PostgreSQL, Redis, NATS, MinIO, Terraform, React, Next.js, Flutter),
+Anti-Gravital se integra en lugar de reinventarla. La estrategia es
+integracion inteligente mediante traits pequenos con adapters
+intercambiables.
+
+El proyecto nace en Panama y tiene a Latinoamerica como primer foco de
+adopcion, manteniendo el ingles como idioma canonico del codigo y de la
+documentacion tecnica para permanecer abierto a contribuidores globales
+(vease `ADR-0008`).
+
+### 3. Alcance
+
+Dentro del alcance:
+
+- Un runtime backend Rust de alto rendimiento (Shield + Core de `ag-core`).
+- El Anti-DSL y su compilador (`ag-dsl`) con codegen multi-objetivo.
+- Una CLI unificada (`ag`).
+- Modulos estandar batteries-included: `ag-auth`, `ag-data`,
+  `ag-realtime`, `ag-cache`, `ag-storage`, `ag-observe`.
+- Modulos estandar diferidos: `ag-mail` (correo transaccional outbound).
+- Modulos opcionales de infraestructura: `ag-domains` (DNS, ACME,
+  SPF/DKIM/DMARC).
+- Modulos opcionales planeados para fases posteriores: `ag-ui`,
+  `ag-cloud`, `ag-ai`, `ag-mobile`, `ag-migrate`.
+- Un sistema de plugins WASI.
+
+Explicitamente fuera del alcance:
+
+- `ag-mail` no es un MTA completo: sin inbound, sin IMAP/POP, sin buzones,
+  sin antispam, sin reputacion de IP.
+- `ag-domains` no es un registrador y no reemplaza Terraform.
+- Anti-Gravital no reinventa herramientas de infraestructura dominantes.
+
+### 4. El ecosistema de un vistazo
+
+El ecosistema lo componen 17 crates en cuatro niveles:
+
+- **Nucleo:** `ag-core`, `ag-dsl`, `ag-cli`, `ag-wasm-host`.
+- **Estandar:** `ag-auth`, `ag-data`, `ag-realtime`, `ag-cache`,
+  `ag-storage`, `ag-observe`.
+- **Estandar diferido:** `ag-mail` (madurez de estandar, no instalado por
+  defecto en los templates oficiales; se incorpora cuando el proyecto lo
+  necesita). `ag-mail` no depende de `ag-auth`.
+- **Opcionales:** `ag-ui`, `ag-cloud`, `ag-ai`, `ag-mobile`, `ag-migrate`,
+  y el crate opcional de infraestructura `ag-domains` (consumido
+  opcionalmente por `ag-cloud` durante `ag deploy`).
+
+Reglas de dependencia: `ag-core` no depende de ningun crate Anti-Gravital;
+sin dependencias circulares; `ag-auth -> ag-mail` (no al reves);
+`ag-cloud -> ag-domains` (no rigida).
+
+### 5. Estado de entrega (cierre de la Fase 4.5)
+
+Las fases 1 a 4.5 tienen su implementacion tecnica completa y mergeada a
+`main`:
+
+- Fase 1 — Shield MVP.
+- Fase 2 — Core MVP + roundtrip completo + CRUD PostgreSQL.
+- Fase 3 — Anti-DSL alpha (v0.1-v0.4), `ag-lsp`, plugin VS Code, fuzzing.
+- Fase 4 — modulos estandar (`ag-auth`, `ag-cache`, `ag-realtime`,
+  `ag-storage`, `ag-observe`) mas DSL v0.5-v0.6.
+- Fase 4.5 — `ag-mail` y `ag-domains`, DSL v0.7 (mail/domain/template),
+  integracion `ag-auth -> ag-mail`, subcomandos de CLI, tests E2E
+  cross-module.
+
+Decisiones practicas de implementacion dignas de registrar a nivel de
+blueprint:
+
+- WebAuthn en `ag-auth` se implementa con `ciborium` + `p256` +
+  `ed25519-dalek` en lugar de `webauthn-rs`, por compatibilidad de
+  licencia (Apache-2.0). Vease `ADR-0006`.
+- El templating de correo se ofrece como trait `MailTemplate` mas una
+  implementacion `StringTemplate`, permitiendo conectar cualquier motor
+  (askama, minijinja).
+- `ag-cache` entrega L1 (moka); el L2 nativo (RESP2) esta propuesto en
+  `RFC-0005` y aun no implementado.
+
+La Fase 5 (`ag-cloud`) es la proxima. El hito de beta publica (v0.5)
+permanece al final de la Fase 5.
+
+### 6. Gobernanza y fuente de verdad
+
+La documentacion es el contrato. El orden de autoridad es: la Hoja de Ruta
+define que se puede construir y cuando; la Arquitectura Tecnica define
+como; este Blueprint define vision, posicionamiento y alcance. Si el codigo
+contradice la documentacion, el codigo esta mal. Toda decision grande
+requiere un RFC; las decisiones arquitectonicas se registran como ADRs.

--- a/docs/master/ANTI-GRAVITAL-Hoja-de-Ruta.md
+++ b/docs/master/ANTI-GRAVITAL-Hoja-de-Ruta.md
@@ -1,11 +1,640 @@
 # Anti-Gravital — Hoja de Ruta y Puertas de Verificación
 
+**[English](#english) | [Espanol](#espanol)**
+
 **Versión:** 4.0 — Mayo 2026
 **Organización:** Gravital Labs — Nereira Technology and Business Solutions
 **Origen:** República de Panamá
 **Estado:** Documento vivo. Se actualiza con cada release.
 
 ---
+
+## English
+
+## How to read this document
+
+This document defines the sequence of phases that the Anti-Gravital project must pass through from its inception until it becomes a stable, market-ready version 1.0, with the promise fulfilled.
+
+Each phase contains four blocks:
+
+1. **Entry criteria**: conditions that must be met before the phase can begin. These come from the previous phase.
+2. **Deliverables**: concrete artifacts that the phase must produce.
+3. **Exit criteria (gate)**: conditions that must be met before moving to the next phase. They function as blocking gates: if they are not met, there is no advancement. This is non-negotiable.
+4. **Phase-specific risks and mitigations**.
+
+The deliverables and exit criteria are expressed as checkable boxes. This document is kept in the repository and is updated by crossing off what has been accomplished. It serves as the project's public dashboard.
+
+The main rule is: **a phase is not considered concluded until all of its exit criteria boxes are checked**. The project may be temporarily paused between phases, but it cannot skip steps due to external pressure or urgency.
+
+---
+
+## Phase summary
+
+| Phase | Name                                       | Estimated duration | Status    |
+|-------|--------------------------------------------|--------------------|-----------|
+| 0     | Foundations and governance                 | 1–2 months         | In progress (external deliverables pending) |
+| 1     | The Shield MVP                             | 2–3 months         | Technical implementation complete |
+| 2     | The Core MVP + roundtrip                   | 2 months           | Technical implementation complete |
+| 3     | Anti-DSL alpha (v0.1–v0.4)                 | 3 months           | Technical implementation complete |
+| 4     | Standard modules (auth, data, realtime)    | 3 months           | Technical implementation complete |
+| 4.5   | `ag-mail` + `ag-domains`: communication and domains | 1–2 months | Technical implementation complete |
+| 5     | `ag-cloud` — simplified deployment         | 2 months           | Next |
+| 6     | `ag-ai` and Knowledge Graph                | 2 months           | Pending |
+| 7     | `ag-migrate` — importers                   | 2 months           | Pending |
+| 8     | `ag-mobile` — Flutter bridge               | 2 months           | Pending |
+| 9     | WASI plugin system                         | 2 months           | Pending |
+| 10    | Hardening and 1.0 milestone                | 3 months           | Pending |
+
+**Total estimated duration:** 25–30 months from the start.
+**Public beta version milestone (0.5):** end of phase 5 (~15 months).
+**Stable version 1.0 milestone:** end of phase 10 (~30 months).
+
+**Status at the close of Phase 4.5 (2026-05-24).** Phases 1 through 4.5 have their
+technical implementation complete and merged to `main`. "Technical implementation
+complete" means that the deliverables of code, tests, fmt, clippy, audit and
+deny are fulfilled; the exit criteria of community adoption (stars,
+external contributors, blog posts) are external metrics that are tracked
+separately and do not block technical advancement. The granular detail of each box
+lives in `docs/roadmap/STATUS.md`, which is the operational dashboard. The
+Phase 0 remains in progress due to external deliverables (Discord, landing, domain).
+Phase 5 (`ag-cloud`) is next.
+
+**Note on Phase 4.5.** Phase 4.5 is an **additive** phase introduced by
+`ADR-0007` after closing Phase 4. It does not modify the scope nor the
+deliverables of the already-completed Phase 4. It does not advance the v0.5 BETA milestone, which
+remains at the end of Phase 5. The ecosystem count goes from 15 to 17
+crates with the incorporation of `ag-mail` and `ag-domains`.
+
+---
+
+## Phase 0 — Foundations and governance
+
+**Objective.** Create the project's foundations: repository, license, governance documentation, CI, contributors, communication with the community. No code yet. The product of this phase is an open source project fit to receive collaborators.
+
+### 0.1 Entry criteria
+
+- [ ] Final decision to begin Anti-Gravital as a formal Gravital Labs project.
+- [ ] Approval of Apache 2.0 license without restrictions.
+- [ ] Public commitment from Ángel Nereira as initial maintainer.
+
+### 0.2 Deliverables
+
+- [ ] Repository `github.com/gravital-labs/anti-gravital` created and public.
+- [ ] `LICENSE` file with complete Apache 2.0 text.
+- [ ] Bilingual `README.md` file (Spanish + English) with value proposition.
+- [ ] `CONTRIBUTING.md` file with contribution guide, code conventions, pull request process.
+- [ ] `CODE_OF_CONDUCT.md` file adopting Contributor Covenant 2.1.
+- [ ] `SECURITY.md` file with responsible disclosure policy and address `anti@gravitalcloud.com` (backup: `angelnereira@gravitalcloud.com`).
+- [ ] `GOVERNANCE.md` file describing initial BDFL model and transition plan.
+- [ ] CI configuration with GitHub Actions: build on Linux x86-64, Linux ARM64, macOS ARM64, Windows x64.
+- [ ] Issue templates (bug report, feature request, RFC) and pull request template.
+- [ ] Basic branding: logo, color palette, typography. Applied to the README.
+- [ ] Official project Discord with channels `#español`, `#english`, `#announcements`, `#help`.
+- [ ] Project account on X/Bluesky for announcements.
+- [ ] Domain `antigravital.dev` registered and pointing to a minimal landing page.
+- [ ] Institutional email `anti@gravitalcloud.com` operational (project root email).
+- [ ] Public release calendar published.
+
+### 0.3 Exit criteria (gate before Phase 1)
+
+- [ ] The repository receives its first unsolicited external star.
+- [ ] At least five external people have joined the Discord.
+- [ ] The monorepo's folder structure is defined and committed (although without functional content).
+- [ ] The Cargo workspace is initialized with the empty crates: `ag-core`, `ag-dsl`, `ag-cli`, `ag-auth`, `ag-data`, `ag-realtime`, `ag-cache`, `ag-storage`, `ag-observe`, `ag-ui`, `ag-cloud`, `ag-ai`, `ag-mobile`, `ag-migrate`, `ag-wasm-host`.
+- [ ] The CI successfully builds the empty workspace on the four target platforms.
+- [ ] The landing page describes in one paragraph what the project is, what it is not, and where it is on the roadmap.
+
+### 0.4 Phase risks
+
+The main risk is procrastination due to perfectionism. Phase 0 does not produce code that runs, which tempts to postpone it. The mitigation is a strict timebox: 8 weeks maximum. If by the end not all deliverables are in place, it concludes with whatever exists and the pending items are documented as phase 0 technical debt to be resolved during phase 1.
+
+---
+
+## Phase 1 — The Shield MVP
+
+**Status: Technical implementation complete.** Detail of boxes in `docs/roadmap/STATUS.md`.
+
+**Objective.** Implement the core's Shield layer: a Tower middleware pipeline that validates, performs basic authentication, applies rate limiting and delivers requests to a placeholder handler. No complete Core yet. No DSL yet. The product is a binary that responds over HTTP with basic security and a publishable benchmark.
+
+### 1.1 Entry criteria
+
+- [ ] Phase 0 completed with all of its exit criteria checked.
+- [ ] At least one contributor in addition to the main maintainer is active in the repository.
+
+### 1.2 Deliverables
+
+- [ ] `ag-core` crate with operational `shield` module.
+- [ ] HTTP/1.1 and HTTP/2 support via Axum + Tokio.
+- [ ] TLS 1.3 termination with rustls.
+- [ ] Basic payload validation middleware (deserialization with serde and simple constraints).
+- [ ] JWT authentication middleware with Ed25519 verification.
+- [ ] Rate limiting middleware with governor (token bucket per IP).
+- [ ] CORS and CSRF middleware with secure defaults.
+- [ ] Structured logging middleware with `tracing`.
+- [ ] Minimal configuration from a TOML file.
+- [ ] Unit tests with coverage ≥ 80% of the `ag-core` crate.
+- [ ] End-to-end integration tests of the Shield pipeline.
+- [ ] Executable Hello World benchmark: `cargo bench` produces reproducible figures.
+- [ ] Crate API documentation generated with `cargo doc`, published on `docs.rs`.
+- [ ] User manual chapter explaining how to use the Shield directly as a library.
+
+### 1.3 Exit criteria (gate before Phase 2)
+
+- [ ] Hello World benchmark reaches ≥ 300 K req/s on documented reference hardware.
+- [ ] Shield pipeline p99 latency ≤ 1 ms at 100 K req/s.
+- [ ] Idle process memory ≤ 15 MB.
+- [ ] Startup time ≤ 100 ms.
+- [ ] CI passes on the four target platforms.
+- [ ] Static analysis with `clippy` without warnings.
+- [ ] Dependency analysis with `cargo-audit` without known vulnerabilities.
+- [ ] Zero undocumented `unsafe` blocks.
+- [ ] At least one technical blog post published about the Shield architecture.
+- [ ] At least ten stars on the repository.
+
+### 1.4 Phase risks
+
+The main risk is underestimating the complexity of TLS and rate limiting in production. The mitigation is to use exclusively proven crates (rustls, governor) and not to roll our own implementations. The secondary risk is that the benchmark figures do not reach the target; the mitigation is to publish what is measured with honesty and document the shortfall.
+
+---
+
+## Phase 2 — The Core MVP and complete roundtrip
+
+**Objective.** Complete the core with the Core layer: Axum router, typed extractors, error system, shared state. Implement the complete roundtrip Request → Shield → Core → Handler → Response. Connect to real PostgreSQL for a minimal CRUD. The product is a binary that serves a real API, although written manually without DSL.
+
+### 2.1 Entry criteria
+
+- [ ] Phase 1 completed with all of its exit criteria checked.
+- [ ] The `ag-data` crate has been started with sqlx as a dependency.
+
+### 2.2 Deliverables
+
+- [ ] `ag-core` crate with operational `core` module.
+- [ ] Axum router integrated with the Shield.
+- [ ] Extractors: `State<T>`, `ValidatedBody<T>`, `Claims<T>`, `Path<T>`, `Query<T>`.
+- [ ] `AgError` error system with automatic conversion to HTTP response.
+- [ ] Response system: JSON, plaintext, streams.
+- [ ] `ag-data` crate with PostgreSQL connection pool via sqlx.
+- [ ] Embedded migrations system with `sqlx::migrate!`.
+- [ ] Example app `todo-api` in `examples/` with complete CRUD.
+- [ ] Executable CRUD + DB benchmark.
+- [ ] `ag-cli` crate with commands `new` (creates project from template), `dev` (starts server with hot reload via `cargo-watch`), `build` (compiles release).
+- [ ] Three templates: `rest`, `realtime`, `fullstack`.
+
+### 2.3 Exit criteria (gate before Phase 3)
+
+- [ ] CRUD + PostgreSQL benchmark reaches ≥ 40 K req/s on reference hardware.
+- [ ] CRUD p99 latency ≤ 5 ms.
+- [ ] The `todo-api` app runs successfully with `ag new` + `ag dev`.
+- [ ] The `todo-api` app deploys as a single binary (`FROM scratch` Docker).
+- [ ] The release binary of `todo-api` occupies ≤ 20 MB.
+- [ ] Documentation: "Your first API with Anti-Gravital" published.
+- [ ] At least 50 stars on the repository.
+- [ ] At least three external contributors with merged PRs.
+
+### 2.4 Phase risks
+
+The main risk is scope drift: wanting to add features not strictly necessary for the Core MVP. The mitigation is an explicit scope declaration in the phase ticket: the Core of this phase does not include complex RBAC authorization, does not include events, does not include cache, does not include complete observability. Those arrive in later phases.
+
+---
+
+## Phase 3 — Anti-DSL alpha (versions 0.1 to 0.4 of the DSL)
+
+**Objective.** Build the DSL compiler with a deliverable subset of the grammar. This phase delivers the first functional codegen: models, basic endpoints, validations and relations. No declarative auth yet, no events yet. The product is the first version of the "define → generate → implement" flow.
+
+### 3.1 Entry criteria
+
+- [ ] Phase 2 completed with all of its exit criteria checked.
+- [ ] `ag-dsl` crate started.
+- [ ] Final decision on the compiler's base libraries (logos for lexer, chumsky for parser, askama and quote for codegen). Documented in RFC.
+
+### 3.2 Deliverables
+
+- [ ] DSL version 0.1: basic models with primitive annotations (`@primary`, `@unique`, `@auto`).
+- [ ] DSL version 0.2: endpoints (method, path, body, response).
+- [ ] DSL version 0.3: validations (`@min`, `@max`, `@email`, `@regex`, `@length`).
+- [ ] DSL version 0.4: relations between models (`1:1`, `1:N`, `N:M`).
+- [ ] Rust generator: structs with serde, validators, sqlx query builders.
+- [ ] SQL generator: idempotent migrations.
+- [ ] TypeScript generator: types and HTTP client.
+- [ ] OpenAPI 3.1 generator.
+- [ ] `ag generate` command that reads `schema.ag` and produces all the artifacts.
+- [ ] `ag schema lint` command that reports best-practices warnings.
+- [ ] `ag schema diff <ref>` command that reports breaking vs non-breaking changes.
+- [ ] Readable diagnostics for common DSL errors (model not found, unknown type, invalid annotation).
+- [ ] Basic LSP server (`ag-lsp`) with autocompletion and diagnostics.
+- [ ] VS Code plugin published on the marketplace.
+- [ ] Compiler test suite with coverage ≥ 85%.
+- [ ] Parser fuzzing with `cargo-fuzz`: 24 hours without crashes.
+- [ ] DSL reference documentation version by version.
+
+### 3.3 Exit criteria (gate before Phase 4)
+
+- [ ] A complete project can be created, defined in `schema.ag`, generated, and executed using only the CLI.
+- [ ] The `ecommerce-api` example is completely rewritten with DSL and works.
+- [ ] The benchmarks are maintained: DSL-generated CRUD is not slower than hand-written CRUD.
+- [ ] The VS Code plugin has ≥ 100 installations.
+- [ ] At least one external collaborator has contributed to the compiler.
+- [ ] The DSL documentation is complete and reviewed by at least two people.
+- [ ] At least 200 stars on the repository.
+
+### 3.4 Phase risks
+
+The DSL compiler is the technically most complex component of the project. The main risk is underestimating the effort and exceeding the schedule. The mitigation is incremental implementation by subversions: if the phase runs long, subversion 0.4 (relations) can be postponed to phase 4 without blocking advancement.
+
+The secondary risk is the compiler's error messages. A compiler with incomprehensible messages ruins the experience. The mitigation is to prioritize readable diagnostics from day one, with specific tests that verify that the messages are useful.
+
+---
+
+## Phase 4 — Standard modules
+
+**Objective.** Complete the batteries-included modules: auth, realtime, cache, storage, observe. Each as an independent crate, with tests, documentation and examples.
+
+### 4.1 Entry criteria
+
+- [ ] Phase 3 completed.
+- [ ] DSL version 0.5 (auth and policies) started.
+
+### 4.2 Deliverables
+
+- [ ] DSL version 0.5: auth declaration and RBAC policies.
+- [ ] DSL version 0.6: events declaration.
+- [ ] Complete `ag-auth` crate: WebAuthn, JWT Ed25519, OAuth2 (Google, GitHub), API keys, refresh tokens with rotation.
+- [ ] Complete `ag-realtime` crate: binary WebSocket, SSE fallback, embedded NATS for small cases, external NATS client for production.
+- [ ] Complete `ag-cache` crate: moka L1 + Redis L2 with fred, event-based invalidation.
+- [ ] Complete `ag-storage` crate: S3, MinIO, local filesystem adapters. Signed URLs. Image processing.
+- [ ] Complete `ag-observe` crate: tracing, OpenTelemetry exporter, Prometheus metrics, Grafana JSON dashboards included.
+- [ ] tokio-console integration in dev mode.
+- [ ] `realtime-chat` example in `examples/`.
+- [ ] `ai-backend` example in `examples/` that demonstrates SSE streaming.
+- [ ] Cross-module integration tests.
+
+### 4.3 Exit criteria (gate before Phase 5)
+
+- [ ] The five modules published on crates.io with their respective independent releases.
+- [ ] Test coverage ≥ 80% in each module.
+- [ ] Documentation for each module: README, usage guide, API reference.
+- [ ] Performance: the `ag-realtime` module sustains 50 K WebSocket connections on a 2 vCPU instance without degradation.
+- [ ] Performance: the `ag-cache` module shows ≥ 1 M ops/second in L1.
+- [ ] At least five bug report issues closed by the community.
+- [ ] At least 500 stars on the repository.
+
+### 4.4 Phase risks
+
+The main risk is the fragmentation of effort among five parallel modules. The mitigation is to sequence the implementation: first auth (blocks many use cases), then advanced data, then realtime, then cache, then storage, then observe.
+
+---
+
+## Phase 4.5 — `ag-mail` + `ag-domains`: communication and domains
+
+**Objective.** Add operational capabilities for transactional communication, DNS,
+TLS and domains without overloading Phase 4 nor delaying the standard modules.
+It prepares the ground so that `ag-cloud` (Phase 5) deploys applications with
+domain, certificate and transactional email using an integrated
+experience. The introduction of this phase is made official in `ADR-0007`.
+
+**Duration:** 1–2 months.
+
+### 4.5.1 Entry criteria
+
+- [ ] Phase 4 completed with all of its exit criteria checked.
+- [ ] `ag-auth` exposes hooks/events for email verification, password
+  recovery and magic links.
+- [ ] `ag-observe` records metrics and traces of asynchronous jobs.
+- [ ] RFC approved for the initial scope of `ag-mail`.
+- [ ] RFC approved for the initial scope of `ag-domains`.
+
+### 4.5.2 Deliverables
+
+- [ ] `ag-mail` crate (deferred standard): native outbound SMTP sender
+  (`lettre` + `rustls`) plus `MailSender` trait with adapters (Resend, SES,
+  Postmark) as Cargo features.
+- [ ] HTML/plaintext templates with typed `askama`, validated at compile-time
+  against `schema.ag`.
+- [ ] Email declaration in `schema.ag` (`mail` block).
+- [ ] `ag-auth` → `ag-mail` integration for verification, recovery and
+  magic links, via a small trait defined in `ag-auth`.
+- [ ] Asynchronous queue with retries and exponential backoff; in-memory backend
+  by default, persistent via optional `ag-data`.
+- [ ] Metrics towards `ag-observe`: `ag_mail_sent_total`, `ag_mail_failed_total`,
+  `ag_mail_retry_total`, latency histogram.
+- [ ] `ag-domains` crate (optional infra): `DnsProvider` trait with Cloudflare
+  adapter; declarative A/AAAA/CNAME/TXT/MX model.
+- [ ] ACME support (Let's Encrypt) via `instant-acme`: automatic issuance and
+  renewal, DNS-01 challenge preferred, HTTP-01 alternative.
+- [ ] Generation of SPF/DKIM/DMARC required by `ag-mail` (cooperation
+  `ag-mail` ↔ `ag-domains` without dependency cycle).
+- [ ] Propagation verification against multiple public resolvers
+  (`hickory-resolver`).
+- [ ] DSL v0.7: `mail`, `domain`, `dns`, `tls` blocks; the compiler validates
+  that the `from` references a declared `domain`, that the template exists and
+  that the HTML variables match the typed `vars`.
+- [ ] Update of the `ag-lsp` LSP for the new blocks.
+- [ ] CLI commands: `ag domains check`, `ag domains sync`, `ag mail test`.
+- [ ] `auth-mail-demo` example in `examples/`: registration + verification by
+  email + magic link.
+- [ ] Documentation: "Configure domain, TLS and transactional email with
+  Anti-Gravital".
+
+### 4.5.3 Exit criteria (gate before Phase 5)
+
+- [ ] `ag-mail` sends transactional HTML and plaintext email from an
+  Anti-Gravital project via the native sender **and** via at least one adapter.
+- [ ] `ag-auth` uses `ag-mail` for email verification and password
+  recovery in the `auth-mail-demo` example.
+- [ ] `ag-domains` creates and verifies DNS records on at least one
+  real provider.
+- [ ] `ag-domains` issues and renews TLS certificates via ACME in a test
+  environment (Let's Encrypt staging).
+- [ ] `ag-domains` generates SPF/DKIM/DMARC required by `ag-mail`.
+- [ ] `ag domains check`, `ag domains sync` and `ag mail test` work in reproducible
+  CI.
+- [ ] Unit and integration test coverage ≥ 75 % in both crates.
+- [ ] Zero circular dependencies with `ag-core`, `ag-dsl`, `ag-auth` or
+  `ag-cloud` (green CI job).
+- [ ] `cargo fmt`, `cargo clippy -D warnings`, `cargo test`, `cargo audit` and
+  `cargo deny check` green.
+
+### 4.5.4 Phase risks
+
+The main risk is **confusing `ag-mail` with a complete MTA**. The
+mitigation is the explicit restriction of the v1 scope to outbound + adapters;
+inbound, IMAP/POP, persistent mailboxes and antispam remain documented as
+out of scope, not as "deferred to v2".
+
+The second risk is the **dependency on young upstreams** (`instant-acme`,
+`hickory-resolver`) in domains where bugs are paid for dearly: a certificate
+that does not renew brings down the site. The mitigation is a small
+and versioned `DnsProvider` trait with contract tests, explicit pinning in the
+workspace, and active monitoring of the evolution of the crates.
+
+The third risk is **turning Anti-Gravital into a hosting panel** by
+accumulation of capabilities. The mitigation is the project's interoperability
+rule: both crates are abstractions with adapters, not replacements for
+providers. The boundary is fixed in `ADR-0007` and does not move without a new
+ADR.
+
+---
+
+## Phase 5 — `ag-cloud` simplified deployment
+
+**Objective.** Build the deployment subsystem in the style of Railway/Fly.io. Support for the four targets: docker-compose, fly, railway, k8s. This is the **public beta version (0.5)** milestone.
+
+### 5.1 Entry criteria
+
+- [ ] Phase 4 completed.
+- [ ] RFC decision on the deployment targets supported in 1.0.
+
+### 5.2 Deliverables
+
+- [ ] `ag-cloud` crate with modules for each target.
+- [ ] Specification of the `deploy.ag` file.
+- [ ] Multi-stage Dockerfile generator optimized for minimal image.
+- [ ] docker-compose target: complete stack generation with Caddy as reverse proxy and automatic TLS.
+- [ ] fly target: integration with flyctl.
+- [ ] railway target: integration with its API.
+- [ ] k8s target: generation of standard manifests.
+- [ ] `ag deploy` command.
+- [ ] `ag rollback` command.
+- [ ] Database migrations pipeline integrated into the deployment.
+- [ ] Documentation: "From zero to production in 15 minutes" with each target.
+
+### 5.3 Exit criteria (gate before Phase 6 and version 0.5)
+
+- [ ] The `todo-api` example deploys successfully to Fly.io with `ag deploy`.
+- [ ] The `ecommerce-api` example deploys successfully with docker-compose to a VPS and is accessed via domain with TLS.
+- [ ] The `realtime-chat` example deploys successfully to Railway.
+- [ ] Version 0.5 (public beta) released on GitHub Releases.
+- [ ] Public announcement on Hacker News, Reddit `/r/rust`, Twitter/X, Bluesky, LinkedIn.
+- [ ] At least ten external projects report that they have deployed Anti-Gravital in production or staging.
+- [ ] At least 1 500 stars on the repository.
+
+### 5.4 Phase risks
+
+The main risk is the dependency on external APIs (Fly, Railway) that can change. The mitigation is to structure each target as a decoupled module with contract tests.
+
+---
+
+## Phase 6 — `ag-ai` and Knowledge Graph
+
+**Objective.** Build the AI module with the knowledge graph and the assisted capabilities.
+
+### 6.1 Entry criteria
+
+- [ ] Version 0.5 (public beta) released.
+- [ ] Feedback from the first users incorporated into the backlog.
+
+### 6.2 Deliverables
+
+- [ ] Knowledge graph generator from the DSL AST.
+- [ ] Persistence of the graph in `.ag/knowledge-graph.json`.
+- [ ] Markdown architectural documentation generator from the graph.
+- [ ] C4 diagram generator (Context, Container, Component) in Mermaid.
+- [ ] Interactive graph dashboard in the dev server (`ag dev`).
+- [ ] `ag ai suggest-schema` command with integration to a configurable provider.
+- [ ] `ag ai review-migration` command.
+- [ ] `ag ai analyze-architecture` command.
+- [ ] Support for providers: Anthropic Claude, OpenAI, local Ollama, local vLLM.
+- [ ] Offline mode where the AI functions are disabled but the framework works.
+- [ ] Documentation: "Anti-Gravital + AI agents: the schema-first flow" with complete examples.
+
+### 6.3 Exit criteria (gate before Phase 7)
+
+- [ ] The knowledge graph regenerates correctly with each `ag generate`.
+- [ ] The generated architectural documentation is readable and useful (reviewed by three people external to the team).
+- [ ] At least one user organization reports that it has integrated `ag ai` into its workflow.
+- [ ] At least 2 500 stars on the repository.
+
+### 6.4 Phase risks
+
+The main risk is the dependency on external AI providers. The mitigation is provider abstraction and offline mode.
+
+---
+
+## Phase 7 — `ag-migrate` importers
+
+**Objective.** Build the migration importers from legacy frameworks. It is probably the phase with the greatest impact on real adoption.
+
+### 7.1 Entry criteria
+
+- [ ] Phase 6 completed.
+- [ ] Research of real samples: at least ten schemas/projects of each target framework collected as a testing corpus.
+
+### 7.2 Deliverables
+
+- [ ] `ag-migrate` crate with five importers:
+  - [ ] OpenAPI 3.0 and 3.1 importer.
+  - [ ] Prisma importer.
+  - [ ] Django importer.
+  - [ ] FastAPI importer.
+  - [ ] Sequelize importer.
+  - [ ] GraphQL SDL importer.
+- [ ] `ag migrate from <framework> <path>` command.
+- [ ] Official migration guides per framework with complete examples.
+- [ ] Documented case study: real migration of a medium-sized FastAPI application.
+
+### 7.3 Exit criteria (gate before Phase 8)
+
+- [ ] Each importer has test coverage ≥ 80% over the corpus of real projects.
+- [ ] The FastAPI migration guide has been validated by at least one external team that migrated its application.
+- [ ] At least 3 500 stars on the repository.
+
+### 7.4 Phase risks
+
+The importers cover the translation of the contract, not the business logic. The risk is generating exaggerated expectations. The mitigation is honest documentation about what is imported and what is not.
+
+---
+
+## Phase 8 — `ag-mobile` Flutter bridge
+
+**Objective.** Build the integration with Flutter as the priority mobile target. Generation of complete Dart SDK, native auth, realtime.
+
+### 8.1 Entry criteria
+
+- [ ] Phase 7 completed.
+- [ ] At least one collaborator with significant Flutter experience has joined the project.
+
+### 8.2 Deliverables
+
+- [ ] `ag-mobile` crate with Dart generator.
+- [ ] `anti_gravital` pub package published on pub.dev:
+  - [ ] Types generated with freezed.
+  - [ ] HTTP client with dio + interceptors.
+  - [ ] WebSocket client.
+  - [ ] SSE client.
+  - [ ] Mocks for tests.
+- [ ] Authentication widgets: registration and login with native WebAuthn (Android Credential Manager, iOS Passkeys), OAuth2.
+- [ ] `flutter-fullstack` example in `examples/`: complete Flutter app with Anti-Gravital backend.
+- [ ] Documentation: Flutter user guide.
+
+### 8.3 Exit criteria (gate before Phase 9)
+
+- [ ] The `anti_gravital` package on pub.dev has at least 50 likes.
+- [ ] The `flutter-fullstack` example runs on Android, iOS and web.
+- [ ] At least one external Flutter application uses Anti-Gravital in staging or production.
+- [ ] At least 4 500 stars on the repository.
+
+### 8.4 Phase risks
+
+The main risk is that the Rust → Dart context switch has unforeseen frictions. The mitigation is to start with the simplest case (CRUD) and build incrementally.
+
+---
+
+## Phase 9 — WASI plugin system
+
+**Objective.** Build the WASI plugin system with wasmtime, define the stable ABI, publish the official plugins, and start the public registry.
+
+### 9.1 Entry criteria
+
+- [ ] Phase 8 completed.
+- [ ] RFC decision on the scope of the 1.0 plugin ABI. Approved by the technical committee (formed in phase 4 or earlier).
+
+### 9.2 Deliverables
+
+- [ ] `ag-wasm-host` crate operational over wasmtime.
+- [ ] Definition of WIT interfaces (WebAssembly Interface Types) for the host.
+- [ ] Specification of `plugin.toml`.
+- [ ] Implementation of the plugin life cycle (discovery, validation, loading, activation, unloading).
+- [ ] Sandbox with memory, fuel and timeout limits.
+- [ ] Official plugins: `prometheus-exporter`, `datadog-exporter`, `sentry`, `honeycomb-exporter`, `slack-notifier`, `discord-webhook`.
+- [ ] `ag plugin add/remove/list` command.
+- [ ] Public registry at `plugins.antigravital.dev`.
+- [ ] Guide: "How to write a plugin for Anti-Gravital" with examples in Rust, Go (TinyGo) and AssemblyScript.
+
+### 9.3 Exit criteria (gate before Phase 10)
+
+- [ ] The registry publishes at least the six official plugins.
+- [ ] At least three third-party external plugins published in the registry.
+- [ ] The benchmark shows plugin overhead ≤ 1% over an equivalent native handler.
+- [ ] At least 6 000 stars on the repository.
+
+### 9.4 Phase risks
+
+The main risk is the complexity of the WebAssembly component model, which keeps evolving. The mitigation is conservative pinning of the supported version and early commitment with the wasmtime community.
+
+---
+
+## Phase 10 — Hardening and 1.0 milestone
+
+**Objective.** Bring the project to stable version 1.0. It is the phase of audits, hardening, final optimization, and public declaration of stability.
+
+### 10.1 Entry criteria
+
+- [ ] Phase 9 completed.
+- [ ] DSL version 1.0 (stable grammar) ready for freeze.
+- [ ] The technical committee is active and operational.
+
+### 10.2 Deliverables
+
+- [ ] DSL version 1.0 (stable grammar, frozen).
+- [ ] Test coverage ≥ 85% in all workspace crates.
+- [ ] 72-hour fuzzing over the DSL parser without crashes.
+- [ ] 72-hour fuzzing over the HTTP parser without crashes.
+- [ ] External security audit of the Shield component, contracted with a specialized company (Trail of Bits, NCC Group or equivalent). Public report.
+- [ ] Resolution of all critical and high findings of the audit.
+- [ ] Load test: 500 K req/s sustained for 30 minutes with degradation ≤ 5%.
+- [ ] Memory leak test: 24 hours of continuous load without detectable memory growth.
+- [ ] Compilation verified on: Linux x86-64, Linux ARM64, macOS ARM64, Windows x64.
+- [ ] Compilation to `wasm32-wasi` to serve Anti-Gravital in edge functions.
+- [ ] Official manual published: "The Anti-Gravital Book" in Spanish and English.
+- [ ] Framework introduction course on YouTube (minimum six videos).
+- [ ] Position in TechEmpower Framework Benchmarks: top 10 in Plaintext and JSON Serialization categories.
+
+### 10.3 Exit criteria (version 1.0)
+
+- [ ] At least three external projects using Anti-Gravital in production for at least 30 days without critical incidents.
+- [ ] At least one internal Gravital Cloud service using Anti-Gravital in production for 30 days without critical incidents.
+- [ ] Public announcement of version 1.0 with complete changelog.
+- [ ] Commitment to strict semver from 1.0.
+- [ ] Announcement of the LTS version calendar.
+- [ ] Talk at at least one international conference (RustConf, EuroRust, RustNation or equivalent).
+- [ ] At least 10 000 stars on the repository.
+- [ ] The technical committee ratifies the promotion to version 1.0 unanimously.
+
+### 10.4 Phase risks
+
+The main risk is the pressure to release 1.0 before time. The mitigation is the project's strictest rule: the exit criteria are non-negotiable. If they are not met, 1.0 is not released. 0.9.5, 0.9.6 are released, until they are met.
+
+---
+
+## Beyond 1.0: future roadmaps
+
+Once 1.0 is released, the project enters stable maintenance mode with minor releases every 3 months. The candidate topics for future versions include:
+
+- Version 1.x: additional performance optimizations, support for additional protocols (HTTP/3 via QUIC).
+- Version 2.x: refactoring of the plugin ABI if the WebAssembly community makes major changes. Support for new deployment targets.
+- Swift generator for native iOS.
+- Kotlin Multiplatform generator for native Android and cross-platform cases.
+- More sophisticated multi-tenant support with instance federation.
+
+This extended roadmap is not a commitment. It is documented to signal direction, but it will be reserved for specific RFCs when the time comes.
+
+---
+
+## Golden rules of the process
+
+By way of closing, the five rules that govern this end-to-end process:
+
+**First rule.** A phase is not considered concluded until all of its exit criteria boxes are checked. No exceptions.
+
+**Second rule.** If a phase requires more time than estimated, it is extended. If the original scope is not attainable, it is reduced with a public RFC; the quality criteria are not relaxed.
+
+**Third rule.** Every significant architectural decision requires an RFC. The iteration speed does not justify skipping the process.
+
+**Fourth rule.** The project is released when it is ready, not when an external date demands it. Technical credibility is the project's most valuable asset.
+
+**Fifth rule.** Every public promise (benchmark, feature, date) is documented with evidence. If there is no evidence, it is not promised.
+
+These rules exist for a reason. Anti-Gravital sets out to compete with frameworks that have matured over decades. The only way to be taken seriously is to build with the same seriousness.
+
+---
+
+**End of the Roadmap document.**
+Complementary document: *Technical Architecture and Implementation.*
+Unified PDF version: *Anti-Gravital Blueprint v4.0 — Master Document.*
+
+---
+
+## Espanol
 
 ## Cómo leer este documento
 

--- a/docs/master/ANTI-GRAVITAL-Hoja-de-Ruta.md
+++ b/docs/master/ANTI-GRAVITAL-Hoja-de-Ruta.md
@@ -28,13 +28,13 @@ La regla principal es: **una fase no se da por concluida hasta que todas sus cas
 
 | Fase | Nombre                                     | Duración estimada | Estado    |
 |------|--------------------------------------------|-------------------|-----------|
-| 0    | Fundaciones y gobernanza                   | 1–2 meses         | Pendiente |
-| 1    | The Shield MVP                             | 2–3 meses         | Pendiente |
-| 2    | The Core MVP + roundtrip                   | 2 meses           | Pendiente |
-| 3    | Anti-DSL alpha (v0.1–v0.4)                 | 3 meses           | Pendiente |
-| 4    | Módulos estándar (auth, data, realtime)    | 3 meses           | Pendiente |
-| 4.5  | `ag-mail` + `ag-domains`: comunicación y dominios | 1–2 meses  | Pendiente |
-| 5    | `ag-cloud` — despliegue simplificado       | 2 meses           | Pendiente |
+| 0    | Fundaciones y gobernanza                   | 1–2 meses         | En curso (entregables externos pendientes) |
+| 1    | The Shield MVP                             | 2–3 meses         | Implementación técnica completa |
+| 2    | The Core MVP + roundtrip                   | 2 meses           | Implementación técnica completa |
+| 3    | Anti-DSL alpha (v0.1–v0.4)                 | 3 meses           | Implementación técnica completa |
+| 4    | Módulos estándar (auth, data, realtime)    | 3 meses           | Implementación técnica completa |
+| 4.5  | `ag-mail` + `ag-domains`: comunicación y dominios | 1–2 meses  | Implementación técnica completa |
+| 5    | `ag-cloud` — despliegue simplificado       | 2 meses           | Próxima |
 | 6    | `ag-ai` y Knowledge Graph                  | 2 meses           | Pendiente |
 | 7    | `ag-migrate` — importadores                | 2 meses           | Pendiente |
 | 8    | `ag-mobile` — Flutter bridge               | 2 meses           | Pendiente |
@@ -44,6 +44,16 @@ La regla principal es: **una fase no se da por concluida hasta que todas sus cas
 **Duración total estimada:** 25–30 meses desde el inicio.
 **Hito de versión beta pública (0.5):** final de fase 5 (~15 meses).
 **Hito de versión 1.0 estable:** final de fase 10 (~30 meses).
+
+**Estado al cierre de la Fase 4.5 (2026-05-24).** Las fases 1 a 4.5 tienen su
+implementación técnica completa y mergeada a `main`. "Implementación técnica
+completa" significa que los entregables de código, tests, fmt, clippy, audit y
+deny están cumplidos; los criterios de salida de adopción comunitaria (stars,
+contribuidores externos, blog posts) son métricas externas que se rastrean
+aparte y no bloquean el avance técnico. El detalle granular de cada casilla
+vive en `docs/roadmap/STATUS.md`, que es el tablero de mando operativo. La
+Fase 0 permanece en curso por entregables externos (Discord, landing, dominio).
+La Fase 5 (`ag-cloud`) es la próxima.
 
 **Nota sobre la Fase 4.5.** La Fase 4.5 es una fase **aditiva** introducida por
 `ADR-0007` después de cerrar la Fase 4. No modifica el alcance ni los
@@ -97,6 +107,8 @@ El principal riesgo es la procrastinación por perfeccionismo. La fase 0 no prod
 ---
 
 ## Fase 1 — The Shield MVP
+
+**Estado: Implementación técnica completa.** Detalle de casillas en `docs/roadmap/STATUS.md`.
 
 **Objetivo.** Implementar la capa Shield del núcleo: una pipeline de middleware Tower que valida, autentica básicamente, aplica rate limiting y entrega requests a un handler placeholder. Sin Core completo todavía. Sin DSL todavía. El producto es un binario que responde HTTP con seguridad básica y benchmark publicable.
 

--- a/docs/master/VERSION.md
+++ b/docs/master/VERSION.md
@@ -12,19 +12,22 @@ desde el origen autorizado antes de continuar.
 ## Versión vigente
 
 - Versión documental: 4.1 (markdown) — Blueprint PDF pendiente de re-export
-- Fecha de la versión documental: 2026-05-23 (suplemento Fase 4.5)
+- Fecha de la versión documental: 2026-05-25 (cierre documental Fase 4.0-4.5)
 - Fecha de instalación en el repositorio: 2026-05-19 (v4.0 inicial)
 - Origen: aporte directo de Gravital Labs (Nereira Technology and
   Business Solutions), República de Panamá.
 - Licencia de la documentación: Apache 2.0, igual que el código.
+- Idioma: maestros markdown bilingües (inglés canónico primero, español
+  después) según `ADR-0008`. El Blueprint v4.1.md es la fuente markdown.
 
 ## Maestros instalados
 
 | Archivo | Tamano (bytes) | SHA-256 |
 | --- | --- | --- |
 | `ANTI-GRAVITAL-Blueprint-v4.0.pdf` | 511945 | `59a1df26bd24e96067c58c142709e3cb55fc33efbb1c8f3739d9473598dfb660` |
-| `ANTI-GRAVITAL-Arquitectura-Tecnica.md` | 102322 | `5f56cadcf03f49289b7f4a141eccf4c6289543caf65041f38b54a4830b6bd76d` |
-| `ANTI-GRAVITAL-Hoja-de-Ruta.md` | 33516 | `ff5e322f568e2ecf416d09235c91d8f4eb004531b6844f513a68b63042b64590` |
+| `ANTI-GRAVITAL-Blueprint-v4.1.md` | 10007 | `a6a1479c3586ea0bb7afeff3f801d13aebcea0f046216130358f0b897e351bc6` |
+| `ANTI-GRAVITAL-Arquitectura-Tecnica.md` | 203145 | `d511e96b4a00a6eb2aec09efe7a7fd6c15a0cef7ff89d055f3e2f9fff7b8de31` |
+| `ANTI-GRAVITAL-Hoja-de-Ruta.md` | 67324 | `24a5fa50a02a167d32bd2c3e650d65344a16f01735dc6a358ec5f303017cd3b9` |
 
 ### Deuda explícita — Blueprint PDF v4.1
 
@@ -51,6 +54,7 @@ nueva del historial de revisiones.
 | 2026-05-19 | Instalacion inicial de los tres maestros v4.0. | Aporte directo de Gravital Labs. |
 | 2026-05-19 | Reemplazo de placeholders de email: `security@gravital.io` y `hello@antigravital.dev` por `anti@gravitalcloud.com` (raiz) con `angelnereira@gravitalcloud.com` como respaldo de seguridad. Registrado en `docs/adr/0005-contact-identities.md`. | Decision del BDFL inicial. |
 | 2026-05-23 | Suplemento Fase 4.5: Hoja-de-Ruta y Arquitectura-Técnica actualizados con `ag-mail` (estándar diferido) y `ag-domains` (opcional infra), 15→17 crates, 24–28→25–30 meses, tabla DSL realineada, dirección de dependencia `ag-auth → ag-mail` documentada. Registrado en `docs/adr/0007-ag-mail-ag-domains.md`. Blueprint PDF queda como deuda explícita pendiente de re-export. | Decisión del BDFL vía ADR-0007. |
+| 2026-05-25 | Cierre documental Fase 4.0-4.5: (1) maestros markdown convertidos a bilingüe (inglés canónico primero, español después) según `ADR-0008`; (2) fidelidad a implementación real — fases 1-4.5 marcadas técnicamente completas en la Hoja-de-Ruta, y en la Arquitectura se corrigió WebAuthn (ciborium/p256/ed25519 vía ADR-0006), templates de correo (StringTemplate), y caché L2 (RFC-0005, no implementado); (3) nuevo `ANTI-GRAVITAL-Blueprint-v4.1.md` como fuente markdown versionable del Blueprint. Blueprint PDF sigue como deuda pendiente de re-export. | Decisión del BDFL vía ADR-0008. |
 
 ## Verificación local
 

--- a/docs/pr-drafts/docs-cierre-fase-4.5.md
+++ b/docs/pr-drafts/docs-cierre-fase-4.5.md
@@ -1,0 +1,85 @@
+# docs(cierre-4.5): fase documental de cierre 4.0-4.5 (idioma + maestros)
+
+## Fase afectada
+
+Cierre documental de las fases 4.0 a 4.5, previo al inicio de la Fase 5
+(`ag-cloud`). No introduce código funcional nuevo: alinea la documentación
+con la implementación real y fija la política de idioma.
+
+## Tipo de cambio
+
+Documentación y gobernanza (`docs`). Conversión de comentarios de código a
+inglés (sin cambios de comportamiento).
+
+## Documentos relacionados
+
+- `docs/rfc/RFC-0008-politica-de-idioma.md` — política de idioma
+- `docs/adr/0008-politica-de-idioma.md` — decisión (supersede ADR-0002)
+- `docs/master/VERSION.md` — hashes y registro de maestros
+
+## Resumen
+
+Fase documental de cierre que deja la documentación fiel a la
+implementación y establece la política de idioma antes de Fase 5.
+
+**Gobernanza de idioma:**
+- `RFC-0008` + `ADR-0008`: inglés canónico para código y documentación
+  técnica; vitrina bilingüe (README, maestros, manual) EN+ES mismo archivo,
+  inglés primero. `ADR-0002` marcado superseded.
+- `CLAUDE.md`: nueva regla de idioma.
+
+**Maestros (fieles + bilingües, inglés-primero):**
+- `ANTI-GRAVITAL-Hoja-de-Ruta.md`: fases 1-4.5 marcadas técnicamente
+  completas (antes todas "Pendiente"); bilingüe.
+- `ANTI-GRAVITAL-Arquitectura-Tecnica.md`: corregida la fidelidad —
+  WebAuthn con ciborium/p256/ed25519 (ADR-0006, no webauthn-rs), templates
+  de correo con StringTemplate/MailTemplate (no askama), caché L2 no
+  implementado (RFC-0005); bilingüe.
+- `ANTI-GRAVITAL-Blueprint-v4.1.md`: nueva fuente markdown versionable del
+  Blueprint, bilingüe. El PDF v4.0 sigue como deuda explícita.
+- `VERSION.md` + `.github/workflows/docs.yml`: hashes SHA-256 recalculados
+  y Blueprint v4.1.md registrado en la verificación de integridad.
+
+**Vitrina:**
+- `README.md`: inglés primero con ancla de idioma; ya fiel a 4.5.
+
+**Código:**
+- Comentarios de código (`//`, `///`, `//!`) traducidos de español a inglés
+  en los crates, examples y tests. Identificadores y mensajes de error de
+  usuario sin cambios.
+
+**Limpieza de ramas:**
+- Borradas las ramas mergeadas (locales y remotas) dejando solo `main` y la
+  rama de cierre. `origin/f45-pendientes` se borra tras el merge de este PR
+  (su commit huérfano 4b32219 se preserva aquí vía cherry-pick).
+
+## Plan de prueba
+
+- `cargo build --workspace` — compila (comentarios no afectan compilación)
+- `cargo clippy --workspace -- -D warnings` — 0 warnings
+- `cargo fmt --all -- --check` — limpio
+- `cargo test --workspace` — 0 fallos
+- CI `masters integrity` — hashes coinciden (verificado localmente)
+- CI `prohibited content scan` — sin emojis ni evidencia de herramientas IA
+
+## Criterios de salida avanzados
+
+- Documentación fiel a la implementación real de fases 4.0-4.5.
+- Política de idioma fijada (inglés canónico + vitrina bilingüe).
+- Maestros bilingües con hashes de integridad actualizados.
+- Repositorio listo para iniciar Fase 5 con la documentación en orden.
+
+## Checklist final
+
+- [x] Pertenece a la fase correcta (cierre 4.0-4.5)
+- [x] Respeta la documentación (RFC + ADR para los cambios de gobernanza)
+- [x] No rompe arquitectura
+- [x] No añade complejidad innecesaria
+- [x] No crea dependencias circulares
+- [x] Compila
+- [x] Pasa tests
+- [x] Pasa fmt
+- [x] Pasa clippy
+- [x] Maestros con hashes actualizados (VERSION.md + workflow)
+- [x] Sin emojis ni evidencia de herramientas IA
+- [x] Mantiene coherencia con Anti-Gravital v4.0/v4.1

--- a/docs/rfc/RFC-0008-politica-de-idioma.md
+++ b/docs/rfc/RFC-0008-politica-de-idioma.md
@@ -1,0 +1,150 @@
+# RFC-0008 - Politica de idioma: ingles canonico y vitrina bilingue
+
+- Estado: aceptada
+- Autor: Angel Nereira
+- Fecha de borrador: 2026-05-24
+- Fase objetivo: Cierre documental Fase 4.0-4.5 (previo a Fase 5)
+- Modulos o crates afectados: todos (comentarios de codigo); docs/
+- RFC predecesora: ninguna
+- ADR relacionada: supersede parcialmente ADR-0002
+- Periodo de comentarios: abreviado por decision del BDFL (cierre de fase)
+
+## 1. Motivacion
+
+`ADR-0002` (2026-05-19) fijo documentacion bilingue con **espanol como
+predeterminado** y dejo escrito que la decision "se revisa cuando el comite
+tecnico se forme en Fase 4". Estamos cerrando la Fase 4.5; es el momento
+previsto para revisar la politica.
+
+Durante las fases 1-4.5 el codigo acumulo ~3200 lineas de comentarios en
+espanol distribuidas en 118 archivos `.rs`, y la documentacion crecio a 147
+archivos markdown (~29 000 lineas) mayoritariamente en espanol. Sin una
+politica de idioma clara para el **codigo** (ADR-0002 solo cubria docs), el
+proyecto queda con una barrera de entrada para contribuidores
+internacionales justo cuando se prepara para abrir la Fase 5 (`ag-cloud`) y
+buscar adopcion mas amplia.
+
+## 2. Problema
+
+- El ingles es el idioma franco del open source. React, Rust, Kubernetes,
+  Tokio y practicamente todo proyecto de infraestructura con adopcion global
+  mantienen codigo y documentacion tecnica en ingles. Comentarios en espanol
+  excluyen a la mayoria de contribuidores potenciales.
+- ADR-0002 no legislo el idioma de los **comentarios de codigo**; quedo
+  como vacio normativo que se lleno por defecto con espanol.
+- Hacer *toda* la documentacion bilingue inline (EN+ES en cada archivo)
+  duplicaria ~29 000 lineas a ~58 000, perjudicaria la escaneabilidad,
+  ensuciaria los diffs y garantizaria desincronizacion entre idiomas.
+
+## 3. Alternativas consideradas
+
+1. **No hacer nada (mantener espanol por defecto).** Ventaja: cero trabajo.
+   Desventaja: perpetua la barrera de entrada internacional. Rechazada: el
+   objetivo declarado es adopcion amplia en Fase 5+.
+2. **Todo en ingles, sin espanol.** Ventaja: simplicidad maxima. Desventaja:
+   contradice el posicionamiento del proyecto (nace en Panama, primer foco
+   Latinoamerica). Rechazada.
+3. **Todo bilingue inline.** Ventaja: cada archivo autocontenido en dos
+   idiomas. Desventaja: duplica volumen, mata escaneabilidad, diffs ruidosos,
+   desincronizacion. Rechazada como mala practica para un corpus de 147
+   archivos.
+4. **Carpetas espejo `docs/es/` + `docs/en/` completas.** Ventaja: limpio.
+   Desventaja: obliga a traducir y mantener 147 archivos en paralelo.
+   Rechazada por costo de mantenimiento desproporcionado en esta etapa.
+5. **Ingles canonico + vitrina bilingue (elegida).** Detalle en seccion 4.
+
+## 4. Diseno propuesto
+
+### 4.1 Codigo
+
+- Todos los comentarios de codigo (`//`, `///`, `//!`) en **ingles**.
+- Los identificadores ya estaban en ingles; se mantiene.
+- Los mensajes de error orientados al usuario final pueden permanecer en el
+  idioma que la UX requiera, pero los comentarios que los rodean van en
+  ingles.
+
+### 4.2 Documentacion
+
+- **Ingles es el idioma canonico** de la documentacion tecnica profunda
+  (`docs/architecture/`, `docs/modules/`, `docs/dsl/`, `docs/rfc/`,
+  `docs/adr/`, `docs/benchmarks/`, `docs/security/`, `docs/governance/`).
+- **Documentos vitrina bilingues (EN+ES, mismo archivo, EN primero,
+  separados por regla horizontal):**
+  - `README.md` (raiz)
+  - Los tres maestros en `docs/master/`
+  - Capitulos del manual en `docs/manual/`
+- Patron de vitrina: ancla de idioma al inicio (`English | Espanol`),
+  seccion inglesa primero (canonica), seccion espanola despues. La seccion
+  espanola es traduccion de la inglesa; si divergen, gana la inglesa.
+- Las carpetas `docs/es/` y `docs/en/` se mantienen como indices por idioma
+  (uso pre-existente de ADR-0002).
+
+### 4.3 Cambios en CI o tooling
+
+- `.github/workflows/docs.yml` ya valida ausencia de emojis y de evidencia
+  de herramientas IA; no requiere cambios por esta RFC.
+- Los hashes SHA-256 de los maestros en `VERSION.md` y en el workflow se
+  recalculan al actualizar los maestros (procedimiento existente).
+
+### 4.4 Cambios en documentacion maestra
+
+- `CLAUDE.md`: nueva regla de idioma (codigo en ingles; vitrina bilingue).
+- `ADR-0002`: marcado como superseded por `ADR-0008`.
+- Los tres maestros pasan a formato vitrina bilingue.
+
+## 5. Plan de implementacion
+
+PR unico de cierre documental (rama `docs-cierre-fase-4.5`):
+
+1. RFC-0008 + ADR-0008 + actualizacion de ADR-0002 + regla en CLAUDE.md.
+2. Maestros actualizados a estado real 4.0-4.5 y formato bilingue;
+   Blueprint v4.1.md fuente; VERSION.md + workflow con hashes nuevos.
+3. README raiz bilingue y fiel a la implementacion.
+4. Conversion de comentarios de codigo a ingles, crate por crate.
+
+## 6. Riesgos
+
+- **Desincronizacion EN/ES en vitrina.** Probabilidad: media. Impacto: bajo.
+  Mitigacion: la seccion inglesa es canonica; la espanola se marca pendiente
+  si la inglesa avanza.
+- **Error al traducir comentarios tecnicos.** Probabilidad: baja. Impacto:
+  medio (un comentario erroneo confunde). Mitigacion: traduccion conservadora
+  que preserva el significado; verificacion `cargo build/test/clippy/fmt`
+  tras cada crate (los comentarios no afectan compilacion, pero el doc-test
+  si).
+- **Rechazo de la comunidad hispanohablante.** Probabilidad: baja. Impacto:
+  bajo. Mitigacion: la vitrina (lo primero que ve un recien llegado)
+  permanece bilingue.
+
+## 7. Impacto
+
+- **Alcance del producto:** sin cambios; es politica documental.
+- **Cronograma:** una fase documental de cierre antes de Fase 5.
+- **Complejidad operacional:** se reduce (un idioma canonico de codigo).
+- **APIs publicas:** sin cambios de firma; los doc-comments cambian de idioma.
+- **Documentacion existente:** maestros y README pasan a bilingue; docs
+  tecnicos profundos quedan en ingles canonico (migracion gradual permitida).
+
+## 8. Rollback
+
+Revertir el PR de cierre documental restaura el estado espanol-por-defecto.
+Indicador de rollback: caida medible en contribuciones o quejas formales de
+la comunidad hispanohablante por perdida de accesibilidad. No se anticipa,
+dado que la vitrina permanece bilingue.
+
+## 9. Decision
+
+- Decisor: BDFL (Angel Nereira).
+- Fecha de decision: 2026-05-24.
+- Resultado: aceptada.
+- Justificacion: el ingles canonico abre el proyecto a contribuidores
+  globales de cara a Fase 5, mientras la vitrina bilingue preserva la
+  accesibilidad para el foco inicial latinoamericano. Cumple el punto de
+  revision anticipado por ADR-0002.
+
+## 10. Referencias
+
+- `docs/adr/0002-bilingual-documentation.md` (superseded en parte)
+- `docs/adr/0008-politica-de-idioma.md` (registro de esta decision)
+- `docs/master/ANTI-GRAVITAL-Arquitectura-Tecnica.md` seccion 1
+- `CLAUDE.md` regla de idioma

--- a/tools/vscode-anti-gravital/syntaxes/anti-gravital.tmLanguage.json
+++ b/tools/vscode-anti-gravital/syntaxes/anti-gravital.tmLanguage.json
@@ -43,7 +43,7 @@
     },
     "keywords": {
       "name": "keyword.control.anti-gravital",
-      "match": "\\b(model|endpoint|request|response|error|config|field|method|path|body|errors|status|message|project_name|database)\\b"
+      "match": "\\b(model|endpoint|request|response|error|config|field|method|path|body|errors|status|message|project_name|database|mail|domain|template|provider|from|subject|vars|dkim_selector|dmarc_policy|dmarc_rua)\\b"
     },
     "identifiers": {
       "name": "entity.name.type.anti-gravital",


### PR DESCRIPTION
# docs(cierre-4.5): fase documental de cierre 4.0-4.5 (idioma + maestros)

## Fase afectada

Cierre documental de las fases 4.0 a 4.5, previo al inicio de la Fase 5
(`ag-cloud`). No introduce código funcional nuevo: alinea la documentación
con la implementación real y fija la política de idioma.

## Tipo de cambio

Documentación y gobernanza (`docs`). Conversión de comentarios de código a
inglés (sin cambios de comportamiento).

## Documentos relacionados

- `docs/rfc/RFC-0008-politica-de-idioma.md` — política de idioma
- `docs/adr/0008-politica-de-idioma.md` — decisión (supersede ADR-0002)
- `docs/master/VERSION.md` — hashes y registro de maestros

## Resumen

Fase documental de cierre que deja la documentación fiel a la
implementación y establece la política de idioma antes de Fase 5.

**Gobernanza de idioma:**
- `RFC-0008` + `ADR-0008`: inglés canónico para código y documentación
  técnica; vitrina bilingüe (README, maestros, manual) EN+ES mismo archivo,
  inglés primero. `ADR-0002` marcado superseded.
- `CLAUDE.md`: nueva regla de idioma.

**Maestros (fieles + bilingües, inglés-primero):**
- `ANTI-GRAVITAL-Hoja-de-Ruta.md`: fases 1-4.5 marcadas técnicamente
  completas (antes todas "Pendiente"); bilingüe.
- `ANTI-GRAVITAL-Arquitectura-Tecnica.md`: corregida la fidelidad —
  WebAuthn con ciborium/p256/ed25519 (ADR-0006, no webauthn-rs), templates
  de correo con StringTemplate/MailTemplate (no askama), caché L2 no
  implementado (RFC-0005); bilingüe.
- `ANTI-GRAVITAL-Blueprint-v4.1.md`: nueva fuente markdown versionable del
  Blueprint, bilingüe. El PDF v4.0 sigue como deuda explícita.
- `VERSION.md` + `.github/workflows/docs.yml`: hashes SHA-256 recalculados
  y Blueprint v4.1.md registrado en la verificación de integridad.

**Vitrina:**
- `README.md`: inglés primero con ancla de idioma; ya fiel a 4.5.

**Código:**
- Comentarios de código (`//`, `///`, `//!`) traducidos de español a inglés
  en los crates, examples y tests. Identificadores y mensajes de error de
  usuario sin cambios.

**Limpieza de ramas:**
- Borradas las ramas mergeadas (locales y remotas) dejando solo `main` y la
  rama de cierre. `origin/f45-pendientes` se borra tras el merge de este PR
  (su commit huérfano 4b32219 se preserva aquí vía cherry-pick).

## Plan de prueba

- `cargo build --workspace` — compila (comentarios no afectan compilación)
- `cargo clippy --workspace -- -D warnings` — 0 warnings
- `cargo fmt --all -- --check` — limpio
- `cargo test --workspace` — 0 fallos
- CI `masters integrity` — hashes coinciden (verificado localmente)
- CI `prohibited content scan` — sin emojis ni evidencia de herramientas IA

## Criterios de salida avanzados

- Documentación fiel a la implementación real de fases 4.0-4.5.
- Política de idioma fijada (inglés canónico + vitrina bilingüe).
- Maestros bilingües con hashes de integridad actualizados.
- Repositorio listo para iniciar Fase 5 con la documentación en orden.

## Checklist final

- [x] Pertenece a la fase correcta (cierre 4.0-4.5)
- [x] Respeta la documentación (RFC + ADR para los cambios de gobernanza)
- [x] No rompe arquitectura
- [x] No añade complejidad innecesaria
- [x] No crea dependencias circulares
- [x] Compila
- [x] Pasa tests
- [x] Pasa fmt
- [x] Pasa clippy
- [x] Maestros con hashes actualizados (VERSION.md + workflow)
- [x] Sin emojis ni evidencia de herramientas IA
- [x] Mantiene coherencia con Anti-Gravital v4.0/v4.1
