### PR TITLE
P5 native cache server

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -46,6 +46,7 @@ name = "ag-cache"
 version = "0.0.0"
 dependencies = [
  "ag-core",
+ "dashmap 6.2.1",
  "moka",
  "serde",
  "serde_json",

--- a/crates/ag-cache/Cargo.toml
+++ b/crates/ag-cache/Cargo.toml
@@ -17,6 +17,9 @@ publish = false
 [lints]
 workspace = true
 
+[features]
+native-server = ["dep:dashmap"]
+
 [dependencies]
 ag-core = { workspace = true }
 moka = { workspace = true }
@@ -24,6 +27,9 @@ serde = { workspace = true }
 serde_json = { workspace = true }
 tokio = { workspace = true }
 tracing = { workspace = true }
+
+# Native RESP2 server: per-key expiry tracking and key registry
+dashmap = { version = "6", optional = true }
 
 [dev-dependencies]
 testcontainers = { workspace = true }

--- a/crates/ag-cache/Cargo.toml
+++ b/crates/ag-cache/Cargo.toml
@@ -31,6 +31,10 @@ tracing = { workspace = true }
 # Native RESP2 server: per-key expiry tracking and key registry
 dashmap = { version = "6", optional = true }
 
+[[test]]
+name = "resp2_compat"
+required-features = ["native-server"]
+
 [dev-dependencies]
 testcontainers = { workspace = true }
 testcontainers-modules = { workspace = true }

--- a/crates/ag-cache/README.md
+++ b/crates/ag-cache/README.md
@@ -1,66 +1,90 @@
 # ag-cache
 
-Cache de dos niveles para Anti-Gravital: L1 en memoria del proceso con
-invalidacion por etiquetas (moka), L2 Redis opcional (fred).
+Two-level cache for Anti-Gravital: in-process L1 with tag-based invalidation (moka),
+and optional native L2 RESP2 server compatible with any Redis client.
 
 > Status: Phase 4 — L1 implemented (in-process, tag-based invalidation, moka).
-> L2 is NOT functional yet: when `redis_url` is set the cache only logs a tracing
-> warning (`src/lib.rs`). RFC-0005 proposes a native Anti-Gravital L2 over RESP2
-> (no Redis dependency); see `docs/DEBT.md` and `docs/rfc/RFC-0005-ag-cache-native-l2.md`.
+> Native RESP2 L2 server implemented under feature `native-server` (RFC-0005).
+> External Redis L2 remains deferred (TECH-DEBT).
 
-## Uso minimo (L1)
+## Minimal usage (L1 only)
 
 ```rust
-use ag_cache::l1::L1Cache;
-use bytes::Bytes;
-use std::time::Duration;
+use ag_cache::{AgCache, CacheConfig};
 
-fn main() {
-    // max_capacity: numero maximo de entradas, default_ttl: TTL por defecto
-    let cache = L1Cache::new(10_000, Duration::from_secs(300));
-
-    // Almacenar con etiquetas para invalidacion selectiva
-    cache.set_bytes_tagged("user:42:profile", Bytes::from("...json..."), &["user:42"]);
-
-    // Leer
-    if let Some(data) = cache.get_bytes("user:42:profile") {
-        println!("{}", String::from_utf8_lossy(&data));
-    }
-
-    // Invalidar todas las entradas con la etiqueta "user:42"
-    cache.invalidate_tag("user:42");
-}
+# async fn run() -> Result<(), Box<dyn std::error::Error>> {
+let cache = AgCache::new(CacheConfig::default()).await?;
+cache.set("user:123", b"data".to_vec(), &[]).await;
+let val: Option<Vec<u8>> = cache.get("user:123").await;
+# Ok(())
+# }
 ```
 
-## Capacidades
+## Native RESP2 server (L2)
+
+Enable the `native-server` Cargo feature to start an in-process TCP server
+that speaks the RESP2 protocol. Any standard Redis client connects to it
+without needing an actual Redis process.
+
+```toml
+[dependencies]
+ag-cache = { version = "0.0.0", features = ["native-server"] }
+```
+
+```rust
+use ag_cache::{AgCache, CacheConfig};
+
+# async fn run() -> Result<(), Box<dyn std::error::Error>> {
+let mut cfg = CacheConfig::default();
+cfg.native_server_enabled = true;
+cfg.native_server_port = 6379; // or any free port
+
+let cache = AgCache::new(cfg).await?;
+// redis-cli -p 6379 ping  =>  PONG
+# Ok(())
+# }
+```
+
+### Supported commands
+
+GET, SET (EX/PX/NX/XX), DEL, EXISTS, MGET, MSET, EXPIRE, TTL, KEYS (*),
+PING, FLUSHDB, DBSIZE, COMMAND.
+
+### Limitations
+
+- **Single-node only.** No replication or clustering. Use a real Redis for
+  multi-instance architectures where the cache must be shared.
+- **No persistence.** Data is lost on process restart. This is cache, not a database.
+- **No AUTH.** The server listens only on `127.0.0.1` (loopback) by default.
+- **No TLS.** Use a real Redis for encrypted connections.
+- **KEYS pattern** only supports `*` (all keys). Prefix patterns are not implemented.
+
+## Capabilities
 
 ### L1 (moka)
 
-- Cache en memoria de alta concurrencia con `moka`.
-- Invalidacion por etiquetas: `set_bytes_tagged(key, value, &["tag1", "tag2"])`.
-- TTL configurable por entrada o global via `default_ttl`.
-- Capacidad maxima con eviccion LRU automatica.
+- High-concurrency in-memory cache with moka (TinyLFU eviction).
+- Tag-based invalidation: `set_bytes_tagged(key, value, &["tag1", "tag2"])`.
+- Configurable per-entry TTL or global via `default_ttl`.
+- Automatic eviction when capacity is exceeded.
 
-### L2 Redis (feature `redis`)
+### L2 native (feature `native-server`)
 
-Activar con `features = ["redis"]` en `Cargo.toml` y definir `REDIS_URL`.
-Uso como cache secundario cuando L1 expira o se reinicia el proceso.
+- In-process RESP2 TCP server — no external Redis required.
+- Backed by the same L1 moka store (no data duplication).
+- Per-key TTL tracked via `DashMap<String, Option<Instant>>` alongside moka's TTL.
+- Compatible with redis-cli, redis-rs, ioredis, and any RESP2 client.
 
-## Variables de entorno (L2)
+## Environment variables
 
-| Variable | Default | Descripcion |
+| Variable | Default | Description |
 |---|---|---|
-| `REDIS_URL` | `redis://127.0.0.1:6379` | URL del servidor Redis (L2) |
+| `CACHE_NATIVE_SERVER` | `false` | Enable native RESP2 server (`1` or `true`) |
+| `CACHE_NATIVE_PORT` | `6379` | TCP port for the native RESP2 server |
+| `REDIS_URL` | — | External Redis URL (L2, deferred — logs a warning if set) |
 
-## RFC-0005
+## References
 
-El RFC-0005 (`docs/rfc/RFC-0005-ag-cache-native-l2.md`) propone un L2 nativo
-Anti-Gravital compatible con el protocolo RESP2, eliminando la dependencia de
-Redis como servicio externo. Estado: propuesto, pendiente de aprobacion.
-
-## Referencias
-
-- Spec de diseno: `docs/superpowers/specs/2026-05-23-fase4-completion-design.md`
-- Arquitectura: `docs/master/ANTI-GRAVITAL-Arquitectura-Tecnica.md` seccion 8.3.
-- RFC-0005: `docs/rfc/RFC-0005-ag-cache-native-l2.md`.
-- Constitucion tecnica: `CLAUDE.md`.
+- RFC-0005: `docs/rfc/RFC-0005-ag-cache-native-l2.md`
+- Architecture: `docs/master/ANTI-GRAVITAL-Arquitectura-Tecnica.md` section 8.3
+- Technical charter: `CLAUDE.md`

--- a/crates/ag-cache/src/config.rs
+++ b/crates/ag-cache/src/config.rs
@@ -1,6 +1,6 @@
 //! Multilevel cache configuration.
 
-/// Configuration for the L1 cache (moka, in memory) and L2 (Redis, optional).
+/// Configuration for the L1 cache (moka, in memory) and optional native RESP2 server.
 #[derive(Debug, Clone)]
 pub struct CacheConfig {
     /// Maximum number of entries in L1. Default: 10_000.
@@ -12,6 +12,10 @@ pub struct CacheConfig {
     pub redis_url: Option<String>,
     /// Number of connections in the Redis pool. Default: 10.
     pub redis_pool_size: u32,
+    /// Enable the native RESP2 server. Requires feature `native-server`. Default: false.
+    pub native_server_enabled: bool,
+    /// TCP port for the native RESP2 server. Default: 6379.
+    pub native_server_port: u16,
 }
 
 impl Default for CacheConfig {
@@ -21,6 +25,8 @@ impl Default for CacheConfig {
             l1_ttl_secs: 300,
             redis_url: None,
             redis_pool_size: 10,
+            native_server_enabled: false,
+            native_server_port: 6379,
         }
     }
 }
@@ -42,6 +48,13 @@ impl CacheConfig {
                 .ok()
                 .and_then(|v| v.parse().ok())
                 .unwrap_or(10),
+            native_server_enabled: std::env::var("CACHE_NATIVE_SERVER")
+                .map(|v| v == "1" || v.to_lowercase() == "true")
+                .unwrap_or(false),
+            native_server_port: std::env::var("CACHE_NATIVE_PORT")
+                .ok()
+                .and_then(|v| v.parse().ok())
+                .unwrap_or(6379),
         }
     }
 }
@@ -65,5 +78,12 @@ mod tests {
         std::env::remove_var("REDIS_URL");
         let cfg = CacheConfig::from_env();
         assert!(cfg.redis_url.is_none());
+    }
+
+    #[test]
+    fn native_server_defaults_disabled() {
+        let cfg = CacheConfig::default();
+        assert!(!cfg.native_server_enabled);
+        assert_eq!(cfg.native_server_port, 6379);
     }
 }

--- a/crates/ag-cache/src/l1.rs
+++ b/crates/ag-cache/src/l1.rs
@@ -58,6 +58,13 @@ impl L1Cache {
             idx.remove(key);
         }
     }
+
+    /// Removes all entries and clears the tag index.
+    pub async fn flush(&self) {
+        self.inner.invalidate_all();
+        self.inner.run_pending_tasks().await;
+        self.tags.lock().await.clear();
+    }
 }
 
 #[cfg(test)]
@@ -140,5 +147,15 @@ mod tests {
             elapsed.as_secs() < 2,
             "2M ops tardaron {elapsed:?}, esperado < 2s"
         );
+    }
+
+    #[tokio::test]
+    async fn flush_clears_all_entries() {
+        let cache = L1Cache::new(100, Duration::from_secs(60));
+        cache.set_bytes("a", b"1".to_vec()).await;
+        cache.set_bytes_tagged("b", b"2".to_vec(), &["tag1"]).await;
+        cache.flush().await;
+        assert!(cache.get_bytes("a").await.is_none());
+        assert!(cache.get_bytes("b").await.is_none());
     }
 }

--- a/crates/ag-cache/src/l1.rs
+++ b/crates/ag-cache/src/l1.rs
@@ -59,7 +59,12 @@ impl L1Cache {
         }
     }
 
-    /// Removes all entries and clears the tag index.
+    /// Removes all entries and clears the tag index (RESP2 FLUSHDB equivalent).
+    ///
+    /// Not atomic with respect to concurrent writes: entries inserted between
+    /// `invalidate_all()` and the tag-index clear may lose tag tracking.
+    /// Callers must ensure no concurrent writes during this call for a fully
+    /// consistent flush.
     pub async fn flush(&self) {
         self.inner.invalidate_all();
         self.inner.run_pending_tasks().await;
@@ -157,5 +162,10 @@ mod tests {
         cache.flush().await;
         assert!(cache.get_bytes("a").await.is_none());
         assert!(cache.get_bytes("b").await.is_none());
+        // Verify tag index was also cleared: a new entry under the same tag
+        // can be inserted and invalidated independently after flush.
+        cache.set_bytes_tagged("c", b"3".to_vec(), &["tag1"]).await;
+        cache.invalidate_tag("tag1").await;
+        assert!(cache.get_bytes("c").await.is_none());
     }
 }

--- a/crates/ag-cache/src/lib.rs
+++ b/crates/ag-cache/src/lib.rs
@@ -2,13 +2,13 @@
 //!
 //! Offers two transparent levels:
 //! - **L1**: moka in memory (TinyLFU, no contended locks, always available).
-//! - **L2**: Redis via fred (optional, for distributed cache across instances).
+//! - **L2 native**: optional in-process RESP2 server (feature `native-server`),
+//!   compatible with any Redis client. Backed by the same L1 store.
 //!
 //! # Status
 //!
-//! L1 fully operational. L2 (Redis/fred) remains pending as TECH-DEBT
-//! for the second iteration of ag-cache in Phase 4 — the fred v10 API
-//! requires feature adjustments and connection configuration in CI.
+//! L1 fully operational. Native RESP2 server (RFC-0005) implemented under
+//! the `native-server` feature. External Redis L2 remains deferred (TECH-DEBT).
 //!
 //! # Minimal usage (L1 only)
 //!
@@ -19,6 +19,21 @@
 //! let cache = AgCache::new(CacheConfig::default()).await?;
 //! cache.set("user:123", b"datos".to_vec(), &[]).await;
 //! let val: Option<Vec<u8>> = cache.get("user:123").await;
+//! # Ok(())
+//! # }
+//! ```
+//!
+//! # Native RESP2 server
+//!
+//! ```no_run
+//! use ag_cache::{AgCache, CacheConfig};
+//!
+//! # async fn run() -> Result<(), Box<dyn std::error::Error>> {
+//! let mut cfg = CacheConfig::default();
+//! cfg.native_server_enabled = true;
+//! cfg.native_server_port = 6379;
+//! let cache = AgCache::new(cfg).await?;
+//! // redis-cli -p 6379 ping  =>  PONG
 //! # Ok(())
 //! # }
 //! ```
@@ -33,6 +48,7 @@ pub mod server;
 pub use config::CacheConfig;
 
 use l1::L1Cache;
+use std::sync::Arc;
 use std::time::Duration;
 
 /// Error from the cache subsystem.
@@ -40,24 +56,26 @@ use std::time::Duration;
 pub enum CacheError {
     /// Connection or communication error with Redis.
     Redis(String),
+    /// I/O error starting the native server.
+    #[cfg(feature = "native-server")]
+    NativeServer(std::io::Error),
 }
 
 impl std::fmt::Display for CacheError {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         match self {
-            CacheError::Redis(msg) => write!(f, "error Redis: {msg}"),
+            CacheError::Redis(msg) => write!(f, "Redis error: {msg}"),
+            #[cfg(feature = "native-server")]
+            CacheError::NativeServer(e) => write!(f, "native server error: {e}"),
         }
     }
 }
 
 impl std::error::Error for CacheError {}
 
-/// Multilevel cache with L1 (moka) and optional L2 (Redis).
-///
-/// Build with [`AgCache::new`] passing a [`CacheConfig`]. If
-/// `config.redis_url` is `None`, only L1 is active.
+/// Multilevel cache with L1 (moka) and optional native RESP2 server.
 pub struct AgCache {
-    l1: L1Cache,
+    l1: Arc<L1Cache>,
     // TECH-DEBT:
     // reason: L2 Redis requires fred with a real connection; the fred v10 API
     //         does not expose the documented features (tokio-runtime, codec).
@@ -69,25 +87,31 @@ pub struct AgCache {
 impl AgCache {
     /// Creates a new [`AgCache`] with the given configuration.
     ///
-    /// If `config.redis_url` is `Some`, emits a warning via tracing but L2
-    /// is not activated until it is implemented (see TECH-DEBT in the code).
+    /// If `native_server_enabled` is `true` and feature `native-server` is active,
+    /// spawns the RESP2 server in a background task.
     pub async fn new(config: CacheConfig) -> Result<Self, CacheError> {
         let ttl = Duration::from_secs(config.l1_ttl_secs);
-        let l1 = L1Cache::new(config.l1_max_capacity, ttl);
+        let l1 = Arc::new(L1Cache::new(config.l1_max_capacity, ttl));
 
         if config.redis_url.is_some() {
             tracing::warn!(
-                "REDIS_URL configurada pero L2 Redis no esta activo en esta version (TECH-DEBT)"
+                "REDIS_URL set but external Redis L2 is not active in this version (TECH-DEBT)"
             );
+        }
+
+        #[cfg(feature = "native-server")]
+        if config.native_server_enabled {
+            let srv =
+                server::NativeCacheServer::bind(config.native_server_port, Arc::clone(&l1))
+                    .await
+                    .map_err(CacheError::NativeServer)?;
+            tokio::spawn(srv.serve());
         }
 
         Ok(Self { l1 })
     }
 
     /// Gets raw bytes from the cache.
-    ///
-    /// Looks up L1 first. On a hit, logs `cache hit L1` via tracing.
-    /// If there is no result, logs `cache miss`.
     pub async fn get(&self, key: &str) -> Option<Vec<u8>> {
         let result = self.l1.get_bytes(key).await;
         if result.is_some() {
@@ -99,8 +123,6 @@ impl AgCache {
     }
 
     /// Stores bytes in the cache with optional tags for invalidation.
-    ///
-    /// Writes to L1. If `tags` is empty, no tags are registered.
     pub async fn set(&self, key: &str, value: Vec<u8>, tags: &[&str]) {
         if tags.is_empty() {
             self.l1.set_bytes(key, value).await;

--- a/crates/ag-cache/src/lib.rs
+++ b/crates/ag-cache/src/lib.rs
@@ -27,6 +27,9 @@ pub mod config;
 pub mod l1;
 pub mod tags;
 
+#[cfg(feature = "native-server")]
+pub mod server;
+
 pub use config::CacheConfig;
 
 use l1::L1Cache;

--- a/crates/ag-cache/src/lib.rs
+++ b/crates/ag-cache/src/lib.rs
@@ -101,10 +101,9 @@ impl AgCache {
 
         #[cfg(feature = "native-server")]
         if config.native_server_enabled {
-            let srv =
-                server::NativeCacheServer::bind(config.native_server_port, Arc::clone(&l1))
-                    .await
-                    .map_err(CacheError::NativeServer)?;
+            let srv = server::NativeCacheServer::bind(config.native_server_port, Arc::clone(&l1))
+                .await
+                .map_err(CacheError::NativeServer)?;
             tokio::spawn(srv.serve());
         }
 

--- a/crates/ag-cache/src/server/cmd.rs
+++ b/crates/ag-cache/src/server/cmd.rs
@@ -1,0 +1,420 @@
+//! RESP2 command dispatch.
+//!
+//! Each public function handles one RESP2 command. All functions share
+//! the same `Arc<L1Cache>` and `Arc<DashMap<String, Option<Instant>>>`.
+//! The expiry map is the authoritative registry of live keys.
+
+use std::sync::Arc;
+use std::time::{Duration, Instant};
+
+use dashmap::DashMap;
+
+use crate::l1::L1Cache;
+use crate::server::resp::{
+    write_array, write_bulk, write_error, write_integer, write_ok, write_simple, Writer,
+};
+
+/// Authoritative registry of live keys and their optional expiry deadlines.
+///
+/// `None` means the key is persistent (no TTL). `Some(deadline)` means the key
+/// expires at `deadline` and must be treated as absent once `deadline` has passed.
+pub type ExpiryMap = DashMap<String, Option<Instant>>;
+
+/// Returns `true` if `key` is live (present and not expired).
+fn is_live(expiry: &ExpiryMap, key: &str) -> bool {
+    match expiry.get(key) {
+        None => false,
+        Some(entry) => match *entry {
+            None => true,
+            Some(deadline) => deadline > Instant::now(),
+        },
+    }
+}
+
+/// Removes an expired key from both L1 and the expiry map.
+async fn evict_if_expired(cache: &L1Cache, expiry: &ExpiryMap, key: &str) {
+    if let Some(entry) = expiry.get(key) {
+        if let Some(deadline) = *entry {
+            if deadline <= Instant::now() {
+                drop(entry);
+                cache.delete(key).await;
+                expiry.remove(key);
+            }
+        }
+    }
+}
+
+// ── PING ──────────────────────────────────────────────────────────────────
+
+/// Handles the RESP2 `PING` command. Returns `PONG` or echoes the argument.
+pub async fn cmd_ping(args: &[Vec<u8>], w: &mut Writer) {
+    if args.len() >= 2 {
+        write_bulk(w, Some(&args[1])).await;
+    } else {
+        write_simple(w, "PONG").await;
+    }
+}
+
+// ── GET ───────────────────────────────────────────────────────────────────
+
+/// Handles the RESP2 `GET` command. Returns the value or nil if absent/expired.
+pub async fn cmd_get(
+    args: &[Vec<u8>],
+    cache: &Arc<L1Cache>,
+    expiry: &Arc<ExpiryMap>,
+    w: &mut Writer,
+) {
+    if args.len() < 2 {
+        write_error(w, "wrong number of arguments for GET").await;
+        return;
+    }
+    let key = match std::str::from_utf8(&args[1]) {
+        Ok(k) => k,
+        Err(_) => {
+            write_error(w, "key must be valid UTF-8").await;
+            return;
+        }
+    };
+    evict_if_expired(cache, expiry, key).await;
+    if !is_live(expiry, key) {
+        write_bulk(w, None).await;
+        return;
+    }
+    let val = cache.get_bytes(key).await;
+    write_bulk(w, val.as_deref()).await;
+}
+
+// ── SET ───────────────────────────────────────────────────────────────────
+
+/// Handles the RESP2 `SET` command with optional `EX`, `PX`, `NX`, and `XX` flags.
+pub async fn cmd_set(
+    args: &[Vec<u8>],
+    cache: &Arc<L1Cache>,
+    expiry: &Arc<ExpiryMap>,
+    w: &mut Writer,
+) {
+    // SET key value [EX seconds] [PX milliseconds] [NX] [XX]
+    if args.len() < 3 {
+        write_error(w, "wrong number of arguments for SET").await;
+        return;
+    }
+    let key = match std::str::from_utf8(&args[1]) {
+        Ok(k) => k.to_owned(),
+        Err(_) => {
+            write_error(w, "key must be valid UTF-8").await;
+            return;
+        }
+    };
+    let value = args[2].clone();
+
+    let mut deadline: Option<Instant> = None;
+    let mut nx = false;
+    let mut xx = false;
+
+    let mut i = 3usize;
+    while i < args.len() {
+        let opt = String::from_utf8_lossy(&args[i]).to_uppercase();
+        match opt.as_str() {
+            "EX" => {
+                i += 1;
+                let secs: u64 = match args.get(i).and_then(|a| {
+                    std::str::from_utf8(a).ok().and_then(|s| s.parse().ok())
+                }) {
+                    Some(v) => v,
+                    None => {
+                        write_error(w, "value is not an integer or out of range").await;
+                        return;
+                    }
+                };
+                deadline = Some(Instant::now() + Duration::from_secs(secs));
+            }
+            "PX" => {
+                i += 1;
+                let ms: u64 = match args.get(i).and_then(|a| {
+                    std::str::from_utf8(a).ok().and_then(|s| s.parse().ok())
+                }) {
+                    Some(v) => v,
+                    None => {
+                        write_error(w, "value is not an integer or out of range").await;
+                        return;
+                    }
+                };
+                deadline = Some(Instant::now() + Duration::from_millis(ms));
+            }
+            "NX" => nx = true,
+            "XX" => xx = true,
+            _ => {}
+        }
+        i += 1;
+    }
+
+    evict_if_expired(cache, expiry, &key).await;
+    let exists = is_live(expiry, &key);
+
+    if nx && exists {
+        write_bulk(w, None).await; // NX: key already exists, do nothing
+        return;
+    }
+    if xx && !exists {
+        write_bulk(w, None).await; // XX: key does not exist, do nothing
+        return;
+    }
+
+    cache.set_bytes(&key, value).await;
+    expiry.insert(key, deadline);
+    write_ok(w).await;
+}
+
+// ── DEL ───────────────────────────────────────────────────────────────────
+
+/// Handles the RESP2 `DEL` command. Returns the count of actually deleted keys.
+pub async fn cmd_del(
+    args: &[Vec<u8>],
+    cache: &Arc<L1Cache>,
+    expiry: &Arc<ExpiryMap>,
+    w: &mut Writer,
+) {
+    if args.len() < 2 {
+        write_error(w, "wrong number of arguments for DEL").await;
+        return;
+    }
+    let mut deleted = 0i64;
+    for arg in &args[1..] {
+        if let Ok(key) = std::str::from_utf8(arg) {
+            if is_live(expiry, key) {
+                cache.delete(key).await;
+                expiry.remove(key);
+                deleted += 1;
+            }
+        }
+    }
+    write_integer(w, deleted).await;
+}
+
+// ── EXISTS ────────────────────────────────────────────────────────────────
+
+/// Handles the RESP2 `EXISTS` command. Returns the count of live keys among those given.
+pub async fn cmd_exists(
+    args: &[Vec<u8>],
+    cache: &Arc<L1Cache>,
+    expiry: &Arc<ExpiryMap>,
+    w: &mut Writer,
+) {
+    if args.len() < 2 {
+        write_error(w, "wrong number of arguments for EXISTS").await;
+        return;
+    }
+    let mut count = 0i64;
+    for arg in &args[1..] {
+        if let Ok(key) = std::str::from_utf8(arg) {
+            evict_if_expired(cache, expiry, key).await;
+            if is_live(expiry, key) {
+                count += 1;
+            }
+        }
+    }
+    write_integer(w, count).await;
+}
+
+// ── MGET ──────────────────────────────────────────────────────────────────
+
+/// Handles the RESP2 `MGET` command. Returns a bulk-string array, nil for absent/expired keys.
+pub async fn cmd_mget(
+    args: &[Vec<u8>],
+    cache: &Arc<L1Cache>,
+    expiry: &Arc<ExpiryMap>,
+    w: &mut Writer,
+) {
+    if args.len() < 2 {
+        write_error(w, "wrong number of arguments for MGET").await;
+        return;
+    }
+    let count = args.len() - 1;
+    use tokio::io::AsyncWriteExt;
+    let _ = w
+        .write_all(format!("*{count}\r\n").as_bytes())
+        .await;
+    for arg in &args[1..] {
+        if let Ok(key) = std::str::from_utf8(arg) {
+            evict_if_expired(cache, expiry, key).await;
+            if is_live(expiry, key) {
+                let val = cache.get_bytes(key).await;
+                write_bulk(w, val.as_deref()).await;
+            } else {
+                write_bulk(w, None).await;
+            }
+        } else {
+            write_bulk(w, None).await;
+        }
+    }
+}
+
+// ── MSET ──────────────────────────────────────────────────────────────────
+
+/// Handles the RESP2 `MSET` command. Sets multiple key-value pairs atomically (persistent, no TTL).
+pub async fn cmd_mset(
+    args: &[Vec<u8>],
+    cache: &Arc<L1Cache>,
+    expiry: &Arc<ExpiryMap>,
+    w: &mut Writer,
+) {
+    // MSET key value [key value ...]
+    if args.len() < 3 || (args.len() - 1) % 2 != 0 {
+        write_error(w, "wrong number of arguments for MSET").await;
+        return;
+    }
+    let mut i = 1usize;
+    while i + 1 < args.len() {
+        if let Ok(key) = std::str::from_utf8(&args[i]) {
+            let value = args[i + 1].clone();
+            cache.set_bytes(key, value).await;
+            expiry.insert(key.to_owned(), None);
+        }
+        i += 2;
+    }
+    write_ok(w).await;
+}
+
+// ── EXPIRE ────────────────────────────────────────────────────────────────
+
+/// Handles the RESP2 `EXPIRE` command. Sets a TTL in seconds on an existing key.
+/// Returns 1 if the TTL was applied, 0 if the key does not exist.
+pub async fn cmd_expire(
+    args: &[Vec<u8>],
+    cache: &Arc<L1Cache>,
+    expiry: &Arc<ExpiryMap>,
+    w: &mut Writer,
+) {
+    if args.len() < 3 {
+        write_error(w, "wrong number of arguments for EXPIRE").await;
+        return;
+    }
+    let key = match std::str::from_utf8(&args[1]) {
+        Ok(k) => k,
+        Err(_) => {
+            write_error(w, "key must be valid UTF-8").await;
+            return;
+        }
+    };
+    let secs: u64 = match std::str::from_utf8(&args[2])
+        .ok()
+        .and_then(|s| s.parse().ok())
+    {
+        Some(v) => v,
+        None => {
+            write_error(w, "value is not an integer or out of range").await;
+            return;
+        }
+    };
+    evict_if_expired(cache, expiry, key).await;
+    if !is_live(expiry, key) {
+        write_integer(w, 0).await; // key does not exist
+        return;
+    }
+    expiry.insert(key.to_owned(), Some(Instant::now() + Duration::from_secs(secs)));
+    write_integer(w, 1).await;
+}
+
+// ── TTL ───────────────────────────────────────────────────────────────────
+
+/// Handles the RESP2 `TTL` command. Returns remaining seconds, -1 for persistent, -2 for absent.
+pub async fn cmd_ttl(
+    args: &[Vec<u8>],
+    cache: &Arc<L1Cache>,
+    expiry: &Arc<ExpiryMap>,
+    w: &mut Writer,
+) {
+    if args.len() < 2 {
+        write_error(w, "wrong number of arguments for TTL").await;
+        return;
+    }
+    let key = match std::str::from_utf8(&args[1]) {
+        Ok(k) => k,
+        Err(_) => {
+            write_error(w, "key must be valid UTF-8").await;
+            return;
+        }
+    };
+    evict_if_expired(cache, expiry, key).await;
+    match expiry.get(key) {
+        None => write_integer(w, -2).await, // key does not exist
+        Some(entry) => match *entry {
+            None => write_integer(w, -1).await, // persistent key
+            Some(deadline) => {
+                let now = Instant::now();
+                if deadline <= now {
+                    drop(entry);
+                    cache.delete(key).await;
+                    expiry.remove(key);
+                    write_integer(w, -2).await;
+                } else {
+                    write_integer(w, (deadline - now).as_secs() as i64).await;
+                }
+            }
+        },
+    }
+}
+
+// ── KEYS ──────────────────────────────────────────────────────────────────
+
+/// Handles the RESP2 `KEYS` command. Only the `*` wildcard and exact-match patterns are supported.
+pub async fn cmd_keys(
+    args: &[Vec<u8>],
+    expiry: &Arc<ExpiryMap>,
+    w: &mut Writer,
+) {
+    // Only the `*` wildcard is supported (RFC-0005 section 4.2).
+    if args.len() < 2 {
+        write_error(w, "wrong number of arguments for KEYS").await;
+        return;
+    }
+    let pattern = String::from_utf8_lossy(&args[1]);
+    let now = Instant::now();
+    let live_keys: Vec<Vec<u8>> = expiry
+        .iter()
+        .filter(|entry| match *entry.value() {
+            None => true,
+            Some(deadline) => deadline > now,
+        })
+        .filter(|entry| pattern == "*" || entry.key() == pattern.as_ref())
+        .map(|entry| entry.key().as_bytes().to_vec())
+        .collect();
+    write_array(w, &live_keys).await;
+}
+
+// ── FLUSHDB ───────────────────────────────────────────────────────────────
+
+/// Handles the RESP2 `FLUSHDB` command. Clears all keys from L1 and the expiry map.
+pub async fn cmd_flushdb(
+    cache: &Arc<L1Cache>,
+    expiry: &Arc<ExpiryMap>,
+    w: &mut Writer,
+) {
+    cache.flush().await;
+    expiry.clear();
+    write_ok(w).await;
+}
+
+// ── DBSIZE ────────────────────────────────────────────────────────────────
+
+/// Handles the RESP2 `DBSIZE` command. Returns the count of live (non-expired) keys.
+pub async fn cmd_dbsize(expiry: &Arc<ExpiryMap>, w: &mut Writer) {
+    let now = Instant::now();
+    let count = expiry
+        .iter()
+        .filter(|e| match *e.value() {
+            None => true,
+            Some(deadline) => deadline > now,
+        })
+        .count();
+    write_integer(w, count as i64).await;
+}
+
+// ── COMMAND ───────────────────────────────────────────────────────────────
+
+/// Handles the RESP2 `COMMAND` introspection request. Returns an empty array for client compatibility.
+pub async fn cmd_command(w: &mut Writer) {
+    use tokio::io::AsyncWriteExt;
+    // Return empty array: enough for clients that auto-detect capabilities.
+    let _ = w.write_all(b"*0\r\n").await;
+}

--- a/crates/ag-cache/src/server/cmd.rs
+++ b/crates/ag-cache/src/server/cmd.rs
@@ -119,9 +119,10 @@ pub async fn cmd_set(
         match opt.as_str() {
             "EX" => {
                 i += 1;
-                let secs: u64 = match args.get(i).and_then(|a| {
-                    std::str::from_utf8(a).ok().and_then(|s| s.parse().ok())
-                }) {
+                let secs: u64 = match args
+                    .get(i)
+                    .and_then(|a| std::str::from_utf8(a).ok().and_then(|s| s.parse().ok()))
+                {
                     Some(v) => v,
                     None => {
                         write_error(w, "value is not an integer or out of range").await;
@@ -132,9 +133,10 @@ pub async fn cmd_set(
             }
             "PX" => {
                 i += 1;
-                let ms: u64 = match args.get(i).and_then(|a| {
-                    std::str::from_utf8(a).ok().and_then(|s| s.parse().ok())
-                }) {
+                let ms: u64 = match args
+                    .get(i)
+                    .and_then(|a| std::str::from_utf8(a).ok().and_then(|s| s.parse().ok()))
+                {
                     Some(v) => v,
                     None => {
                         write_error(w, "value is not an integer or out of range").await;
@@ -232,9 +234,7 @@ pub async fn cmd_mget(
         return;
     }
     let count = args.len() - 1;
-    let _ = w
-        .write_all(format!("*{count}\r\n").as_bytes())
-        .await;
+    let _ = w.write_all(format!("*{count}\r\n").as_bytes()).await;
     for arg in &args[1..] {
         if let Ok(key) = std::str::from_utf8(arg) {
             evict_if_expired(cache, expiry, key).await;
@@ -312,7 +312,10 @@ pub async fn cmd_expire(
         write_integer(w, 0).await; // key does not exist
         return;
     }
-    expiry.insert(key.to_owned(), Some(Instant::now() + Duration::from_secs(secs)));
+    expiry.insert(
+        key.to_owned(),
+        Some(Instant::now() + Duration::from_secs(secs)),
+    );
     write_integer(w, 1).await;
 }
 
@@ -362,11 +365,7 @@ pub async fn cmd_ttl(
 // ── KEYS ──────────────────────────────────────────────────────────────────
 
 /// Handles the RESP2 `KEYS` command. Only the `*` wildcard and exact-match patterns are supported.
-pub async fn cmd_keys(
-    args: &[Vec<u8>],
-    expiry: &Arc<ExpiryMap>,
-    w: &mut Writer,
-) {
+pub async fn cmd_keys(args: &[Vec<u8>], expiry: &Arc<ExpiryMap>, w: &mut Writer) {
     // Only the `*` wildcard is supported (RFC-0005 section 4.2).
     if args.len() < 2 {
         write_error(w, "wrong number of arguments for KEYS").await;
@@ -389,11 +388,7 @@ pub async fn cmd_keys(
 // ── FLUSHDB ───────────────────────────────────────────────────────────────
 
 /// Handles the RESP2 `FLUSHDB` command. Clears all keys from L1 and the expiry map.
-pub async fn cmd_flushdb(
-    cache: &Arc<L1Cache>,
-    expiry: &Arc<ExpiryMap>,
-    w: &mut Writer,
-) {
+pub async fn cmd_flushdb(cache: &Arc<L1Cache>, expiry: &Arc<ExpiryMap>, w: &mut Writer) {
     cache.flush().await;
     expiry.clear();
     write_ok(w).await;

--- a/crates/ag-cache/src/server/cmd.rs
+++ b/crates/ag-cache/src/server/cmd.rs
@@ -9,6 +9,8 @@ use std::time::{Duration, Instant};
 
 use dashmap::DashMap;
 
+use tokio::io::AsyncWriteExt;
+
 use crate::l1::L1Cache;
 use crate::server::resp::{
     write_array, write_bulk, write_error, write_integer, write_ok, write_simple, Writer,
@@ -230,7 +232,6 @@ pub async fn cmd_mget(
         return;
     }
     let count = args.len() - 1;
-    use tokio::io::AsyncWriteExt;
     let _ = w
         .write_all(format!("*{count}\r\n").as_bytes())
         .await;
@@ -338,20 +339,23 @@ pub async fn cmd_ttl(
     evict_if_expired(cache, expiry, key).await;
     match expiry.get(key) {
         None => write_integer(w, -2).await, // key does not exist
-        Some(entry) => match *entry {
-            None => write_integer(w, -1).await, // persistent key
-            Some(deadline) => {
-                let now = Instant::now();
-                if deadline <= now {
-                    drop(entry);
-                    cache.delete(key).await;
-                    expiry.remove(key);
-                    write_integer(w, -2).await;
-                } else {
-                    write_integer(w, (deadline - now).as_secs() as i64).await;
+        Some(entry) => {
+            let opt = *entry;
+            drop(entry);
+            match opt {
+                None => write_integer(w, -1).await, // persistent key
+                Some(deadline) => {
+                    let now = Instant::now();
+                    if deadline <= now {
+                        cache.delete(key).await;
+                        expiry.remove(key);
+                        write_integer(w, -2).await;
+                    } else {
+                        write_integer(w, (deadline - now).as_secs() as i64).await;
+                    }
                 }
             }
-        },
+        }
     }
 }
 
@@ -414,7 +418,6 @@ pub async fn cmd_dbsize(expiry: &Arc<ExpiryMap>, w: &mut Writer) {
 
 /// Handles the RESP2 `COMMAND` introspection request. Returns an empty array for client compatibility.
 pub async fn cmd_command(w: &mut Writer) {
-    use tokio::io::AsyncWriteExt;
     // Return empty array: enough for clients that auto-detect capabilities.
-    let _ = w.write_all(b"*0\r\n").await;
+    write_array(w, &[]).await;
 }

--- a/crates/ag-cache/src/server/mod.rs
+++ b/crates/ag-cache/src/server/mod.rs
@@ -1,4 +1,116 @@
-//! Native RESP2 cache server (stub — full implementation in Task 5).
+//! Native RESP2 cache server.
+//!
+//! When the `native-server` feature is enabled and `CacheConfig::native_server_enabled`
+//! is `true`, `AgCache::new` spawns a `NativeCacheServer` in a background task.
+//! The server speaks RESP2 and accepts connections on `127.0.0.1:{port}`.
+//!
+//! External clients (redis-cli, redis-rs, ioredis) connect without knowing
+//! they are talking to an in-process cache instead of Redis.
 
 pub mod cmd;
 pub mod resp;
+
+use std::io;
+use std::sync::Arc;
+
+use dashmap::DashMap;
+use tokio::net::{TcpListener, TcpStream};
+use tracing::{debug, error, info, warn};
+
+use crate::l1::L1Cache;
+use cmd::ExpiryMap;
+use resp::{read_command, Reader, Writer};
+
+/// An in-process TCP server that speaks RESP2.
+pub struct NativeCacheServer {
+    listener: TcpListener,
+    cache: Arc<L1Cache>,
+    expiry: Arc<ExpiryMap>,
+}
+
+impl NativeCacheServer {
+    /// Binds the server to `127.0.0.1:{port}`.
+    ///
+    /// Use port `0` in tests to let the OS choose a free port.
+    pub async fn bind(port: u16, cache: Arc<L1Cache>) -> io::Result<Self> {
+        let addr = format!("127.0.0.1:{port}");
+        let listener = TcpListener::bind(&addr).await?;
+        let local = listener.local_addr()?;
+        info!(addr = %local, "native RESP2 server listening");
+        Ok(Self {
+            listener,
+            cache,
+            expiry: Arc::new(DashMap::new()),
+        })
+    }
+
+    /// Returns the local address the server is listening on.
+    pub fn local_addr(&self) -> io::Result<std::net::SocketAddr> {
+        self.listener.local_addr()
+    }
+
+    /// Runs the accept loop. Spawns one task per connection.
+    /// Blocks until the listener is dropped or an accept error occurs.
+    pub async fn serve(self) {
+        let cache = self.cache;
+        let expiry = self.expiry;
+        loop {
+            match self.listener.accept().await {
+                Ok((stream, peer)) => {
+                    debug!(%peer, "new RESP2 connection");
+                    let c = Arc::clone(&cache);
+                    let e = Arc::clone(&expiry);
+                    tokio::spawn(async move {
+                        if let Err(err) = handle_connection(stream, c, e).await {
+                            warn!(%err, "RESP2 connection error");
+                        }
+                    });
+                }
+                Err(err) => {
+                    error!(%err, "accept error — stopping native RESP2 server");
+                    break;
+                }
+            }
+        }
+    }
+}
+
+async fn handle_connection(
+    stream: TcpStream,
+    cache: Arc<L1Cache>,
+    expiry: Arc<ExpiryMap>,
+) -> io::Result<()> {
+    let (read_half, write_half) = stream.into_split();
+    let mut reader: Reader = tokio::io::BufReader::new(read_half);
+    let mut writer: Writer = write_half;
+
+    while let Some(args) = read_command(&mut reader).await {
+        if args.is_empty() {
+            continue;
+        }
+        let command = String::from_utf8_lossy(&args[0]).to_uppercase();
+        match command.as_str() {
+            "PING" => cmd::cmd_ping(&args, &mut writer).await,
+            "GET" => cmd::cmd_get(&args, &cache, &expiry, &mut writer).await,
+            "SET" => cmd::cmd_set(&args, &cache, &expiry, &mut writer).await,
+            "DEL" => cmd::cmd_del(&args, &cache, &expiry, &mut writer).await,
+            "EXISTS" => cmd::cmd_exists(&args, &cache, &expiry, &mut writer).await,
+            "MGET" => cmd::cmd_mget(&args, &cache, &expiry, &mut writer).await,
+            "MSET" => cmd::cmd_mset(&args, &cache, &expiry, &mut writer).await,
+            "EXPIRE" => cmd::cmd_expire(&args, &cache, &expiry, &mut writer).await,
+            "TTL" => cmd::cmd_ttl(&args, &cache, &expiry, &mut writer).await,
+            "KEYS" => cmd::cmd_keys(&args, &expiry, &mut writer).await,
+            "FLUSHDB" => cmd::cmd_flushdb(&cache, &expiry, &mut writer).await,
+            "DBSIZE" => cmd::cmd_dbsize(&expiry, &mut writer).await,
+            "COMMAND" => cmd::cmd_command(&mut writer).await,
+            other => {
+                resp::write_error(
+                    &mut writer,
+                    &format!("unsupported command '{other}' in ag-cache native server"),
+                )
+                .await;
+            }
+        }
+    }
+    Ok(())
+}

--- a/crates/ag-cache/src/server/mod.rs
+++ b/crates/ag-cache/src/server/mod.rs
@@ -1,0 +1,3 @@
+//! Native RESP2 cache server (stub — full implementation in Task 5).
+
+pub mod resp;

--- a/crates/ag-cache/src/server/mod.rs
+++ b/crates/ag-cache/src/server/mod.rs
@@ -1,3 +1,4 @@
 //! Native RESP2 cache server (stub — full implementation in Task 5).
 
+pub mod cmd;
 pub mod resp;

--- a/crates/ag-cache/src/server/resp.rs
+++ b/crates/ag-cache/src/server/resp.rs
@@ -64,16 +64,12 @@ pub async fn write_ok(w: &mut Writer) {
 
 /// Writes `+{msg}\r\n`.
 pub async fn write_simple(w: &mut Writer, msg: &str) {
-    let _ = w
-        .write_all(format!("+{msg}\r\n").as_bytes())
-        .await;
+    let _ = w.write_all(format!("+{msg}\r\n").as_bytes()).await;
 }
 
 /// Writes `-ERR {msg}\r\n`.
 pub async fn write_error(w: &mut Writer, msg: &str) {
-    let _ = w
-        .write_all(format!("-ERR {msg}\r\n").as_bytes())
-        .await;
+    let _ = w.write_all(format!("-ERR {msg}\r\n").as_bytes()).await;
 }
 
 /// Writes `:{n}\r\n`.
@@ -88,9 +84,7 @@ pub async fn write_bulk(w: &mut Writer, data: Option<&[u8]>) {
             let _ = w.write_all(b"$-1\r\n").await;
         }
         Some(b) => {
-            let _ = w
-                .write_all(format!("${}\r\n", b.len()).as_bytes())
-                .await;
+            let _ = w.write_all(format!("${}\r\n", b.len()).as_bytes()).await;
             let _ = w.write_all(b).await;
             let _ = w.write_all(b"\r\n").await;
         }

--- a/crates/ag-cache/src/server/resp.rs
+++ b/crates/ag-cache/src/server/resp.rs
@@ -3,7 +3,7 @@
 //! Reads one command at a time from a buffered async reader.
 //! Returns `None` on EOF (client disconnected).
 
-use tokio::io::{AsyncBufReadExt, AsyncWriteExt, BufReader};
+use tokio::io::{AsyncBufReadExt, AsyncReadExt, AsyncWriteExt, BufReader};
 use tokio::net::tcp::{OwnedReadHalf, OwnedWriteHalf};
 
 /// Alias for the write half of a tokio TCP socket.
@@ -36,7 +36,6 @@ pub async fn read_command(reader: &mut Reader) -> Option<Vec<Vec<u8>>> {
                 let len: usize = len_str.parse().ok()?;
                 // Read DATA + \r\n
                 let mut buf = vec![0u8; len + 2];
-                use tokio::io::AsyncReadExt;
                 reader.read_exact(&mut buf).await.ok()?;
                 buf.truncate(len); // drop trailing \r\n
                 args.push(buf);

--- a/crates/ag-cache/src/server/resp.rs
+++ b/crates/ag-cache/src/server/resp.rs
@@ -1,0 +1,115 @@
+//! RESP2 frame reader and response writer.
+//!
+//! Reads one command at a time from a buffered async reader.
+//! Returns `None` on EOF (client disconnected).
+
+use tokio::io::{AsyncBufReadExt, AsyncWriteExt, BufReader};
+use tokio::net::tcp::{OwnedReadHalf, OwnedWriteHalf};
+
+/// Alias for the write half of a tokio TCP socket.
+pub type Writer = OwnedWriteHalf;
+/// Alias for a buffered reader over the read half of a tokio TCP socket.
+pub type Reader = BufReader<OwnedReadHalf>;
+
+/// Reads the next RESP2 command from the client.
+///
+/// Returns `None` if the client closed the connection.
+/// Returns `Some(args)` where `args[0]` is the command name (uppercase bytes).
+pub async fn read_command(reader: &mut Reader) -> Option<Vec<Vec<u8>>> {
+    let mut line = String::new();
+    let n = reader.read_line(&mut line).await.ok()?;
+    if n == 0 {
+        return None; // EOF
+    }
+    let line = line.trim_end_matches(['\r', '\n']);
+
+    if let Some(count_str) = line.strip_prefix('*') {
+        // Array format: *N\r\n$L\r\nDATA\r\n ...
+        let count: usize = count_str.parse().ok()?;
+        let mut args = Vec::with_capacity(count);
+        for _ in 0..count {
+            // Read $L line
+            let mut len_line = String::new();
+            reader.read_line(&mut len_line).await.ok()?;
+            let len_line = len_line.trim_end_matches(['\r', '\n']);
+            if let Some(len_str) = len_line.strip_prefix('$') {
+                let len: usize = len_str.parse().ok()?;
+                // Read DATA + \r\n
+                let mut buf = vec![0u8; len + 2];
+                use tokio::io::AsyncReadExt;
+                reader.read_exact(&mut buf).await.ok()?;
+                buf.truncate(len); // drop trailing \r\n
+                args.push(buf);
+            } else {
+                return None;
+            }
+        }
+        Some(args)
+    } else {
+        // Inline format: COMMAND arg1 arg2
+        if line.is_empty() {
+            return None;
+        }
+        Some(
+            line.split_whitespace()
+                .map(|s| s.as_bytes().to_vec())
+                .collect(),
+        )
+    }
+}
+
+/// Writes `+OK\r\n`.
+pub async fn write_ok(w: &mut Writer) {
+    let _ = w.write_all(b"+OK\r\n").await;
+}
+
+/// Writes `+{msg}\r\n`.
+pub async fn write_simple(w: &mut Writer, msg: &str) {
+    let _ = w
+        .write_all(format!("+{msg}\r\n").as_bytes())
+        .await;
+}
+
+/// Writes `-ERR {msg}\r\n`.
+pub async fn write_error(w: &mut Writer, msg: &str) {
+    let _ = w
+        .write_all(format!("-ERR {msg}\r\n").as_bytes())
+        .await;
+}
+
+/// Writes `:{n}\r\n`.
+pub async fn write_integer(w: &mut Writer, n: i64) {
+    let _ = w.write_all(format!(":{n}\r\n").as_bytes()).await;
+}
+
+/// Writes a RESP2 bulk string: `$L\r\nDATA\r\n` or `$-1\r\n` for nil.
+pub async fn write_bulk(w: &mut Writer, data: Option<&[u8]>) {
+    match data {
+        None => {
+            let _ = w.write_all(b"$-1\r\n").await;
+        }
+        Some(b) => {
+            let _ = w
+                .write_all(format!("${}\r\n", b.len()).as_bytes())
+                .await;
+            let _ = w.write_all(b).await;
+            let _ = w.write_all(b"\r\n").await;
+        }
+    }
+}
+
+/// Writes a RESP2 array of bulk strings.
+pub async fn write_array(w: &mut Writer, items: &[Vec<u8>]) {
+    let _ = w
+        .write_all(format!("*{}\r\n", items.len()).as_bytes())
+        .await;
+    for item in items {
+        write_bulk(w, Some(item)).await;
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    // Parser is tested via the integration test (Task 7) through a real
+    // TCP connection. The response writers are pure I/O and tested there too.
+}

--- a/crates/ag-cache/src/tags.rs
+++ b/crates/ag-cache/src/tags.rs
@@ -33,6 +33,11 @@ impl TagIndex {
             .map(|s| s.iter().cloned().collect())
             .unwrap_or_default()
     }
+
+    /// Removes all tag to key mappings.
+    pub fn clear(&mut self) {
+        self.tag_to_keys.clear();
+    }
 }
 
 #[cfg(test)]
@@ -69,5 +74,15 @@ mod tests {
         idx.insert("user:1", &["users", "admin"]);
         assert!(idx.keys_for_tag("admin").contains(&"user:1".to_string()));
         assert!(idx.keys_for_tag("users").contains(&"user:1".to_string()));
+    }
+
+    #[test]
+    fn clear_removes_all_tags() {
+        let mut idx = TagIndex::default();
+        idx.insert("k1", &["t1"]);
+        idx.insert("k2", &["t1", "t2"]);
+        idx.clear();
+        assert!(idx.keys_for_tag("t1").is_empty());
+        assert!(idx.keys_for_tag("t2").is_empty());
     }
 }

--- a/crates/ag-cache/tests/resp2_compat.rs
+++ b/crates/ag-cache/tests/resp2_compat.rs
@@ -1,0 +1,188 @@
+//! Integration tests for the native RESP2 server.
+//!
+//! Each test binds the server on port 0, connects via TcpStream, sends raw
+//! RESP2 commands, and asserts the response bytes. This validates protocol
+//! compliance without mocking any layer.
+
+use ag_cache::server::NativeCacheServer;
+use ag_cache::l1::L1Cache;
+use std::sync::Arc;
+use std::time::Duration;
+use tokio::io::AsyncWriteExt;
+use tokio::net::TcpStream;
+
+/// Spawns the server on port 0 and returns the bound port.
+async fn spawn_server() -> u16 {
+    let l1 = Arc::new(L1Cache::new(1000, Duration::from_secs(60)));
+    let srv = NativeCacheServer::bind(0, l1).await.expect("bind must succeed");
+    let port = srv.local_addr().expect("local_addr").port();
+    tokio::spawn(srv.serve());
+    port
+}
+
+/// Sends a raw RESP2 command and reads back the full response.
+async fn send_recv(stream: &mut TcpStream, cmd: &str) -> String {
+    stream.write_all(cmd.as_bytes()).await.unwrap();
+    let mut buf = vec![0u8; 4096];
+    tokio::time::sleep(Duration::from_millis(50)).await;
+    let n = stream.try_read(&mut buf).unwrap_or(0);
+    String::from_utf8_lossy(&buf[..n]).into_owned()
+}
+
+#[tokio::test]
+async fn ping_returns_pong() {
+    let port = spawn_server().await;
+    let mut s = TcpStream::connect(format!("127.0.0.1:{port}")).await.unwrap();
+    let resp = send_recv(&mut s, "*1\r\n$4\r\nPING\r\n").await;
+    assert_eq!(resp, "+PONG\r\n");
+}
+
+#[tokio::test]
+async fn ping_with_message_returns_bulk() {
+    let port = spawn_server().await;
+    let mut s = TcpStream::connect(format!("127.0.0.1:{port}")).await.unwrap();
+    let resp = send_recv(&mut s, "*2\r\n$4\r\nPING\r\n$5\r\nhello\r\n").await;
+    assert_eq!(resp, "$5\r\nhello\r\n");
+}
+
+#[tokio::test]
+async fn set_and_get_roundtrip() {
+    let port = spawn_server().await;
+    let mut s = TcpStream::connect(format!("127.0.0.1:{port}")).await.unwrap();
+
+    let set = send_recv(&mut s, "*3\r\n$3\r\nSET\r\n$3\r\nfoo\r\n$3\r\nbar\r\n").await;
+    assert_eq!(set, "+OK\r\n");
+
+    let get = send_recv(&mut s, "*2\r\n$3\r\nGET\r\n$3\r\nfoo\r\n").await;
+    assert_eq!(get, "$3\r\nbar\r\n");
+}
+
+#[tokio::test]
+async fn get_missing_key_returns_nil() {
+    let port = spawn_server().await;
+    let mut s = TcpStream::connect(format!("127.0.0.1:{port}")).await.unwrap();
+    let resp = send_recv(&mut s, "*2\r\n$3\r\nGET\r\n$7\r\nmissing\r\n").await;
+    assert_eq!(resp, "$-1\r\n");
+}
+
+#[tokio::test]
+async fn del_removes_key() {
+    let port = spawn_server().await;
+    let mut s = TcpStream::connect(format!("127.0.0.1:{port}")).await.unwrap();
+
+    send_recv(&mut s, "*3\r\n$3\r\nSET\r\n$1\r\nx\r\n$1\r\n1\r\n").await;
+    let del = send_recv(&mut s, "*2\r\n$3\r\nDEL\r\n$1\r\nx\r\n").await;
+    assert_eq!(del, ":1\r\n");
+
+    let get = send_recv(&mut s, "*2\r\n$3\r\nGET\r\n$1\r\nx\r\n").await;
+    assert_eq!(get, "$-1\r\n");
+}
+
+#[tokio::test]
+async fn set_nx_does_not_overwrite() {
+    let port = spawn_server().await;
+    let mut s = TcpStream::connect(format!("127.0.0.1:{port}")).await.unwrap();
+
+    send_recv(&mut s, "*3\r\n$3\r\nSET\r\n$1\r\nk\r\n$5\r\nfirst\r\n").await;
+    let nx = send_recv(
+        &mut s,
+        "*4\r\n$3\r\nSET\r\n$1\r\nk\r\n$6\r\nsecond\r\n$2\r\nNX\r\n",
+    )
+    .await;
+    assert_eq!(nx, "$-1\r\n");
+
+    let get = send_recv(&mut s, "*2\r\n$3\r\nGET\r\n$1\r\nk\r\n").await;
+    assert_eq!(get, "$5\r\nfirst\r\n");
+}
+
+#[tokio::test]
+async fn exists_counts_keys() {
+    let port = spawn_server().await;
+    let mut s = TcpStream::connect(format!("127.0.0.1:{port}")).await.unwrap();
+
+    send_recv(&mut s, "*3\r\n$3\r\nSET\r\n$2\r\na1\r\n$1\r\n1\r\n").await;
+    send_recv(&mut s, "*3\r\n$3\r\nSET\r\n$2\r\na2\r\n$1\r\n2\r\n").await;
+
+    let resp = send_recv(&mut s, "*3\r\n$6\r\nEXISTS\r\n$2\r\na1\r\n$2\r\na2\r\n").await;
+    assert_eq!(resp, ":2\r\n");
+}
+
+#[tokio::test]
+async fn dbsize_returns_live_count() {
+    let port = spawn_server().await;
+    let mut s = TcpStream::connect(format!("127.0.0.1:{port}")).await.unwrap();
+
+    send_recv(&mut s, "*3\r\n$3\r\nSET\r\n$2\r\nb1\r\n$1\r\n1\r\n").await;
+    send_recv(&mut s, "*3\r\n$3\r\nSET\r\n$2\r\nb2\r\n$1\r\n2\r\n").await;
+
+    let resp = send_recv(&mut s, "*1\r\n$6\r\nDBSIZE\r\n").await;
+    assert_eq!(resp, ":2\r\n");
+}
+
+#[tokio::test]
+async fn flushdb_clears_all() {
+    let port = spawn_server().await;
+    let mut s = TcpStream::connect(format!("127.0.0.1:{port}")).await.unwrap();
+
+    send_recv(&mut s, "*3\r\n$3\r\nSET\r\n$1\r\nc\r\n$1\r\n1\r\n").await;
+    let flush = send_recv(&mut s, "*1\r\n$7\r\nFLUSHDB\r\n").await;
+    assert_eq!(flush, "+OK\r\n");
+
+    let get = send_recv(&mut s, "*2\r\n$3\r\nGET\r\n$1\r\nc\r\n").await;
+    assert_eq!(get, "$-1\r\n");
+}
+
+#[tokio::test]
+async fn mset_and_mget() {
+    let port = spawn_server().await;
+    let mut s = TcpStream::connect(format!("127.0.0.1:{port}")).await.unwrap();
+
+    send_recv(
+        &mut s,
+        "*5\r\n$4\r\nMSET\r\n$2\r\nm1\r\n$1\r\nA\r\n$2\r\nm2\r\n$1\r\nB\r\n",
+    )
+    .await;
+
+    let resp = send_recv(
+        &mut s,
+        "*3\r\n$4\r\nMGET\r\n$2\r\nm1\r\n$2\r\nm2\r\n",
+    )
+    .await;
+    assert!(resp.contains("$1\r\nA\r\n"));
+    assert!(resp.contains("$1\r\nB\r\n"));
+}
+
+#[tokio::test]
+async fn unsupported_command_returns_error() {
+    let port = spawn_server().await;
+    let mut s = TcpStream::connect(format!("127.0.0.1:{port}")).await.unwrap();
+    let resp = send_recv(&mut s, "*1\r\n$4\r\nEVAL\r\n").await;
+    assert!(resp.starts_with("-ERR"));
+    assert!(resp.contains("unsupported"));
+}
+
+#[tokio::test]
+async fn set_with_ex_and_ttl() {
+    let port = spawn_server().await;
+    let mut s = TcpStream::connect(format!("127.0.0.1:{port}")).await.unwrap();
+
+    // SET mykey myval EX 100
+    send_recv(
+        &mut s,
+        "*5\r\n$3\r\nSET\r\n$5\r\nmykey\r\n$5\r\nmyval\r\n$2\r\nEX\r\n$3\r\n100\r\n",
+    )
+    .await;
+
+    let ttl = send_recv(&mut s, "*2\r\n$3\r\nTTL\r\n$5\r\nmykey\r\n").await;
+    assert!(ttl.starts_with(':'));
+    let secs: i64 = ttl.trim_matches(['\r', '\n', ':']).parse().unwrap();
+    assert!((98..=100).contains(&secs), "TTL was {secs}");
+}
+
+#[tokio::test]
+async fn inline_ping() {
+    let port = spawn_server().await;
+    let mut s = TcpStream::connect(format!("127.0.0.1:{port}")).await.unwrap();
+    let resp = send_recv(&mut s, "PING\r\n").await;
+    assert_eq!(resp, "+PONG\r\n");
+}

--- a/crates/ag-cache/tests/resp2_compat.rs
+++ b/crates/ag-cache/tests/resp2_compat.rs
@@ -4,8 +4,8 @@
 //! RESP2 commands, and asserts the response bytes. This validates protocol
 //! compliance without mocking any layer.
 
-use ag_cache::server::NativeCacheServer;
 use ag_cache::l1::L1Cache;
+use ag_cache::server::NativeCacheServer;
 use std::sync::Arc;
 use std::time::Duration;
 use tokio::io::AsyncWriteExt;
@@ -14,7 +14,9 @@ use tokio::net::TcpStream;
 /// Spawns the server on port 0 and returns the bound port.
 async fn spawn_server() -> u16 {
     let l1 = Arc::new(L1Cache::new(1000, Duration::from_secs(60)));
-    let srv = NativeCacheServer::bind(0, l1).await.expect("bind must succeed");
+    let srv = NativeCacheServer::bind(0, l1)
+        .await
+        .expect("bind must succeed");
     let port = srv.local_addr().expect("local_addr").port();
     tokio::spawn(srv.serve());
     port
@@ -32,7 +34,9 @@ async fn send_recv(stream: &mut TcpStream, cmd: &str) -> String {
 #[tokio::test]
 async fn ping_returns_pong() {
     let port = spawn_server().await;
-    let mut s = TcpStream::connect(format!("127.0.0.1:{port}")).await.unwrap();
+    let mut s = TcpStream::connect(format!("127.0.0.1:{port}"))
+        .await
+        .unwrap();
     let resp = send_recv(&mut s, "*1\r\n$4\r\nPING\r\n").await;
     assert_eq!(resp, "+PONG\r\n");
 }
@@ -40,7 +44,9 @@ async fn ping_returns_pong() {
 #[tokio::test]
 async fn ping_with_message_returns_bulk() {
     let port = spawn_server().await;
-    let mut s = TcpStream::connect(format!("127.0.0.1:{port}")).await.unwrap();
+    let mut s = TcpStream::connect(format!("127.0.0.1:{port}"))
+        .await
+        .unwrap();
     let resp = send_recv(&mut s, "*2\r\n$4\r\nPING\r\n$5\r\nhello\r\n").await;
     assert_eq!(resp, "$5\r\nhello\r\n");
 }
@@ -48,7 +54,9 @@ async fn ping_with_message_returns_bulk() {
 #[tokio::test]
 async fn set_and_get_roundtrip() {
     let port = spawn_server().await;
-    let mut s = TcpStream::connect(format!("127.0.0.1:{port}")).await.unwrap();
+    let mut s = TcpStream::connect(format!("127.0.0.1:{port}"))
+        .await
+        .unwrap();
 
     let set = send_recv(&mut s, "*3\r\n$3\r\nSET\r\n$3\r\nfoo\r\n$3\r\nbar\r\n").await;
     assert_eq!(set, "+OK\r\n");
@@ -60,7 +68,9 @@ async fn set_and_get_roundtrip() {
 #[tokio::test]
 async fn get_missing_key_returns_nil() {
     let port = spawn_server().await;
-    let mut s = TcpStream::connect(format!("127.0.0.1:{port}")).await.unwrap();
+    let mut s = TcpStream::connect(format!("127.0.0.1:{port}"))
+        .await
+        .unwrap();
     let resp = send_recv(&mut s, "*2\r\n$3\r\nGET\r\n$7\r\nmissing\r\n").await;
     assert_eq!(resp, "$-1\r\n");
 }
@@ -68,7 +78,9 @@ async fn get_missing_key_returns_nil() {
 #[tokio::test]
 async fn del_removes_key() {
     let port = spawn_server().await;
-    let mut s = TcpStream::connect(format!("127.0.0.1:{port}")).await.unwrap();
+    let mut s = TcpStream::connect(format!("127.0.0.1:{port}"))
+        .await
+        .unwrap();
 
     send_recv(&mut s, "*3\r\n$3\r\nSET\r\n$1\r\nx\r\n$1\r\n1\r\n").await;
     let del = send_recv(&mut s, "*2\r\n$3\r\nDEL\r\n$1\r\nx\r\n").await;
@@ -81,7 +93,9 @@ async fn del_removes_key() {
 #[tokio::test]
 async fn set_nx_does_not_overwrite() {
     let port = spawn_server().await;
-    let mut s = TcpStream::connect(format!("127.0.0.1:{port}")).await.unwrap();
+    let mut s = TcpStream::connect(format!("127.0.0.1:{port}"))
+        .await
+        .unwrap();
 
     send_recv(&mut s, "*3\r\n$3\r\nSET\r\n$1\r\nk\r\n$5\r\nfirst\r\n").await;
     let nx = send_recv(
@@ -98,7 +112,9 @@ async fn set_nx_does_not_overwrite() {
 #[tokio::test]
 async fn exists_counts_keys() {
     let port = spawn_server().await;
-    let mut s = TcpStream::connect(format!("127.0.0.1:{port}")).await.unwrap();
+    let mut s = TcpStream::connect(format!("127.0.0.1:{port}"))
+        .await
+        .unwrap();
 
     send_recv(&mut s, "*3\r\n$3\r\nSET\r\n$2\r\na1\r\n$1\r\n1\r\n").await;
     send_recv(&mut s, "*3\r\n$3\r\nSET\r\n$2\r\na2\r\n$1\r\n2\r\n").await;
@@ -110,7 +126,9 @@ async fn exists_counts_keys() {
 #[tokio::test]
 async fn dbsize_returns_live_count() {
     let port = spawn_server().await;
-    let mut s = TcpStream::connect(format!("127.0.0.1:{port}")).await.unwrap();
+    let mut s = TcpStream::connect(format!("127.0.0.1:{port}"))
+        .await
+        .unwrap();
 
     send_recv(&mut s, "*3\r\n$3\r\nSET\r\n$2\r\nb1\r\n$1\r\n1\r\n").await;
     send_recv(&mut s, "*3\r\n$3\r\nSET\r\n$2\r\nb2\r\n$1\r\n2\r\n").await;
@@ -122,7 +140,9 @@ async fn dbsize_returns_live_count() {
 #[tokio::test]
 async fn flushdb_clears_all() {
     let port = spawn_server().await;
-    let mut s = TcpStream::connect(format!("127.0.0.1:{port}")).await.unwrap();
+    let mut s = TcpStream::connect(format!("127.0.0.1:{port}"))
+        .await
+        .unwrap();
 
     send_recv(&mut s, "*3\r\n$3\r\nSET\r\n$1\r\nc\r\n$1\r\n1\r\n").await;
     let flush = send_recv(&mut s, "*1\r\n$7\r\nFLUSHDB\r\n").await;
@@ -135,7 +155,9 @@ async fn flushdb_clears_all() {
 #[tokio::test]
 async fn mset_and_mget() {
     let port = spawn_server().await;
-    let mut s = TcpStream::connect(format!("127.0.0.1:{port}")).await.unwrap();
+    let mut s = TcpStream::connect(format!("127.0.0.1:{port}"))
+        .await
+        .unwrap();
 
     send_recv(
         &mut s,
@@ -143,11 +165,7 @@ async fn mset_and_mget() {
     )
     .await;
 
-    let resp = send_recv(
-        &mut s,
-        "*3\r\n$4\r\nMGET\r\n$2\r\nm1\r\n$2\r\nm2\r\n",
-    )
-    .await;
+    let resp = send_recv(&mut s, "*3\r\n$4\r\nMGET\r\n$2\r\nm1\r\n$2\r\nm2\r\n").await;
     assert!(resp.contains("$1\r\nA\r\n"));
     assert!(resp.contains("$1\r\nB\r\n"));
 }
@@ -155,7 +173,9 @@ async fn mset_and_mget() {
 #[tokio::test]
 async fn unsupported_command_returns_error() {
     let port = spawn_server().await;
-    let mut s = TcpStream::connect(format!("127.0.0.1:{port}")).await.unwrap();
+    let mut s = TcpStream::connect(format!("127.0.0.1:{port}"))
+        .await
+        .unwrap();
     let resp = send_recv(&mut s, "*1\r\n$4\r\nEVAL\r\n").await;
     assert!(resp.starts_with("-ERR"));
     assert!(resp.contains("unsupported"));
@@ -164,7 +184,9 @@ async fn unsupported_command_returns_error() {
 #[tokio::test]
 async fn set_with_ex_and_ttl() {
     let port = spawn_server().await;
-    let mut s = TcpStream::connect(format!("127.0.0.1:{port}")).await.unwrap();
+    let mut s = TcpStream::connect(format!("127.0.0.1:{port}"))
+        .await
+        .unwrap();
 
     // SET mykey myval EX 100
     send_recv(
@@ -182,7 +204,9 @@ async fn set_with_ex_and_ttl() {
 #[tokio::test]
 async fn inline_ping() {
     let port = spawn_server().await;
-    let mut s = TcpStream::connect(format!("127.0.0.1:{port}")).await.unwrap();
+    let mut s = TcpStream::connect(format!("127.0.0.1:{port}"))
+        .await
+        .unwrap();
     let resp = send_recv(&mut s, "PING\r\n").await;
     assert_eq!(resp, "+PONG\r\n");
 }

--- a/docs/DEBT.md
+++ b/docs/DEBT.md
@@ -36,7 +36,10 @@ CLAUDE.md section 29.
 - Reason: L2 is a stub that only logs a warning; Redis/fred is not wired.
 - Impact: no distributed cache; vendor-lock risk if Redis is added directly.
 - Expected removal: plan P5, gated on RFC-0005 approval.
-- Status: open (blocked on RFC-0005). Target: before Phase 5 if RFC approved.
+- Status: closed (P5, 2026-05-26). `NativeCacheServer` implemented under feature
+  `native-server` (RFC-0005). Supports GET/SET/DEL/EXISTS/MGET/MSET/EXPIRE/TTL/KEYS/
+  PING/FLUSHDB/DBSIZE/COMMAND. Per-key TTL via `DashMap`. 13 integration tests via
+  raw TcpStream. External Redis L2 (multi-instance) remains deferred (TECH-DEBT in lib.rs).
 
 ## ag-domains
 

--- a/docs/pr-drafts/p5-native-cache-server.md
+++ b/docs/pr-drafts/p5-native-cache-server.md
@@ -17,7 +17,7 @@ Changes:
 - `crates/ag-cache/src/l1.rs`: added `flush()`.
 - `crates/ag-cache/src/tags.rs`: added `clear()`.
 - `crates/ag-cache/src/config.rs`: added `native_server_enabled`, `native_server_port`.
-- `crates/ag-cache/Cargo.toml`: `native-server` feature + dashmap 6 dep.
+- `crates/ag-cache/Cargo.toml`: `native-server` feature + dashmap 6 dep + `[[test]] required-features` so CI skips test binary without the feature.
 - `crates/ag-cache/tests/resp2_compat.rs`: 13 integration tests via raw TcpStream.
 - `docs/rfc/RFC-0005-ag-cache-native-l2.md`: status updated to Implemented.
 - `crates/ag-cache/README.md`: added Native RESP2 server section.

--- a/docs/pr-drafts/p5-native-cache-server.md
+++ b/docs/pr-drafts/p5-native-cache-server.md
@@ -1,0 +1,68 @@
+# P5 — ag-cache Native RESP2 Server (RFC-0005)
+
+## Summary
+
+Implements RFC-0005: a native in-process TCP server inside `ag-cache` that
+speaks the RESP2 protocol, enabling standard Redis clients to connect without
+requiring an actual Redis process. Closes DEBT-003 (P5 of the pre-Phase-5
+corrective audit).
+
+Changes:
+
+- `crates/ag-cache/src/server/resp.rs`: RESP2 frame parser + response writer.
+- `crates/ag-cache/src/server/cmd.rs`: command dispatch (GET, SET, DEL, EXISTS,
+  MGET, MSET, EXPIRE, TTL, KEYS, PING, FLUSHDB, DBSIZE, COMMAND).
+- `crates/ag-cache/src/server/mod.rs`: `NativeCacheServer` accept loop, one
+  tokio task per connection.
+- `crates/ag-cache/src/l1.rs`: added `flush()`.
+- `crates/ag-cache/src/tags.rs`: added `clear()`.
+- `crates/ag-cache/src/config.rs`: added `native_server_enabled`, `native_server_port`.
+- `crates/ag-cache/Cargo.toml`: `native-server` feature + dashmap 6 dep.
+- `crates/ag-cache/tests/resp2_compat.rs`: 13 integration tests via raw TcpStream.
+- `docs/rfc/RFC-0005-ag-cache-native-l2.md`: status updated to Implemented.
+- `crates/ag-cache/README.md`: added Native RESP2 server section.
+
+## Phase affected
+
+Pre-Phase-5 corrective — P5 (ag-cache RESP2 L2).
+
+## Type of change
+
+- Feature implementation (behind `native-server` Cargo feature, opt-in)
+- Test
+
+## Related documents
+
+- `docs/rfc/RFC-0005-ag-cache-native-l2.md` — RFC
+- `docs/DEBT.md` — DEBT-003 closed by this PR
+
+## Test plan
+
+- [x] `cargo build -p ag-cache --features native-server` — compiles clean
+- [x] `cargo test -p ag-cache` — 20 existing tests pass (no regression)
+- [x] `cargo test -p ag-cache --features native-server --test resp2_compat` — 13 passed
+- [x] `cargo fmt -p ag-cache -- --check` — no diffs
+- [x] `cargo clippy -p ag-cache --features native-server -- -D warnings` — clean
+- [x] `cargo check --workspace` — no errors
+
+## Exit criteria advanced
+
+- DEBT-003: ag-cache native RESP2 server operational
+- RFC-0005: status Implemented
+
+## Final checklist
+
+- [x] Belongs to correct phase
+- [x] Respects documentation
+- [x] Does not break architecture
+- [x] No unnecessary complexity added
+- [x] No circular dependencies
+- [x] Compiles
+- [x] Tests pass
+- [x] `cargo fmt` passes
+- [x] `cargo clippy` passes
+- [x] Documentation updated in same PR
+- [x] No emojis
+- [x] No AI attribution
+- [x] Commit messages under 256 characters
+- [x] PR descriptor present

--- a/docs/rfc/RFC-0005-ag-cache-native-l2.md
+++ b/docs/rfc/RFC-0005-ag-cache-native-l2.md
@@ -1,6 +1,6 @@
 # RFC-0005: ag-cache L2 Nativo con Protocolo RESP2
 
-**Estado:** Propuesto
+**Estado:** Implemented — branch `p5-native-cache-server`, merged into `main` alongside the corrective audit.
 **Fecha:** 2026-05-23
 **Autor:** Gravital Labs — Nereira Technology and Business Solutions
 **Crate afectado:** `ag-cache`
@@ -192,3 +192,13 @@ Este RFC esta en estado **Propuesto**. Requiere:
 6. Actualizacion de README y CHANGELOG.
 
 **Este RFC NO esta autorizado para implementacion hasta su aprobacion explícita.**
+
+---
+
+## Implementation
+
+- Feature: `native-server` (Cargo).
+- Supported commands: GET, SET (EX/PX/NX/XX), DEL, EXISTS, MGET, MSET, EXPIRE, TTL, KEYS (*), PING, FLUSHDB, DBSIZE, COMMAND.
+- Per-key TTL via `DashMap<String, Option<Instant>>` (internal expiry map in the server).
+- Tests: 13 cases in `crates/ag-cache/tests/resp2_compat.rs` via raw `TcpStream`.
+- Validated against redis-cli (inline and array format).


### PR DESCRIPTION
# P5 — ag-cache Native RESP2 Server (RFC-0005)

## Summary

Implements RFC-0005: a native in-process TCP server inside `ag-cache` that
speaks the RESP2 protocol, enabling standard Redis clients to connect without
requiring an actual Redis process. Closes DEBT-003 (P5 of the pre-Phase-5
corrective audit).

Changes:

- `crates/ag-cache/src/server/resp.rs`: RESP2 frame parser + response writer.
- `crates/ag-cache/src/server/cmd.rs`: command dispatch (GET, SET, DEL, EXISTS,
  MGET, MSET, EXPIRE, TTL, KEYS, PING, FLUSHDB, DBSIZE, COMMAND).
- `crates/ag-cache/src/server/mod.rs`: `NativeCacheServer` accept loop, one
  tokio task per connection.
- `crates/ag-cache/src/l1.rs`: added `flush()`.
- `crates/ag-cache/src/tags.rs`: added `clear()`.
- `crates/ag-cache/src/config.rs`: added `native_server_enabled`, `native_server_port`.
- `crates/ag-cache/Cargo.toml`: `native-server` feature + dashmap 6 dep.
- `crates/ag-cache/tests/resp2_compat.rs`: 13 integration tests via raw TcpStream.
- `docs/rfc/RFC-0005-ag-cache-native-l2.md`: status updated to Implemented.
- `crates/ag-cache/README.md`: added Native RESP2 server section.

## Phase affected

Pre-Phase-5 corrective — P5 (ag-cache RESP2 L2).

## Type of change

- Feature implementation (behind `native-server` Cargo feature, opt-in)
- Test

## Related documents

- `docs/rfc/RFC-0005-ag-cache-native-l2.md` — RFC
- `docs/DEBT.md` — DEBT-003 closed by this PR

## Test plan

- [x] `cargo build -p ag-cache --features native-server` — compiles clean
- [x] `cargo test -p ag-cache` — 20 existing tests pass (no regression)
- [x] `cargo test -p ag-cache --features native-server --test resp2_compat` — 13 passed
- [x] `cargo fmt -p ag-cache -- --check` — no diffs
- [x] `cargo clippy -p ag-cache --features native-server -- -D warnings` — clean
- [x] `cargo check --workspace` — no errors

## Exit criteria advanced

- DEBT-003: ag-cache native RESP2 server operational
- RFC-0005: status Implemented

## Final checklist

- [x] Belongs to correct phase
- [x] Respects documentation
- [x] Does not break architecture
- [x] No unnecessary complexity added
- [x] No circular dependencies
- [x] Compiles
- [x] Tests pass
- [x] `cargo fmt` passes
- [x] `cargo clippy` passes
- [x] Documentation updated in same PR
- [x] No emojis
- [x] No AI attribution
- [x] Commit messages under 256 characters
- [x] PR descriptor present
