### PR TITLE
fix(vscode-ext): upgrade tmp to 0.2.6 — CVE-2026-44705 path traversal

### DIFF
--- a/docs/pr-drafts/security-tmp-cve-2026-44705.md
+++ b/docs/pr-drafts/security-tmp-cve-2026-44705.md
@@ -1,0 +1,46 @@
+# Security — tmp path traversal CVE-2026-44705
+
+## Summary
+
+Patches CVE-2026-44705 (GHSA-ph9p-34f9-6g65) in the VS Code extension tooling.
+The `tmp` npm package (<0.2.6) allowed path traversal via unsanitized `prefix`,
+`postfix`, or `dir` options. Forced upgrade to `>=0.2.6` via npm `overrides`.
+
+Changes:
+- `tools/vscode-anti-gravital/package.json`: add `overrides.tmp >= 0.2.6`.
+- `tools/vscode-anti-gravital/package-lock.json`: `tmp` resolved to `0.2.6`.
+
+## Phase affected
+
+Maintenance / security — no phase dependency. Affects tooling only (dev scope).
+
+## Type of change
+
+- Security patch (transitive devDependency upgrade)
+
+## Related documents
+
+- Dependabot alert #7: github.com/Anti-Gravital/Anti-Gravital/security/dependabot/7
+- GHSA-ph9p-34f9-6g65 / CVE-2026-44705
+
+## Test plan
+
+- [ ] `npm audit` inside `tools/vscode-anti-gravital/` reports 0 vulnerabilities
+- [ ] `grep tmp tools/vscode-anti-gravital/package-lock.json` shows version 0.2.6
+- [ ] `npm run compile` inside `tools/vscode-anti-gravital/` succeeds (no regression)
+
+## Exit criteria advanced
+
+- Dependabot alert #7 resolved
+
+## Final checklist
+
+- [x] Belongs to correct phase (security maintenance)
+- [x] Respects documentation
+- [x] Does not break architecture
+- [x] No unnecessary complexity added
+- [x] Compiles
+- [x] No emojis
+- [x] No AI attribution
+- [x] Commit message under 256 characters
+- [x] PR descriptor present

--- a/tools/vscode-anti-gravital/package-lock.json
+++ b/tools/vscode-anti-gravital/package-lock.json
@@ -2255,9 +2255,9 @@
       }
     },
     "node_modules/tmp": {
-      "version": "0.2.5",
-      "resolved": "https://registry.npmjs.org/tmp/-/tmp-0.2.5.tgz",
-      "integrity": "sha512-voyz6MApa1rQGUxT3E+BK7/ROe8itEx7vD8/HEvt4xwXucvQ5G5oeEiHkmHZJuBO21RpOf+YYm9MOivj709jow==",
+      "version": "0.2.6",
+      "resolved": "https://registry.npmjs.org/tmp/-/tmp-0.2.6.tgz",
+      "integrity": "sha512-5sJPdPjfI5Kx+qbrDesxkglRBxW//g7hCsqspEjwkewGvBMGIKMOTKzLt1hFVJzyadba3lDUN20O9qhvbQUSTA==",
       "dev": true,
       "license": "MIT",
       "engines": {

--- a/tools/vscode-anti-gravital/package.json
+++ b/tools/vscode-anti-gravital/package.json
@@ -53,5 +53,8 @@
     "@types/vscode": "^1.75.0",
     "@vscode/vsce": "^2.22.0",
     "typescript": "^5.3.0"
+  },
+  "overrides": {
+    "tmp": ">=0.2.6"
   }
 }


### PR DESCRIPTION
# Security — tmp path traversal CVE-2026-44705

## Summary

Patches CVE-2026-44705 (GHSA-ph9p-34f9-6g65) in the VS Code extension tooling.
The `tmp` npm package (<0.2.6) allowed path traversal via unsanitized `prefix`,
`postfix`, or `dir` options. Forced upgrade to `>=0.2.6` via npm `overrides`.

Changes:
- `tools/vscode-anti-gravital/package.json`: add `overrides.tmp >= 0.2.6`.
- `tools/vscode-anti-gravital/package-lock.json`: `tmp` resolved to `0.2.6`.

## Phase affected

Maintenance / security — no phase dependency. Affects tooling only (dev scope).

## Type of change

- Security patch (transitive devDependency upgrade)

## Related documents

- Dependabot alert #7: github.com/Anti-Gravital/Anti-Gravital/security/dependabot/7
- GHSA-ph9p-34f9-6g65 / CVE-2026-44705

## Test plan

- [ ] `npm audit` inside `tools/vscode-anti-gravital/` reports 0 vulnerabilities
- [ ] `grep tmp tools/vscode-anti-gravital/package-lock.json` shows version 0.2.6
- [ ] `npm run compile` inside `tools/vscode-anti-gravital/` succeeds (no regression)

## Exit criteria advanced

- Dependabot alert #7 resolved

## Final checklist

- [x] Belongs to correct phase (security maintenance)
- [x] Respects documentation
- [x] Does not break architecture
- [x] No unnecessary complexity added
- [x] Compiles
- [x] No emojis
- [x] No AI attribution
- [x] Commit message under 256 characters
- [x] PR descriptor present
