### PR TITLE
Feat/ag domains cert issuance

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,20 @@ primera version etiquetada.
 
 ## [Unreleased]
 
+### ag-domains: orquestacion de emision de certificados (RFC-0011, fase 2)
+
+Anadido:
+
+- `crates/ag-domains/src/issuance.rs`: proteccion de rate-limit del blueprint
+  §13.4. `CertIssuer` trait (el emisor ACME real se inyecta), `IssuedCertificate`,
+  `san_key` (clave de deduplicacion canonica por conjunto SAN), `IssuanceLimiter`
+  (dedup de ordenes en vuelo + contadores por dominio registrable) y
+  `issue_certificate` (reserva, emite, cuenta exitos, libera). Logica nativa sin
+  dependencias externas; tests con issuer mock.
+- `crates/ag-edge/tests/issuance_to_edge.rs`: test E2E que emite via la
+  orquestacion (issuer rcgen), carga el PEM en el `CertStore` del edge y lo
+  selecciona por SNI; verifica la cadena emision -> serving completa.
+
 ### ag-domains: event log de dominio + metricas de control-plane
 
 Anadido:

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -160,6 +160,7 @@ name = "ag-edge"
 version = "0.0.0"
 dependencies = [
  "ag-domains",
+ "async-trait",
  "axum 0.7.9",
  "http-body-util",
  "hyper",

--- a/crates/ag-domains/src/issuance.rs
+++ b/crates/ag-domains/src/issuance.rs
@@ -1,0 +1,335 @@
+//! Certificate issuance orchestration: SAN-set deduplication and rate limits.
+//!
+//! Implements the rate-limit protections from the blueprint section 13.4:
+//! deduplication by SAN set (so concurrent requests for the same certificate do
+//! not start two ACME orders) and per-registered-domain issuance counters (so
+//! the control plane stays under the CA's "certificates per registered domain"
+//! limit). This is native logic with no external dependency; the actual ACME
+//! order is performed by an injected [`CertIssuer`] (production wraps
+//! `crate::acme::renewal::issue`; tests use a mock).
+
+use std::collections::{HashMap, HashSet};
+use std::sync::Mutex;
+
+use async_trait::async_trait;
+
+/// An issued certificate: PEM chain + PEM private key.
+///
+/// Mirrors `acme::renewal::IssuedCert` without coupling this module to the
+/// `acme` Cargo feature; the ACME issuer maps one into the other.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct IssuedCertificate {
+    /// Certificate chain in PEM format (leaf + intermediates).
+    pub cert_chain_pem: String,
+    /// Private key in PEM format.
+    pub private_key_pem: String,
+}
+
+/// Errors from the issuance orchestration.
+#[derive(Debug, thiserror::Error)]
+pub enum IssuanceError {
+    /// The SAN set was empty.
+    #[error("empty SAN set")]
+    EmptySanSet,
+    /// An order for the same SAN set is already running.
+    #[error("an order for the same SAN set is already in flight")]
+    DuplicateInFlight,
+    /// The per-registered-domain issuance limit was reached.
+    #[error("issuance rate limit reached for '{domain}' ({count}/{max} in window)")]
+    RateLimited {
+        /// Registered domain that hit the limit.
+        domain: String,
+        /// Current count in the window.
+        count: u32,
+        /// Configured maximum.
+        max: u32,
+    },
+    /// The underlying issuer failed.
+    #[error("issuer error: {0}")]
+    Issuer(String),
+}
+
+/// Produces a certificate for a set of subject alternative names.
+///
+/// The production implementation wraps the ACME client; tests inject a mock.
+#[async_trait]
+pub trait CertIssuer: Send + Sync {
+    /// Issues a certificate covering exactly `sans`.
+    async fn issue(&self, sans: &[String]) -> Result<IssuedCertificate, IssuanceError>;
+}
+
+/// Canonical deduplication key for a SAN set: lowercased, de-duplicated, sorted.
+///
+/// Order- and case-independent, so `[a, B]` and `[b, a]` map to the same key.
+pub fn san_key(sans: &[String]) -> String {
+    let mut norm: Vec<String> = sans
+        .iter()
+        .map(|s| s.trim().trim_end_matches('.').to_ascii_lowercase())
+        .filter(|s| !s.is_empty())
+        .collect();
+    norm.sort();
+    norm.dedup();
+    norm.join(",")
+}
+
+/// Best-effort registered domain used for per-domain counting.
+///
+/// Strips a leading `*.` and keeps the last two labels. This shares the
+/// two-label heuristic of [`crate::hostname`] and its Public Suffix List
+/// limitation (DEBT-024): multi-label public suffixes (`co.uk`) are
+/// over-counted under a single key.
+fn counting_key(san: &str) -> String {
+    let host = san.trim().trim_end_matches('.').to_ascii_lowercase();
+    let host = host.strip_prefix("*.").unwrap_or(&host);
+    let labels: Vec<&str> = host.split('.').filter(|l| !l.is_empty()).collect();
+    let n = labels.len();
+    if n <= 2 {
+        labels.join(".")
+    } else {
+        labels[n - 2..].join(".")
+    }
+}
+
+/// Tracks in-flight SAN sets and per-registered-domain issuance counts.
+///
+/// `max_per_domain` mirrors the CA's certificates-per-registered-domain window
+/// limit; counts increment on successful issuance only (matching how CAs count
+/// issued certificates), while the in-flight set prevents duplicate concurrent
+/// orders.
+#[derive(Debug)]
+pub struct IssuanceLimiter {
+    max_per_domain: u32,
+    state: Mutex<LimiterState>,
+}
+
+#[derive(Default)]
+struct LimiterState {
+    in_flight: HashSet<String>,
+    issued_counts: HashMap<String, u32>,
+}
+
+impl std::fmt::Debug for LimiterState {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("LimiterState")
+            .field("in_flight", &self.in_flight.len())
+            .field("tracked_domains", &self.issued_counts.len())
+            .finish()
+    }
+}
+
+impl IssuanceLimiter {
+    /// Creates a limiter that allows `max_per_domain` issued certificates per
+    /// registered domain.
+    pub fn new(max_per_domain: u32) -> Self {
+        Self {
+            max_per_domain,
+            state: Mutex::new(LimiterState::default()),
+        }
+    }
+
+    fn lock(&self) -> std::sync::MutexGuard<'_, LimiterState> {
+        self.state.lock().expect("issuance limiter lock poisoned")
+    }
+
+    /// Reserves an in-flight slot for `sans` after checking dedup and rate.
+    ///
+    /// Returns the SAN key to pass to [`IssuanceLimiter::release`].
+    fn reserve(&self, sans: &[String], key: &str) -> Result<(), IssuanceError> {
+        let mut st = self.lock();
+        if st.in_flight.contains(key) {
+            return Err(IssuanceError::DuplicateInFlight);
+        }
+        for san in sans {
+            let domain = counting_key(san);
+            let count = st.issued_counts.get(&domain).copied().unwrap_or(0);
+            if count >= self.max_per_domain {
+                return Err(IssuanceError::RateLimited {
+                    domain,
+                    count,
+                    max: self.max_per_domain,
+                });
+            }
+        }
+        st.in_flight.insert(key.to_owned());
+        Ok(())
+    }
+
+    /// Records a successful issuance, incrementing per-domain counters once per
+    /// distinct registered domain in the SAN set.
+    fn record_success(&self, sans: &[String]) {
+        let mut st = self.lock();
+        let mut seen = HashSet::new();
+        for san in sans {
+            let domain = counting_key(san);
+            if seen.insert(domain.clone()) {
+                *st.issued_counts.entry(domain).or_insert(0) += 1;
+            }
+        }
+    }
+
+    /// Releases the in-flight reservation for `key`.
+    fn release(&self, key: &str) {
+        self.lock().in_flight.remove(key);
+    }
+
+    /// Current issued count for a registered domain (test/diagnostics).
+    pub fn issued_count(&self, registered_domain: &str) -> u32 {
+        self.lock()
+            .issued_counts
+            .get(&counting_key(registered_domain))
+            .copied()
+            .unwrap_or(0)
+    }
+}
+
+/// Issues a certificate for `sans`, honoring deduplication and rate limits.
+///
+/// Reserves an in-flight slot (rejecting duplicates and rate-limited domains),
+/// delegates to `issuer`, increments per-domain counters on success, and always
+/// releases the in-flight slot.
+pub async fn issue_certificate(
+    limiter: &IssuanceLimiter,
+    issuer: &dyn CertIssuer,
+    sans: &[String],
+) -> Result<IssuedCertificate, IssuanceError> {
+    if sans.iter().all(|s| s.trim().is_empty()) {
+        return Err(IssuanceError::EmptySanSet);
+    }
+    let key = san_key(sans);
+    limiter.reserve(sans, &key)?;
+
+    let result = issuer.issue(sans).await;
+
+    if result.is_ok() {
+        limiter.record_success(sans);
+    }
+    limiter.release(&key);
+    result
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::sync::atomic::{AtomicUsize, Ordering};
+
+    struct MockIssuer {
+        calls: AtomicUsize,
+        fail: bool,
+    }
+    impl MockIssuer {
+        fn ok() -> Self {
+            Self {
+                calls: AtomicUsize::new(0),
+                fail: false,
+            }
+        }
+        fn failing() -> Self {
+            Self {
+                calls: AtomicUsize::new(0),
+                fail: true,
+            }
+        }
+    }
+    #[async_trait]
+    impl CertIssuer for MockIssuer {
+        async fn issue(&self, sans: &[String]) -> Result<IssuedCertificate, IssuanceError> {
+            self.calls.fetch_add(1, Ordering::SeqCst);
+            if self.fail {
+                return Err(IssuanceError::Issuer("boom".to_owned()));
+            }
+            Ok(IssuedCertificate {
+                cert_chain_pem: format!("CERT for {}", san_key(sans)),
+                private_key_pem: "KEY".to_owned(),
+            })
+        }
+    }
+
+    #[test]
+    fn san_key_is_order_and_case_independent() {
+        let a = san_key(&["B.example.com".to_owned(), "a.example.com".to_owned()]);
+        let b = san_key(&["a.example.com".to_owned(), "b.example.com.".to_owned()]);
+        assert_eq!(a, b);
+        assert_eq!(a, "a.example.com,b.example.com");
+    }
+
+    #[test]
+    fn counting_key_strips_wildcard_and_keeps_etld1() {
+        assert_eq!(counting_key("*.example.com"), "example.com");
+        assert_eq!(counting_key("api.example.com"), "example.com");
+        assert_eq!(counting_key("example.com"), "example.com");
+    }
+
+    #[tokio::test]
+    async fn issues_and_counts_success() {
+        let limiter = IssuanceLimiter::new(5);
+        let issuer = MockIssuer::ok();
+        let cert = issue_certificate(&limiter, &issuer, &["api.example.com".to_owned()])
+            .await
+            .unwrap();
+        assert!(cert.cert_chain_pem.contains("api.example.com"));
+        assert_eq!(limiter.issued_count("example.com"), 1);
+    }
+
+    #[tokio::test]
+    async fn empty_san_set_rejected() {
+        let limiter = IssuanceLimiter::new(5);
+        let issuer = MockIssuer::ok();
+        let err = issue_certificate(&limiter, &issuer, &["  ".to_owned()])
+            .await
+            .unwrap_err();
+        assert!(matches!(err, IssuanceError::EmptySanSet));
+        assert_eq!(issuer.calls.load(Ordering::SeqCst), 0);
+    }
+
+    #[tokio::test]
+    async fn duplicate_in_flight_rejected() {
+        let limiter = IssuanceLimiter::new(5);
+        let key = san_key(&["api.example.com".to_owned()]);
+        limiter
+            .reserve(&["api.example.com".to_owned()], &key)
+            .unwrap();
+        // A second reserve for the same key fails until released.
+        let err = limiter
+            .reserve(&["api.example.com".to_owned()], &key)
+            .unwrap_err();
+        assert!(matches!(err, IssuanceError::DuplicateInFlight));
+        limiter.release(&key);
+        assert!(limiter
+            .reserve(&["api.example.com".to_owned()], &key)
+            .is_ok());
+    }
+
+    #[tokio::test]
+    async fn rate_limit_enforced_per_domain() {
+        let limiter = IssuanceLimiter::new(2);
+        let issuer = MockIssuer::ok();
+        for sub in ["a.example.com", "b.example.com"] {
+            issue_certificate(&limiter, &issuer, &[sub.to_owned()])
+                .await
+                .unwrap();
+        }
+        assert_eq!(limiter.issued_count("example.com"), 2);
+        let err = issue_certificate(&limiter, &issuer, &["c.example.com".to_owned()])
+            .await
+            .unwrap_err();
+        assert!(matches!(err, IssuanceError::RateLimited { max: 2, .. }));
+    }
+
+    #[tokio::test]
+    async fn failure_does_not_count_and_releases() {
+        let limiter = IssuanceLimiter::new(2);
+        let issuer = MockIssuer::failing();
+        let err = issue_certificate(&limiter, &issuer, &["api.example.com".to_owned()])
+            .await
+            .unwrap_err();
+        assert!(matches!(err, IssuanceError::Issuer(_)));
+        // Not counted, and the in-flight slot was released (can retry).
+        assert_eq!(limiter.issued_count("example.com"), 0);
+        let ok_issuer = MockIssuer::ok();
+        assert!(
+            issue_certificate(&limiter, &ok_issuer, &["api.example.com".to_owned()])
+                .await
+                .is_ok()
+        );
+    }
+}

--- a/crates/ag-domains/src/lib.rs
+++ b/crates/ag-domains/src/lib.rs
@@ -54,6 +54,7 @@ pub mod diagnostics;
 pub mod events;
 pub mod hostname;
 pub mod instructions;
+pub mod issuance;
 pub mod ownership;
 pub mod store;
 

--- a/crates/ag-edge/Cargo.toml
+++ b/crates/ag-edge/Cargo.toml
@@ -55,3 +55,4 @@ rcgen = { workspace = true }
 rustls = { workspace = true }
 rustls-pki-types = { workspace = true }
 tokio-rustls = { workspace = true }
+async-trait = { workspace = true }

--- a/crates/ag-edge/tests/issuance_to_edge.rs
+++ b/crates/ag-edge/tests/issuance_to_edge.rs
@@ -1,0 +1,54 @@
+//! End-to-end glue: control-plane issuance -> edge certificate store -> SNI.
+//!
+//! Proves that a certificate produced through the `ag-domains` issuance
+//! orchestration (deduplicated + rate-limited) can be loaded into the edge
+//! `CertStore` via its PEM bridge and then selected by SNI. The issuer here is
+//! a mock that mints a real self-signed certificate with `rcgen`, standing in
+//! for the production ACME issuer.
+#![cfg(feature = "tls")]
+
+use std::sync::Arc;
+
+use ag_domains::issuance::{
+    issue_certificate, CertIssuer, IssuanceError, IssuanceLimiter, IssuedCertificate,
+};
+use ag_edge::cert::{server_config, CertStore};
+use async_trait::async_trait;
+
+struct RcgenIssuer;
+
+#[async_trait]
+impl CertIssuer for RcgenIssuer {
+    async fn issue(&self, sans: &[String]) -> Result<IssuedCertificate, IssuanceError> {
+        let ck = rcgen::generate_simple_self_signed(sans.to_vec())
+            .map_err(|e| IssuanceError::Issuer(e.to_string()))?;
+        Ok(IssuedCertificate {
+            cert_chain_pem: ck.cert.pem(),
+            private_key_pem: ck.key_pair.serialize_pem(),
+        })
+    }
+}
+
+#[tokio::test]
+async fn issued_certificate_serves_over_sni() {
+    let limiter = IssuanceLimiter::new(50);
+    let issuer = RcgenIssuer;
+    let host = "api.example.com".to_owned();
+
+    // Issue through the control-plane orchestration (dedup + rate limit).
+    let cert = issue_certificate(&limiter, &issuer, std::slice::from_ref(&host))
+        .await
+        .expect("issuance succeeds");
+    assert_eq!(limiter.issued_count("example.com"), 1);
+
+    // Load the issued PEM into the edge certificate store and select by SNI.
+    let mut store = CertStore::new();
+    store
+        .insert_pem(&host, &cert.cert_chain_pem, &cert.private_key_pem)
+        .expect("PEM loads into the edge cert store");
+    assert!(store.resolve(&host).is_some());
+    assert!(store.resolve("other.example.com").is_none());
+
+    // The store builds a usable rustls server config (handshake-ready).
+    assert!(server_config(Arc::new(store)).is_ok());
+}

--- a/docs/ag-domains/BACKLOG.md
+++ b/docs/ag-domains/BACKLOG.md
@@ -29,7 +29,7 @@ Governing docs: `docs/rfc/RFC-0011-ag-domains-control-plane.md`,
 | 11 | Unknown domains cannot route to another tenant | DONE | Fail-closed; tested. |
 | 12 | Detached domains enter tombstone/quarantine | DONE | `store.rs` tombstones. |
 | 13 | CAA check before issuance | DONE | `caa.rs`. |
-| 14 | Certificate renewal queue | PARTIAL | `spawn_renewal_task` exists; issuance queue + SAN dedup + ARI scheduling pending. |
+| 14 | Certificate renewal queue | PARTIAL | `spawn_renewal_task` + `issuance` dedup-by-SAN and per-domain rate limits DONE; ARI-aware scheduling pending. |
 | 15 | CLI docs updated | DONE | `docs/ag-domains/reference/cli.md`. |
 | 16 | OpenAPI docs updated | DONE | `openapi/ag-domains.v1.yaml` (implemented contract). |
 | 17 | Provider docs for first providers | PARTIAL | Cloudflare adapter exists; per-provider how-to guides pending. |
@@ -41,7 +41,7 @@ Governing docs: `docs/rfc/RFC-0011-ag-domains-control-plane.md`,
 |-------|-------|--------|-----------|
 | 0 | Audit + scaffolding | DONE | — |
 | 1 | Manual attachment (CLI/API, TXT, instructions, diagnostics, shadow) | DONE | — |
-| 2 | Managed TLS for exact hostnames | PARTIAL | issuance queue, dedup, ARI-aware renewal, `#[ignore]` staging E2E. |
+| 2 | Managed TLS for exact hostnames | PARTIAL | issuance dedup-by-SAN + per-registered-domain rate limits + issuer seam DONE (`issuance` module; ACME path is the injected issuer); remaining: ARI-aware renewal scheduling and a live `#[ignore]` staging E2E. |
 | 3 | Active routing + canonical policies | DONE | http->https upgrade at listener (only canonical redirects today). |
 | D | SQL-backed store (`sql-store`, Postgres) | DONE | `SqlAttachmentStore` (JSONB + indexed columns) + migration; `#[ignore]` integration tests requiring `DATABASE_URL`. Native store stays default. |
 | 4 | Provider automation | PARTIAL | Domain Connect; Route 53 / Google / Azure / Namecheap adapters; richer adapter SDK (discover/read/diff/apply/rollback/verify). BIND export DONE; Cloudflare DONE. |

--- a/docs/pr-drafts/feat-ag-domains-cert-issuance.md
+++ b/docs/pr-drafts/feat-ag-domains-cert-issuance.md
@@ -1,0 +1,68 @@
+# ag-domains certificate issuance: dedup + per-domain rate limits (RFC-0011 phase 2)
+
+## Summary
+
+Adds the certificate-issuance rate-limit protections from the blueprint section
+13.4 as native, tested logic in `ag-domains`, plus an end-to-end test proving
+the issuance output serves through the `ag-edge` certificate store by SNI.
+Additive: no existing behavior changes; the real ACME order is the injected
+issuer.
+
+Changes:
+
+- `crates/ag-domains/src/issuance.rs`: `CertIssuer` trait (seam for the ACME
+  issuer), `IssuedCertificate`, `san_key` (canonical SAN-set dedup key),
+  `IssuanceLimiter` (in-flight dedup + per-registered-domain issuance counters),
+  and `issue_certificate` (reserve -> issue -> count successes -> release).
+- `crates/ag-domains/src/lib.rs`: export `issuance`.
+- `crates/ag-edge/tests/issuance_to_edge.rs`: E2E — issue via the orchestration
+  (rcgen issuer), load the PEM into `ag_edge::cert::CertStore`, select by SNI,
+  build a rustls server config.
+- `crates/ag-edge/Cargo.toml`: `async-trait` dev-dependency for the test issuer.
+- Docs: CHANGELOG, `docs/ag-domains/BACKLOG.md` (phase 2 / checklist 14).
+
+## Phase affected
+
+Phase 5 (extends Phase 4.5 `ag-domains`). RFC-0011 phase 2 hardening.
+
+## Type of change
+
+- Feature implementation (additive; native logic; no new runtime deps)
+- Test
+
+## Related documents
+
+- `docs/rfc/RFC-0011-ag-domains-control-plane.md`
+- `docs/ag-domains/BACKLOG.md` (phase 2; blueprint section 13.4)
+- `docs/DEBT.md` — DEBT-024 (eTLD+1 heuristic shared by the per-domain counter)
+
+## Test plan
+
+- [x] `cargo test -p ag-domains issuance` — 7 unit tests pass
+- [x] `cargo test -p ag-edge --features tls` — incl. `issuance_to_edge` E2E pass
+- [x] `cargo clippy -p ag-domains --all-features --all-targets -- -D warnings` — clean
+- [x] `cargo clippy -p ag-edge --all-features --all-targets -- -D warnings` — clean
+- [x] `cargo fmt` — clean
+
+## Exit criteria advanced
+
+- Blueprint section 13.4: SAN-set deduplication and per-registered-domain rate
+  limits implemented and tested. Remaining: ARI-aware renewal scheduling and a
+  live `#[ignore]` staging E2E (tracked in BACKLOG / DEBT-025).
+
+## Final checklist
+
+- [x] Belongs to correct phase
+- [x] Respects documentation (RFC-0011)
+- [x] Does not break architecture (additive; ACME issuer injected)
+- [x] No unnecessary complexity added
+- [x] No circular dependencies
+- [x] Compiles
+- [x] Tests pass
+- [x] `cargo fmt` passes
+- [x] `cargo clippy` passes
+- [x] Documentation updated in same PR
+- [x] No emojis
+- [x] No AI attribution
+- [x] Commit messages under 256 characters
+- [x] PR descriptor present


### PR DESCRIPTION
# ag-domains certificate issuance: dedup + per-domain rate limits (RFC-0011 phase 2)

## Summary

Adds the certificate-issuance rate-limit protections from the blueprint section
13.4 as native, tested logic in `ag-domains`, plus an end-to-end test proving
the issuance output serves through the `ag-edge` certificate store by SNI.
Additive: no existing behavior changes; the real ACME order is the injected
issuer.

Changes:

- `crates/ag-domains/src/issuance.rs`: `CertIssuer` trait (seam for the ACME
  issuer), `IssuedCertificate`, `san_key` (canonical SAN-set dedup key),
  `IssuanceLimiter` (in-flight dedup + per-registered-domain issuance counters),
  and `issue_certificate` (reserve -> issue -> count successes -> release).
- `crates/ag-domains/src/lib.rs`: export `issuance`.
- `crates/ag-edge/tests/issuance_to_edge.rs`: E2E — issue via the orchestration
  (rcgen issuer), load the PEM into `ag_edge::cert::CertStore`, select by SNI,
  build a rustls server config.
- `crates/ag-edge/Cargo.toml`: `async-trait` dev-dependency for the test issuer.
- Docs: CHANGELOG, `docs/ag-domains/BACKLOG.md` (phase 2 / checklist 14).

## Phase affected

Phase 5 (extends Phase 4.5 `ag-domains`). RFC-0011 phase 2 hardening.

## Type of change

- Feature implementation (additive; native logic; no new runtime deps)
- Test

## Related documents

- `docs/rfc/RFC-0011-ag-domains-control-plane.md`
- `docs/ag-domains/BACKLOG.md` (phase 2; blueprint section 13.4)
- `docs/DEBT.md` — DEBT-024 (eTLD+1 heuristic shared by the per-domain counter)

## Test plan

- [x] `cargo test -p ag-domains issuance` — 7 unit tests pass
- [x] `cargo test -p ag-edge --features tls` — incl. `issuance_to_edge` E2E pass
- [x] `cargo clippy -p ag-domains --all-features --all-targets -- -D warnings` — clean
- [x] `cargo clippy -p ag-edge --all-features --all-targets -- -D warnings` — clean
- [x] `cargo fmt` — clean

## Exit criteria advanced

- Blueprint section 13.4: SAN-set deduplication and per-registered-domain rate
  limits implemented and tested. Remaining: ARI-aware renewal scheduling and a
  live `#[ignore]` staging E2E (tracked in BACKLOG / DEBT-025).

## Final checklist

- [x] Belongs to correct phase
- [x] Respects documentation (RFC-0011)
- [x] Does not break architecture (additive; ACME issuer injected)
- [x] No unnecessary complexity added
- [x] No circular dependencies
- [x] Compiles
- [x] Tests pass
- [x] `cargo fmt` passes
- [x] `cargo clippy` passes
- [x] Documentation updated in same PR
- [x] No emojis
- [x] No AI attribution
- [x] Commit messages under 256 characters
- [x] PR descriptor present
