### PR TITLE
Issues/solver

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -301,6 +301,8 @@ dependencies = [
  "base64ct",
  "blake3",
  "bytes",
+ "cap-fs-ext",
+ "cap-std",
  "futures-util",
  "getrandom 0.2.17",
  "governor",
@@ -371,6 +373,12 @@ name = "allocator-api2"
 version = "0.2.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "683d7910e743518b0e34f1186f92494becacb047c7b6bf616c96772180fef923"
+
+[[package]]
+name = "ambient-authority"
+version = "0.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e9d4ee0d472d1cd2e28c97dfa124b3d8d992e10eb0a035f33f5d12e3a177ba3b"
 
 [[package]]
 name = "android_system_properties"
@@ -949,6 +957,48 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1e748733b7cbc798e1434b6ac524f0c1ff2ab456fe201501e6497c8417a4fc33"
 dependencies = [
  "serde",
+]
+
+[[package]]
+name = "cap-fs-ext"
+version = "4.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d78e5a3368ae89b7cb68186411452b4b9fac8b41be9c19bf3f47c2d2c8e36e6b"
+dependencies = [
+ "cap-primitives",
+ "cap-std",
+ "io-lifetimes 3.0.1",
+ "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "cap-primitives"
+version = "4.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cdadbd7c002d3a484b35243669abdae85a0ebaded5a61117169dc3400f9a7ff0"
+dependencies = [
+ "ambient-authority",
+ "fs-set-times",
+ "io-extras",
+ "io-lifetimes 3.0.1",
+ "ipnet",
+ "maybe-owned",
+ "rustix",
+ "rustix-linux-procfs",
+ "windows-sys 0.61.2",
+ "winx",
+]
+
+[[package]]
+name = "cap-std"
+version = "4.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7281235d6e96d3544ca18bba9049be92f4190f8d923e3caef1b5f66cfa752608"
+dependencies = [
+ "cap-primitives",
+ "io-extras",
+ "io-lifetimes 3.0.1",
+ "rustix",
 ]
 
 [[package]]
@@ -1815,6 +1865,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "fs-set-times"
+version = "0.20.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "94e7099f6313ecacbe1256e8ff9d617b75d1bcb16a6fddef94866d225a01a14a"
+dependencies = [
+ "io-lifetimes 2.0.4",
+ "rustix",
+ "windows-sys 0.59.0",
+]
+
+[[package]]
 name = "futures"
 version = "0.3.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2623,6 +2684,28 @@ dependencies = [
 ]
 
 [[package]]
+name = "io-extras"
+version = "0.19.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "20fd6de4ccfcc187e38bc21cfa543cb5a302cb86a8b114eb7f0bf0dc9f8ac00f"
+dependencies = [
+ "io-lifetimes 3.0.1",
+ "windows-sys 0.60.2",
+]
+
+[[package]]
+name = "io-lifetimes"
+version = "2.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "06432fb54d3be7964ecd3649233cddf80db2832f47fec34c01f65b3d9d774983"
+
+[[package]]
+name = "io-lifetimes"
+version = "3.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2f0fb0570afe1fed943c5c3d4102d5358592d8625fda6a0007fdbe65a92fba96"
+
+[[package]]
 name = "ipconfig"
 version = "0.3.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3022,6 +3105,12 @@ name = "matchit"
 version = "0.8.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "47e1ffaa40ddd1f3ed91f717a33c8c0ee23fff369e3aa8772b9605cc1d22f4c3"
+
+[[package]]
+name = "maybe-owned"
+version = "0.3.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4facc753ae494aeb6e3c22f839b158aebd4f9270f55cd3c79906c45476c47ab4"
 
 [[package]]
 name = "md-5"
@@ -4308,6 +4397,16 @@ dependencies = [
  "libc",
  "linux-raw-sys",
  "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "rustix-linux-procfs"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2fc84bf7e9aa16c4f2c758f27412dc9841341e16aa682d9c7ac308fe3ee12056"
+dependencies = [
+ "once_cell",
+ "rustix",
 ]
 
 [[package]]
@@ -6522,6 +6621,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "df79d97927682d2fd8adb29682d1140b343be4ac0f08fd68b7765d9c059d3945"
 dependencies = [
  "memchr",
+]
+
+[[package]]
+name = "winx"
+version = "0.36.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3f3fd376f71958b862e7afb20cfe5a22830e1963462f3a17f49d82a6c1d1f42d"
+dependencies = [
+ "bitflags 2.11.1",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -92,6 +92,8 @@ console-subscriber       = "0.4"
 async-trait              = "0.1"
 blake3                   = "1"
 base64ct                 = { version = "1", features = ["alloc"] }
+cap-fs-ext               = "4.0.2"
+cap-std                  = "4.0.2"
 getrandom                = "0.2"
 passkey-types            = "0.5"
 oauth2                   = { version = "5", default-features = false }

--- a/crates/ag-storage/Cargo.toml
+++ b/crates/ag-storage/Cargo.toml
@@ -27,6 +27,8 @@ ag-auth       = { path = "../ag-auth", version = "0.0.0", optional = true }
 axum          = { workspace = true }
 blake3        = { workspace = true }
 bytes         = { workspace = true }
+cap-fs-ext    = { workspace = true }
+cap-std       = { workspace = true }
 getrandom     = { workspace = true }
 governor      = { workspace = true }
 http          = { workspace = true }

--- a/crates/ag-storage/README.md
+++ b/crates/ag-storage/README.md
@@ -118,6 +118,8 @@ their final rename remain inside that same capability.
 - Rate limiting: 100 req/s por defecto, configurable.
 - Content-Type: lista positiva, extensiones desconocidas forzadas a `attachment`.
 
+Uploaded HTML, HTM, and SVG retain their media type but are always returned with `Content-Disposition: attachment` to prevent active content from executing on the storage origin.
+
 ## Referencias
 
 - Spec de diseno: `docs/superpowers/specs/2026-05-22-ag-storage-design.md`

--- a/crates/ag-storage/README.md
+++ b/crates/ag-storage/README.md
@@ -25,7 +25,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
 ## Modo servidor HTTP
 
 ```bash
-STORAGE_SERVER=true STORAGE_PORT=4280 cargo run
+STORAGE_SERVER=true STORAGE_BIND=127.0.0.1 STORAGE_PORT=4280 cargo run
 ```
 
 ```
@@ -82,8 +82,10 @@ Variable de entorno: `STORAGE_SIGN_SECRET` (string arbitrario).
 | `STORAGE_BACKEND` | `native` | `native`, `s3` (feature) |
 | `STORAGE_ROOT` | `./ag-store-data` | Directorio raiz (native) |
 | `STORAGE_SERVER` | `false` | Levantar servidor HTTP |
+| `STORAGE_BIND` | `127.0.0.1` | Direccion de escucha; loopback por defecto |
 | `STORAGE_PORT` | `4280` | Puerto del servidor |
-| `STORE_TOKEN` | `""` | Bearer token (vacio = sin auth) |
+| `STORE_TOKEN` | `""` | Bearer token; vacio solo se permite en loopback |
+| `STORAGE_ALLOW_INSECURE_PUBLIC` | `false` | Permite explicitamente bind publico sin token |
 | `STORAGE_MAX_OBJECT_SIZE_MB` | `100` | Tamano maximo de objeto |
 | `STORAGE_RATE_LIMIT_RPS` | `100` | Requests/segundo del servidor |
 | `STORAGE_SIGN_SECRET` | `""` | Secreto para URLs firmadas |
@@ -99,6 +101,11 @@ Variable de entorno: `STORAGE_SIGN_SECRET` (string arbitrario).
 - `s3` -- Adaptadores AWS S3 y MinIO via `object_store 0.11`.
 
 ## Seguridad
+
+A non-loopback `STORAGE_BIND` requires `STORE_TOKEN`. Starting with a
+public bind and an empty token returns a configuration error before the server
+task starts. `STORAGE_ALLOW_INSECURE_PUBLIC=true` is an explicit unsafe escape
+hatch for controlled environments.
 
 Native filesystem operations are relative to an opened directory capability.
 Parent symlinks cannot escape the configured root, and temporary writes plus

--- a/crates/ag-storage/README.md
+++ b/crates/ag-storage/README.md
@@ -100,6 +100,10 @@ Variable de entorno: `STORAGE_SIGN_SECRET` (string arbitrario).
 
 ## Seguridad
 
+Native filesystem operations are relative to an opened directory capability.
+Parent symlinks cannot escape the configured root, and temporary writes plus
+their final rename remain inside that same capability.
+
 - Validacion de clave: rechaza path traversal (`..`), bytes nulos, caracteres de control.
 - Confinamiento de path: canonicalizacion + verificacion `starts_with(root)` impide escape del directorio raiz.
 - Proteccion contra symlinks: `canonicalize()` resuelve symlinks antes del check.

--- a/crates/ag-storage/src/config.rs
+++ b/crates/ag-storage/src/config.rs
@@ -1,6 +1,7 @@
 //! Storage store configuration.
 
-use std::path::PathBuf;
+use crate::StorageError;
+use std::{net::IpAddr, path::PathBuf};
 
 /// Active storage backend.
 #[derive(Debug, Clone, PartialEq)]
@@ -24,9 +25,13 @@ pub struct StorageConfig {
     pub root_path: PathBuf,
     /// If `true`, starts an Axum HTTP server in the background.
     pub server_mode: bool,
+    /// HTTP server bind address. Default: loopback only.
+    pub server_bind: IpAddr,
     /// HTTP server port. Default: 4280.
     pub server_port: u16,
-    /// Static Bearer token. Empty = no authentication (dev mode).
+    /// Allows an unauthenticated non-loopback bind when explicitly enabled.
+    pub allow_insecure_public: bool,
+    /// Static Bearer token. Empty = no authentication (loopback development only).
     pub store_token: String,
     /// Maximum object size in MB. Default: 100.
     pub max_object_size_mb: u64,
@@ -53,7 +58,9 @@ impl Default for StorageConfig {
             backend: StorageBackend::Native,
             root_path: PathBuf::from("./ag-store-data"),
             server_mode: false,
+            server_bind: IpAddr::from([127, 0, 0, 1]),
             server_port: 4280,
+            allow_insecure_public: false,
             store_token: String::new(),
             max_object_size_mb: 100,
             rate_limit_rps: 100,
@@ -113,10 +120,17 @@ impl StorageConfig {
             server_mode: std::env::var("STORAGE_SERVER")
                 .map(|v| v.eq_ignore_ascii_case("true"))
                 .unwrap_or(false),
+            server_bind: std::env::var("STORAGE_BIND")
+                .ok()
+                .and_then(|value| value.parse().ok())
+                .unwrap_or_else(|| IpAddr::from([127, 0, 0, 1])),
             server_port: std::env::var("STORAGE_PORT")
                 .ok()
                 .and_then(|v| v.parse().ok())
                 .unwrap_or(4280),
+            allow_insecure_public: std::env::var("STORAGE_ALLOW_INSECURE_PUBLIC")
+                .map(|value| value.eq_ignore_ascii_case("true"))
+                .unwrap_or(false),
             store_token: std::env::var("STORE_TOKEN").unwrap_or_default(),
             max_object_size_mb: std::env::var("STORAGE_MAX_OBJECT_SIZE_MB")
                 .ok()
@@ -133,6 +147,20 @@ impl StorageConfig {
             bucket: std::env::var("STORAGE_BUCKET").unwrap_or_else(|_| "ag-storage".into()),
             sign_secret: std::env::var("STORAGE_SIGN_SECRET").unwrap_or_default(),
         }
+    }
+
+    /// Validates that server exposure is authenticated or deliberately local.
+    pub fn validate_server_security(&self) -> Result<(), StorageError> {
+        if self.server_mode
+            && !self.server_bind.is_loopback()
+            && self.store_token.is_empty()
+            && !self.allow_insecure_public
+        {
+            return Err(StorageError::Config(
+                "unauthenticated public storage bind rejected; set STORE_TOKEN, use a loopback STORAGE_BIND, or explicitly set STORAGE_ALLOW_INSECURE_PUBLIC=true".into(),
+            ));
+        }
+        Ok(())
     }
 }
 
@@ -176,6 +204,54 @@ mod tests {
             None => std::env::remove_var("STORAGE_SERVER"),
         }
         assert!(cfg.server_mode);
+    }
+
+    #[test]
+    fn public_bind_without_token_is_rejected() {
+        let config = StorageConfig {
+            server_mode: true,
+            server_bind: IpAddr::from([0, 0, 0, 0]),
+            ..StorageConfig::default()
+        };
+
+        assert!(matches!(
+            config.validate_server_security(),
+            Err(StorageError::Config(_))
+        ));
+    }
+
+    #[test]
+    fn loopback_bind_without_token_is_allowed() {
+        let config = StorageConfig {
+            server_mode: true,
+            ..StorageConfig::default()
+        };
+
+        assert!(config.validate_server_security().is_ok());
+    }
+
+    #[test]
+    fn explicit_insecure_public_bind_is_allowed() {
+        let config = StorageConfig {
+            server_mode: true,
+            server_bind: IpAddr::from([0, 0, 0, 0]),
+            allow_insecure_public: true,
+            ..StorageConfig::default()
+        };
+
+        assert!(config.validate_server_security().is_ok());
+    }
+
+    #[test]
+    fn public_bind_with_token_is_allowed() {
+        let config = StorageConfig {
+            server_mode: true,
+            server_bind: IpAddr::from([0, 0, 0, 0]),
+            store_token: "secret".into(),
+            ..StorageConfig::default()
+        };
+
+        assert!(config.validate_server_security().is_ok());
     }
 
     #[test]

--- a/crates/ag-storage/src/lib.rs
+++ b/crates/ag-storage/src/lib.rs
@@ -75,6 +75,7 @@ impl AgStorage {
     /// Creates a new instance. If `config.server_mode` is `true`, starts
     /// the HTTP server in the background via `tokio::spawn`.
     pub async fn new(config: StorageConfig) -> Result<Self, StorageError> {
+        config.validate_server_security()?;
         let store = std::sync::Arc::new(AgStore::new(&config)?);
         if config.server_mode {
             let srv_store = std::sync::Arc::clone(&store);
@@ -124,8 +125,8 @@ impl AgStorage {
     pub fn object_url(&self, key: &str) -> Result<String, StorageError> {
         if self.config.server_mode {
             Ok(format!(
-                "http://localhost:{}/v1/objects/{}",
-                self.config.server_port, key
+                "http://{}:{}/v1/objects/{}",
+                self.config.server_bind, self.config.server_port, key
             ))
         } else {
             let path = self.config.root_path.join(key);

--- a/crates/ag-storage/src/store/mod.rs
+++ b/crates/ag-storage/src/store/mod.rs
@@ -10,7 +10,12 @@ pub mod server;
 
 use crate::{StorageBackend, StorageConfig, StorageError};
 use bytes::Bytes;
+use cap_fs_ext::{FollowSymlinks, OpenOptionsFollowExt};
+use cap_std::ambient_authority;
+use cap_std::fs::{Dir, OpenOptions};
+use std::io::Write;
 use std::path::{Component, Path, PathBuf};
+use std::sync::Arc;
 
 // ---------------------------------------------------------------------------
 // NativeStore: implementation over local filesystem
@@ -22,6 +27,7 @@ use std::path::{Component, Path, PathBuf};
 /// Every operation passes through [`validate_key`] and [`resolve_path`] before I/O.
 pub struct NativeStore {
     pub(crate) root: PathBuf,
+    dir: Arc<Dir>,
     max_object_size: usize,
 }
 
@@ -41,57 +47,103 @@ impl NativeStore {
                 limit: self.max_object_size,
             });
         }
-        let dest = resolve_path(&self.root, key)?;
-        if let Some(parent) = dest.parent() {
-            tokio::fs::create_dir_all(parent).await?;
-        }
-        // atomic write-then-rename: avoids reads of partially written files
+        validate_key(key)?;
+        let dir = Arc::clone(&self.dir);
+        let key = PathBuf::from(key);
         let mut nonce = [0u8; 8];
         getrandom::getrandom(&mut nonce).unwrap_or_default();
-        let tmp = dest.with_file_name(format!(".tmp.{:016x}", u64::from_le_bytes(nonce)));
-        tokio::fs::write(&tmp, &data).await?;
-        tokio::fs::rename(&tmp, &dest).await?;
-        Ok(())
+
+        blocking_io(move || {
+            let (parent, name) = open_parent_dir(&dir, &key, true)?;
+            let tmp = format!(".tmp.{:016x}", u64::from_le_bytes(nonce));
+            let mut options = OpenOptions::new();
+            options
+                .write(true)
+                .create_new(true)
+                .follow(FollowSymlinks::No);
+            let result = (|| {
+                let mut file = parent.open_with(&tmp, &options)?;
+                file.write_all(&data)?;
+                file.sync_all()?;
+                parent.rename(&tmp, &parent, &name)
+            })();
+            if result.is_err() {
+                let _ = parent.remove_file(&tmp);
+            }
+            result
+        })
+        .await
     }
 
     /// Retrieves the content of the object with key `key`.
     pub async fn get(&self, key: &str) -> Result<Bytes, StorageError> {
-        let path = resolve_path(&self.root, key)?;
-        match tokio::fs::read(&path).await {
+        validate_key(key)?;
+        let dir = Arc::clone(&self.dir);
+        let key_owned = key.to_owned();
+        match blocking_io(move || {
+            let (parent, name) = open_parent_dir(&dir, Path::new(&key_owned), false)?;
+            let mut options = OpenOptions::new();
+            options.read(true).follow(FollowSymlinks::No);
+            let mut file = parent.open_with(name, &options)?;
+            let mut data = Vec::new();
+            std::io::Read::read_to_end(&mut file, &mut data)?;
+            Ok(data)
+        })
+        .await
+        {
             Ok(data) => Ok(Bytes::from(data)),
-            Err(e) if e.kind() == std::io::ErrorKind::NotFound => {
+            Err(StorageError::Io(error)) if error.kind() == std::io::ErrorKind::NotFound => {
                 Err(StorageError::NotFound(key.to_owned()))
             }
-            Err(e) => Err(StorageError::Io(e)),
+            Err(error) => Err(error),
         }
     }
 
     /// Deletes the object with key `key`.
     pub async fn delete(&self, key: &str) -> Result<(), StorageError> {
-        let path = resolve_path(&self.root, key)?;
-        match tokio::fs::remove_file(&path).await {
+        validate_key(key)?;
+        let dir = Arc::clone(&self.dir);
+        let key_owned = key.to_owned();
+        match blocking_io(move || {
+            let (parent, name) = open_parent_dir(&dir, Path::new(&key_owned), false)?;
+            parent.remove_file(name)
+        })
+        .await
+        {
             Ok(()) => Ok(()),
-            Err(e) if e.kind() == std::io::ErrorKind::NotFound => {
+            Err(StorageError::Io(error)) if error.kind() == std::io::ErrorKind::NotFound => {
                 Err(StorageError::NotFound(key.to_owned()))
             }
-            Err(e) => Err(StorageError::Io(e)),
+            Err(error) => Err(error),
         }
     }
 
     /// Returns `true` if an object with key `key` exists.
     pub async fn exists(&self, key: &str) -> Result<bool, StorageError> {
-        let path = resolve_path(&self.root, key)?;
-        Ok(tokio::fs::try_exists(&path).await.unwrap_or(false))
+        validate_key(key)?;
+        let dir = Arc::clone(&self.dir);
+        let key = key.to_owned();
+        blocking_io(move || {
+            let (parent, name) = match open_parent_dir(&dir, Path::new(&key), false) {
+                Ok(value) => value,
+                Err(error) if error.kind() == std::io::ErrorKind::NotFound => return Ok(false),
+                Err(error) => return Err(error),
+            };
+            match parent.symlink_metadata(name) {
+                Ok(metadata) => Ok(metadata.is_file()),
+                Err(error) if error.kind() == std::io::ErrorKind::NotFound => Ok(false),
+                Err(error) => Err(error),
+            }
+        })
+        .await
     }
 
     /// Lists object keys under `prefix`.
     pub async fn list(&self, prefix: Option<&str>) -> Result<Vec<String>, StorageError> {
-        let root = self.root.clone();
+        let dir = Arc::clone(&self.dir);
         let prefix_str = prefix.map(|p| p.trim_end_matches('/').to_owned());
 
-        let keys = tokio::task::spawn_blocking(move || collect_keys(&root, &root))
-            .await
-            .map_err(|e| StorageError::Io(std::io::Error::other(e.to_string())))??;
+        let keys = blocking_io(move || collect_keys(&dir, Path::new(""))).await?;
 
         Ok(match prefix_str {
             Some(p) => keys
@@ -129,8 +181,11 @@ impl AgStore {
             StorageBackend::Native => {
                 std::fs::create_dir_all(&config.root_path).map_err(StorageError::Io)?;
                 let root = config.root_path.canonicalize().map_err(StorageError::Io)?;
+                let dir =
+                    Dir::open_ambient_dir(&root, ambient_authority()).map_err(StorageError::Io)?;
                 Ok(AgStore::Native(NativeStore {
                     root,
+                    dir: Arc::new(dir),
                     max_object_size: config.max_object_size_mb as usize * 1024 * 1024,
                 }))
             }
@@ -265,30 +320,72 @@ fn normalize_path(path: &Path) -> PathBuf {
     out
 }
 
-/// Recursively walks `dir` and returns paths relative to `root`.
-/// Ignores temporary files with the `.tmp.` prefix.
-fn collect_keys(
-    dir: &std::path::Path,
-    root: &std::path::Path,
-) -> Result<Vec<String>, StorageError> {
-    let mut keys = Vec::new();
-    if !dir.exists() {
-        return Ok(keys);
+fn open_parent_dir(
+    root: &Dir,
+    key: &Path,
+    create: bool,
+) -> std::io::Result<(Dir, std::ffi::OsString)> {
+    let name = key
+        .file_name()
+        .ok_or_else(|| std::io::Error::new(std::io::ErrorKind::InvalidInput, "missing file name"))?
+        .to_owned();
+    let mut current = root.try_clone()?;
+    if let Some(parent) = key.parent() {
+        for component in parent.components() {
+            let Component::Normal(segment) = component else {
+                return Err(std::io::Error::new(
+                    std::io::ErrorKind::InvalidInput,
+                    "invalid path component",
+                ));
+            };
+            match current.symlink_metadata(segment) {
+                Ok(metadata) if metadata.file_type().is_symlink() => {
+                    return Err(std::io::Error::new(
+                        std::io::ErrorKind::PermissionDenied,
+                        "symbolic link path component rejected",
+                    ));
+                }
+                Ok(_) => {}
+                Err(error) if create && error.kind() == std::io::ErrorKind::NotFound => {
+                    current.create_dir(segment)?;
+                }
+                Err(error) => return Err(error),
+            }
+            current = current.open_dir(segment)?;
+        }
     }
-    for entry in std::fs::read_dir(dir).map_err(StorageError::Io)? {
-        let entry = entry.map_err(StorageError::Io)?;
-        let path = entry.path();
-        if path.is_dir() {
-            let mut sub = collect_keys(&path, root)?;
+    Ok((current, name))
+}
+
+async fn blocking_io<T, F>(operation: F) -> Result<T, StorageError>
+where
+    T: Send + 'static,
+    F: FnOnce() -> std::io::Result<T> + Send + 'static,
+{
+    tokio::task::spawn_blocking(operation)
+        .await
+        .map_err(|error| StorageError::Io(std::io::Error::other(error.to_string())))?
+        .map_err(StorageError::Io)
+}
+
+/// Recursively walks a capability directory and returns relative object keys.
+/// Ignores temporary files with the `.tmp.` prefix and symbolic links.
+fn collect_keys(dir: &Dir, prefix: &Path) -> std::io::Result<Vec<String>> {
+    let mut keys = Vec::new();
+    for entry in dir.entries()? {
+        let entry = entry?;
+        let name = entry.file_name();
+        let path = prefix.join(&name);
+        let file_type = entry.file_type()?;
+        if file_type.is_dir() {
+            let child = entry.open_dir()?;
+            let mut sub = collect_keys(&child, &path)?;
             keys.append(&mut sub);
-        } else if path.is_file() {
-            let name = path.file_name().unwrap_or_default().to_string_lossy();
-            if name.starts_with(".tmp.") {
+        } else if file_type.is_file() {
+            if name.to_string_lossy().starts_with(".tmp.") {
                 continue;
             }
-            if let Ok(rel) = path.strip_prefix(root) {
-                keys.push(rel.to_string_lossy().replace('\\', "/"));
-            }
+            keys.push(path.to_string_lossy().replace('\\', "/"));
         }
     }
     Ok(keys)
@@ -302,17 +399,17 @@ pub fn resolve_path(root: &Path, key: &str) -> Result<PathBuf, StorageError> {
     validate_key(key)?;
     let canonical_root = root.canonicalize().map_err(StorageError::Io)?;
     let candidate = canonical_root.join(key);
-    let resolved = if candidate.exists() {
-        candidate.canonicalize().map_err(StorageError::Io)?
-    } else {
-        // Safe because validate_key (called above) already rejected all
-        // '.' and '..' segments. normalize_path is just additional defense.
-        normalize_path(&candidate)
-    };
-    if !resolved.starts_with(&canonical_root) {
+    let mut existing = candidate.as_path();
+    while !existing.exists() {
+        existing = existing
+            .parent()
+            .ok_or_else(|| StorageError::PathEscape(key.to_owned()))?;
+    }
+    let canonical_existing = existing.canonicalize().map_err(StorageError::Io)?;
+    if !canonical_existing.starts_with(&canonical_root) {
         return Err(StorageError::PathEscape(key.to_owned()));
     }
-    Ok(resolved)
+    Ok(normalize_path(&candidate))
 }
 
 // ---------------------------------------------------------------------------
@@ -386,6 +483,34 @@ mod tests {
             result,
             Err(StorageError::PathEscape(_)) | Err(StorageError::Io(_))
         ));
+    }
+
+    #[tokio::test]
+    #[cfg(unix)]
+    async fn put_cannot_follow_parent_symlink_outside_root() {
+        let root = tempdir();
+        let outside = tempdir();
+        std::os::unix::fs::symlink(outside.path(), root.path().join("escape")).unwrap();
+
+        let store = AgStore::new(&test_config(root.path())).unwrap();
+        let result = store.put("escape/new.txt", Bytes::from("secret")).await;
+
+        assert!(result.is_err());
+        assert!(!outside.path().join("new.txt").exists());
+    }
+
+    #[tokio::test]
+    #[cfg(unix)]
+    async fn get_cannot_follow_parent_symlink_outside_root() {
+        let root = tempdir();
+        let outside = tempdir();
+        std::fs::write(outside.path().join("secret.txt"), b"secret").unwrap();
+        std::os::unix::fs::symlink(outside.path(), root.path().join("escape")).unwrap();
+
+        let store = AgStore::new(&test_config(root.path())).unwrap();
+        let result = store.get("escape/secret.txt").await;
+
+        assert!(result.is_err());
     }
 
     // --- Functional tests ---

--- a/crates/ag-storage/src/store/server.rs
+++ b/crates/ag-storage/src/store/server.rs
@@ -38,11 +38,12 @@ use tower::ServiceBuilder;
 
 /// Starts the HTTP server and blocks until the process ends.
 pub async fn run_server(store: Arc<AgStore>, config: &StorageConfig) -> Result<(), StorageError> {
-    let addr = format!("0.0.0.0:{}", config.server_port);
-    let listener = tokio::net::TcpListener::bind(&addr)
+    config.validate_server_security()?;
+    let addr = std::net::SocketAddr::new(config.server_bind, config.server_port);
+    let listener = tokio::net::TcpListener::bind(addr)
         .await
         .map_err(StorageError::Io)?;
-    tracing::info!(port = config.server_port, "ag-storage server escuchando");
+    tracing::info!(%addr, authenticated = !config.store_token.is_empty(), "ag-storage server listening");
     let app = build_router(store, config);
     axum::serve(listener, app)
         .await

--- a/crates/ag-storage/src/store/server.rs
+++ b/crates/ag-storage/src/store/server.rs
@@ -125,15 +125,12 @@ fn content_type_for(key: &str) -> (&'static str, bool) {
         "png" => ("image/png", false),
         "gif" => ("image/gif", false),
         "webp" => ("image/webp", false),
-        // TECH-DEBT:
-        // reason: SVG can contain JavaScript and trigger XSS in browsers.
-        // impact: SVG objects are served inline; use a sanitizer or force
-        //          attachment to mitigate XSS in browser clients.
-        // expected removal: second ag-storage iteration with a CSP policy.
-        "svg" => ("image/svg+xml", false),
+        // User-controlled active content keeps its MIME type but must not render
+        // inline on the storage origin.
+        "svg" => ("image/svg+xml", true),
         "ico" => ("image/x-icon", false),
         "txt" => ("text/plain; charset=utf-8", false),
-        "html" | "htm" => ("text/html; charset=utf-8", false),
+        "html" | "htm" => ("text/html; charset=utf-8", true),
         "css" => ("text/css; charset=utf-8", false),
         "json" => ("application/json", false),
         "pdf" => ("application/pdf", false),
@@ -478,6 +475,56 @@ mod tests {
             .unwrap();
         let resp = app.oneshot(get_req).await.unwrap();
         assert_eq!(resp.status(), StatusCode::OK);
+    }
+
+    #[tokio::test]
+    async fn active_content_is_served_as_attachment() {
+        for (key, body, content_type) in [
+            (
+                "page.html",
+                "<script>alert(1)</script>",
+                "text/html; charset=utf-8",
+            ),
+            (
+                "image.svg",
+                r#"<svg onload="alert(1)"></svg>"#,
+                "image/svg+xml",
+            ),
+        ] {
+            let (_dir, store) = temp_store();
+            store.put(key, Bytes::from(body)).await.unwrap();
+            let app = build_router(store, &crate::StorageConfig::default());
+
+            let response = app
+                .oneshot(
+                    Request::builder()
+                        .uri(format!("/v1/objects/{key}"))
+                        .body(Body::empty())
+                        .unwrap(),
+                )
+                .await
+                .unwrap();
+
+            assert_eq!(response.status(), StatusCode::OK);
+            assert_eq!(response.headers()[header::CONTENT_TYPE], content_type);
+            assert!(response.headers()[header::CONTENT_DISPOSITION]
+                .to_str()
+                .unwrap()
+                .starts_with("attachment;"));
+        }
+    }
+
+    #[test]
+    fn active_content_types_require_attachment() {
+        assert_eq!(
+            content_type_for("page.html"),
+            ("text/html; charset=utf-8", true)
+        );
+        assert_eq!(
+            content_type_for("page.htm"),
+            ("text/html; charset=utf-8", true)
+        );
+        assert_eq!(content_type_for("image.svg"), ("image/svg+xml", true));
     }
 
     #[tokio::test]

--- a/docs/modules/ag-storage/README.md
+++ b/docs/modules/ag-storage/README.md
@@ -75,6 +75,8 @@ prevents parent symlinks and check/open races from escaping the configured root.
 - Confinamiento: `canonicalize()` + `starts_with(root)` tras resolucion de symlinks.
 - Escritura atomica: write-then-rename con nonce aleatorio.
 
+Uploaded HTML, HTM, and SVG retain their media type but are always returned with `Content-Disposition: attachment` to prevent active content from executing on the storage origin.
+
 ### Procesamiento de imagen (ImageProcessor)
 
 - `resize(width, height)`, `thumbnail(size)`, `to_webp(quality)`.

--- a/docs/modules/ag-storage/README.md
+++ b/docs/modules/ag-storage/README.md
@@ -55,7 +55,10 @@ POST   /v1/copy?from=&to=
 GET    /v1/health
 ```
 
-Bearer token configurable via `STORE_TOKEN`. Rate limiting 100 req/s.
+The server binds to `127.0.0.1` by default. A non-loopback `STORAGE_BIND`
+requires a non-empty `STORE_TOKEN`; otherwise construction fails before the
+background server starts. `STORAGE_ALLOW_INSECURE_PUBLIC=true` is the explicit
+unsafe override. Rate limiting defaults to 100 req/s.
 
 ### URLs firmadas
 

--- a/docs/modules/ag-storage/README.md
+++ b/docs/modules/ag-storage/README.md
@@ -65,6 +65,9 @@ constante via fold XOR. Variable de entorno: `STORAGE_SIGN_SECRET`.
 
 ### Seguridad de path
 
+Native filesystem operations use an opened root-directory capability. This
+prevents parent symlinks and check/open races from escaping the configured root.
+
 - Validacion: rechaza `..`, bytes nulos, caracteres de control.
 - Confinamiento: `canonicalize()` + `starts_with(root)` tras resolucion de symlinks.
 - Escritura atomica: write-then-rename con nonce aleatorio.

--- a/docs/pr-drafts/issues-solver.md
+++ b/docs/pr-drafts/issues-solver.md
@@ -1,0 +1,72 @@
+# fix(ag-storage): close critical storage security issues
+
+## Summary
+
+Resolves three security issues in the native storage backend and embedded HTTP
+server: parent-symlink path escape, unauthenticated public binding, and inline
+rendering of uploaded active content.
+
+## Phase affected
+
+Phase 4 production hardening for `ag-storage`.
+
+## Type of change
+
+- [x] Security fix
+- [x] Bug fix
+- [x] Tests
+- [x] Documentation
+- [ ] New feature
+- [ ] Breaking public API change
+
+## Changes
+
+- Native filesystem operations walk parent directories through directory
+  capabilities, reject symlink components, disable final symlink following,
+  and keep temporary writes plus rename inside the opened parent capability.
+- Server mode binds to `127.0.0.1` by default. A non-loopback bind without a
+  token fails during construction unless
+  `STORAGE_ALLOW_INSECURE_PUBLIC=true` is explicitly configured.
+- Uploaded HTML, HTM, and SVG retain their media type but are always returned
+  with `Content-Disposition: attachment`.
+
+## Related documents
+
+- `CLAUDE.md` sections 15, 16, 18, 19, 28, and 36
+- `docs/rfc/RFC-0013-capability-filesystem-confinement.md`
+- `docs/modules/ag-storage/README.md`
+- Issues #62, #63, and #64
+
+## Test plan
+
+- [x] `cargo test -p ag-storage`
+- [x] `cargo clippy -p ag-storage --all-targets -- -D warnings`
+- [x] `cargo fmt --all -- --check`
+- [x] `git diff --check`
+
+Verified result: 72 unit/property/integration tests and 2 doctests pass.
+
+## Exit criteria advanced
+
+- [x] Parent symlinks cannot read or write outside the native storage root.
+- [x] Native filesystem validation and I/O are no longer a separable
+  canonicalize/open sequence.
+- [x] Public unauthenticated server configuration fails with an actionable
+  error unless an explicit unsafe override is present.
+- [x] Loopback development without authentication remains supported.
+- [x] HTML, HTM, and SVG responses include safe attachment headers.
+
+## Final checklist
+
+- [x] Belongs to the approved Phase 4 storage scope.
+- [x] Security behavior and limitations are documented.
+- [x] Architecture boundaries remain unchanged.
+- [x] New dependencies are justified by RFC-0013.
+- [x] Tests cover the reported regressions.
+- [x] Clippy passes with warnings denied.
+- [x] No unrelated changes are included.
+- [x] PR descriptor is present.
+
+Closes #62
+Closes #63
+Closes #64

--- a/docs/rfc/RFC-0013-capability-filesystem-confinement.md
+++ b/docs/rfc/RFC-0013-capability-filesystem-confinement.md
@@ -1,0 +1,50 @@
+# RFC-0013: Capability-based filesystem confinement
+
+## Title
+
+Capability-based filesystem confinement for `ag-storage`
+
+## Motivation
+
+The native storage backend must guarantee that object operations cannot escape
+the configured root, including when an attacker can replace path components
+with symlinks between validation and I/O.
+
+## Problem
+
+Path canonicalization followed by a separate open, create, or rename operation
+is subject to time-of-check/time-of-use races. It also cannot validate a final
+path that does not exist without walking its existing ancestors.
+
+## Alternatives
+
+- Re-check each path component with `symlink_metadata`: rejected because the
+  later I/O still races with component replacement.
+- Use platform-specific `openat2`/handle APIs directly: rejected because it
+  requires duplicated unsafe and operating-system-specific code.
+- Keep canonicalization and document the limitation: rejected because native
+  storage is a security boundary.
+
+## Design
+
+Add `cap-std` and `cap-fs-ext` and open the configured root once as a `cap_std::fs::Dir`.
+Native reads, writes, deletes, existence checks, renames, and directory walks
+walk each parent directory without following symlinks and operate relative to the resulting capability. Temporary files and their final rename
+remain inside the same directory capability.
+
+Blocking filesystem operations run through Tokio's blocking pool so async
+workers are not blocked.
+
+## Risks
+
+- One additional maintained dependency and its transitive platform support.
+- Capability filesystem behavior must remain covered on Unix and Windows CI.
+
+## Impact
+
+The public API and object-key format remain unchanged. Attempts to traverse a
+symlink outside the root fail as storage I/O errors and cannot access the target.
+
+## Rollback
+
+Remove `cap-std` and restore path-based operations only if an equivalent,


### PR DESCRIPTION
# fix(ag-storage): close critical storage security issues

## Summary

Resolves three security issues in the native storage backend and embedded HTTP
server: parent-symlink path escape, unauthenticated public binding, and inline
rendering of uploaded active content.

## Phase affected

Phase 4 production hardening for `ag-storage`.

## Type of change

- [x] Security fix
- [x] Bug fix
- [x] Tests
- [x] Documentation
- [ ] New feature
- [ ] Breaking public API change

## Changes

- Native filesystem operations walk parent directories through directory
  capabilities, reject symlink components, disable final symlink following,
  and keep temporary writes plus rename inside the opened parent capability.
- Server mode binds to `127.0.0.1` by default. A non-loopback bind without a
  token fails during construction unless
  `STORAGE_ALLOW_INSECURE_PUBLIC=true` is explicitly configured.
- Uploaded HTML, HTM, and SVG retain their media type but are always returned
  with `Content-Disposition: attachment`.

## Related documents

- `CLAUDE.md` sections 15, 16, 18, 19, 28, and 36
- `docs/rfc/RFC-0013-capability-filesystem-confinement.md`
- `docs/modules/ag-storage/README.md`
- Issues #62, #63, and #64

## Test plan

- [x] `cargo test -p ag-storage`
- [x] `cargo clippy -p ag-storage --all-targets -- -D warnings`
- [x] `cargo fmt --all -- --check`
- [x] `git diff --check`

Verified result: 72 unit/property/integration tests and 2 doctests pass.

## Exit criteria advanced

- [x] Parent symlinks cannot read or write outside the native storage root.
- [x] Native filesystem validation and I/O are no longer a separable
  canonicalize/open sequence.
- [x] Public unauthenticated server configuration fails with an actionable
  error unless an explicit unsafe override is present.
- [x] Loopback development without authentication remains supported.
- [x] HTML, HTM, and SVG responses include safe attachment headers.

## Final checklist

- [x] Belongs to the approved Phase 4 storage scope.
- [x] Security behavior and limitations are documented.
- [x] Architecture boundaries remain unchanged.
- [x] New dependencies are justified by RFC-0013.
- [x] Tests cover the reported regressions.
- [x] Clippy passes with warnings denied.
- [x] No unrelated changes are included.
- [x] PR descriptor is present.

Closes #62
Closes #63
Closes #64
