### PR TITLE
fix(ag-realtime): reject corrupt replay records

### DIFF
--- a/crates/ag-realtime/README.md
+++ b/crates/ag-realtime/README.md
@@ -87,10 +87,19 @@ let app = Router::new()
 | `NATS_KEY_PATH` | `""` | Ruta a la clave cliente (mtls) |
 | `NATS_JETSTREAM` | `false` | Activar JetStream |
 
+## Persistencia opcional de eventos
+
+La feature `event-persistence` habilita un buffer NDJSON append-only para
+eventos criticos. `EventBuffer::append_async` mantiene el I/O de archivos
+fuera de los workers de Tokio. Durante replay, registros truncados, campos
+ausentes o tipos invalidos detienen el proceso con `InvalidData` y numero de
+linea; un fallo de publicacion se propaga como `BrokenPipe`.
+
 ## Features
 
 - `nats-external` -- cliente NATS externo via `async-nats 0.48`.
   Habilitado por defecto. Requerir `NATS_MODE=external` en runtime.
+- `event-persistence` -- buffer NDJSON local para eventos criticos.
 
 ## Referencias
 

--- a/crates/ag-realtime/src/persistence.rs
+++ b/crates/ag-realtime/src/persistence.rs
@@ -73,13 +73,18 @@ impl EventBuffer {
         lock_writer(&self.writer)?.flush()?;
         let file = File::open(&self.path)?;
         let mut out = Vec::new();
-        for line in BufReader::new(file).lines() {
+        for (index, line) in BufReader::new(file).lines().enumerate() {
+            let line_number = index + 1;
             let line = line?;
             if line.trim().is_empty() {
                 continue;
             }
-            let event: PersistedEvent = serde_json::from_str(&line)
-                .map_err(|error| std::io::Error::new(std::io::ErrorKind::InvalidData, error))?;
+            let event: PersistedEvent = serde_json::from_str(&line).map_err(|error| {
+                std::io::Error::new(
+                    std::io::ErrorKind::InvalidData,
+                    format!("invalid persisted event at line {line_number}: {error}"),
+                )
+            })?;
             out.push((event.subject, event.payload));
         }
         Ok(out)
@@ -99,10 +104,37 @@ fn lock_writer(writer: &Arc<Mutex<File>>) -> std::io::Result<MutexGuard<'_, File
         .map_err(|_| std::io::Error::other("event buffer writer lock poisoned"))
 }
 
+trait ReplayPublisher {
+    fn publish(&self, subject: String, payload: Vec<u8>) -> Result<(), crate::BusError>;
+}
+
+impl ReplayPublisher for crate::EventBus {
+    fn publish(&self, subject: String, payload: Vec<u8>) -> Result<(), crate::BusError> {
+        crate::EventBus::publish(self, subject, payload)
+    }
+}
+
 /// Replays all buffered events into the given bus, in order. Call once on startup.
+///
+/// Invalid persisted records return InvalidData. A bus publication failure
+/// stops replay and returns BrokenPipe.
 pub fn replay_into_bus(buffer: &EventBuffer, bus: &crate::EventBus) -> std::io::Result<()> {
+    replay_into_publisher(buffer, bus)
+}
+
+fn replay_into_publisher(
+    buffer: &EventBuffer,
+    publisher: &impl ReplayPublisher,
+) -> std::io::Result<()> {
     for (subject, payload) in buffer.replay()? {
-        let _ = bus.publish(subject, payload);
+        publisher
+            .publish(subject.clone(), payload)
+            .map_err(|error| {
+                std::io::Error::new(
+                    std::io::ErrorKind::BrokenPipe,
+                    format!("failed to replay event '{subject}': {error}"),
+                )
+            })?;
     }
     Ok(())
 }
@@ -157,14 +189,57 @@ mod tests {
     }
 
     #[test]
-    fn malformed_record_is_rejected() {
+    fn malformed_record_is_rejected_with_line_context() {
         let dir = tempfile::tempdir().unwrap();
         let path = dir.path().join("events.ndjson");
-        std::fs::write(&path, b"{not-json}\n").unwrap();
+        std::fs::write(
+            &path,
+            b"{\"subject\":\"valid\",\"payload\":[1]}\n{not-json}\n",
+        )
+        .unwrap();
 
         let buf = EventBuffer::open(&path).unwrap();
         let error = buf.replay().unwrap_err();
         assert_eq!(error.kind(), std::io::ErrorKind::InvalidData);
+        assert!(error.to_string().contains("line 2"));
+    }
+
+    #[test]
+    fn record_with_missing_or_wrong_fields_is_rejected() {
+        for record in [
+            r#"{"payload":[1,2,3]}"#,
+            r#"{"subject":"user.created","payload":"not-bytes"}"#,
+        ] {
+            let dir = tempfile::tempdir().unwrap();
+            let path = dir.path().join("events.ndjson");
+            std::fs::write(&path, format!("{record}\n")).unwrap();
+
+            let buf = EventBuffer::open(&path).unwrap();
+            let error = buf.replay().unwrap_err();
+            assert_eq!(error.kind(), std::io::ErrorKind::InvalidData);
+            assert!(error.to_string().contains("line 1"));
+        }
+    }
+
+    struct ClosedPublisher;
+
+    impl ReplayPublisher for ClosedPublisher {
+        fn publish(&self, _subject: String, _payload: Vec<u8>) -> Result<(), crate::BusError> {
+            Err(crate::BusError::Closed)
+        }
+    }
+
+    #[test]
+    fn replay_propagates_publish_failure() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("events.ndjson");
+        let buf = EventBuffer::open(&path).unwrap();
+        buf.append("user.created", b"alice").unwrap();
+
+        let error = replay_into_publisher(&buf, &ClosedPublisher).unwrap_err();
+        assert_eq!(error.kind(), std::io::ErrorKind::BrokenPipe);
+        assert!(error.to_string().contains("user.created"));
+        assert!(error.to_string().contains("bus closed"));
     }
 
     #[tokio::test]

--- a/docs/pr-drafts/issues-solver.md
+++ b/docs/pr-drafts/issues-solver.md
@@ -1,14 +1,13 @@
-# fix(ag-dsl): make generated Rust validation executable
+# fix(ag-realtime): reject corrupt replay records
 
 ## Summary
 
-Completes the generated-Rust blocker by emitting executable, cached `@regex`
-validation, rejecting malformed patterns during semantic analysis, and compiling
-a representative generated project in CI.
+Makes persisted event replay fail explicitly on corrupt records and publication
+errors instead of creating empty events or hiding replay loss.
 
 ## Phase affected
 
-Phase 3 generated-project exit criterion, preserving Phase 4 DSL extensions.
+Phase 4 production hardening for ag-realtime event persistence.
 
 ## Type of change
 
@@ -21,50 +20,40 @@ Phase 3 generated-project exit criterion, preserving Phase 4 DSL extensions.
 
 ## Changes
 
-- Validate `@regex` patterns during semantic analysis so malformed schemas fail
-  before code generation.
-- Emit one `OnceLock<regex::Regex>` per annotated field and execute it from the
-  generated `validate()` method.
-- Add an explicit `regex = "1"` dependency contract, justified by RFC-0014.
-- Regenerate the representative Rust fixture and exercise accepted and rejected
-  values in an integration test.
-- Document executable validation and the generated-project dependency contract.
+- Deserialize each NDJSON record into the strict PersistedEvent type with line
+  context on InvalidData failures.
+- Propagate replay publication failures as BrokenPipe with the affected subject.
+- Test malformed JSON, missing fields, wrong field types, and a closed publisher.
+- Document replay failure behavior for the event-persistence feature.
 
 ## Related documents
 
-- `CLAUDE.md` sections 20, 26, 31, and 36
-- `docs/rfc/RFC-0014-regex-runtime-validation.md`
-- `docs/dsl/referencia-v01-v04.md`
-- Issues #70, #59, and #60
+- CLAUDE.md sections 11, 13, 18, and 36
+- crates/ag-realtime/README.md
+- Issue #65
 
 ## Test plan
 
-- [x] `cargo test -p ag-dsl`
-- [x] `cargo test -p ag-generated-rust-fixture`
-- [x] `cargo clippy -p ag-dsl -p ag-generated-rust-fixture --all-targets -- -D warnings`
-- [x] `cargo fmt --all`
-- [x] `git diff --check`
+- [x] cargo test -p ag-realtime --features event-persistence
+- [x] cargo clippy -p ag-realtime --features event-persistence --all-targets -- -D warnings
+- [x] cargo fmt --all -- --check
+- [x] git diff --check
 
 ## Exit criteria advanced
 
-- [x] Generated modules use coherent ownership and imports.
-- [x] Authenticated handlers import the existing `Claims` extractor.
-- [x] A representative generated Rust project compiles and runs validation tests.
-- [x] `@regex` validation is executable and its dependency is explicit.
-- [x] Patterns are compiled once per field instead of once per request.
-- [x] Malformed patterns fail semantic analysis.
-- [x] Handler bodies remain developer-owned stubs.
-- [x] Generated comments remain in English.
+- [x] Invalid persisted fields return InvalidData with line context.
+- [x] Replay no longer synthesizes empty events from corrupt records.
+- [x] Publication errors stop replay and are returned to the caller.
+- [x] Tests cover malformed records and a closed publisher.
 
 ## Final checklist
 
-- [x] Belongs to the approved Phase 3 scope.
-- [x] New dependency is justified by RFC-0014.
-- [x] Tests cover malformed, matching, and non-matching patterns.
+- [x] Belongs to the approved Phase 4 scope.
+- [x] No new dependencies are introduced.
+- [x] Public success-path behavior remains source-compatible.
+- [x] Tests cover the reported regressions.
 - [x] Clippy passes with warnings denied.
 - [x] No unrelated changes are included.
 - [x] PR descriptor is present.
 
-Closes #70
-Closes #59
-Closes #60
+Closes #65


### PR DESCRIPTION
# fix(ag-realtime): reject corrupt replay records

## Summary

Makes persisted event replay fail explicitly on corrupt records and publication
errors instead of creating empty events or hiding replay loss.

## Phase affected

Phase 4 production hardening for ag-realtime event persistence.

## Type of change

- [ ] Security fix
- [x] Bug fix
- [x] Tests
- [x] Documentation
- [ ] New feature
- [ ] Breaking public API change

## Changes

- Deserialize each NDJSON record into the strict PersistedEvent type with line
  context on InvalidData failures.
- Propagate replay publication failures as BrokenPipe with the affected subject.
- Test malformed JSON, missing fields, wrong field types, and a closed publisher.
- Document replay failure behavior for the event-persistence feature.

## Related documents

- CLAUDE.md sections 11, 13, 18, and 36
- crates/ag-realtime/README.md
- Issue #65

## Test plan

- [x] cargo test -p ag-realtime --features event-persistence
- [x] cargo clippy -p ag-realtime --features event-persistence --all-targets -- -D warnings
- [x] cargo fmt --all -- --check
- [x] git diff --check

## Exit criteria advanced

- [x] Invalid persisted fields return InvalidData with line context.
- [x] Replay no longer synthesizes empty events from corrupt records.
- [x] Publication errors stop replay and are returned to the caller.
- [x] Tests cover malformed records and a closed publisher.

## Final checklist

- [x] Belongs to the approved Phase 4 scope.
- [x] No new dependencies are introduced.
- [x] Public success-path behavior remains source-compatible.
- [x] Tests cover the reported regressions.
- [x] Clippy passes with warnings denied.
- [x] No unrelated changes are included.
- [x] PR descriptor is present.

Closes #65
