### PR TITLE
Resolve ag-domains/ag-workers/ag-data issues (one commit per issue)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -168,6 +168,7 @@ dependencies = [
  "http-body-util",
  "hyper",
  "hyper-util",
+ "metrics",
  "rcgen",
  "reqwest",
  "rustls",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6802,6 +6802,7 @@ dependencies = [
 name = "workers-postgres"
 version = "0.0.0"
 dependencies = [
+ "ag-data",
  "ag-workers",
  "async-trait",
  "serde",

--- a/crates/ag-data/src/lib.rs
+++ b/crates/ag-data/src/lib.rs
@@ -50,6 +50,53 @@ use thiserror::Error;
 /// at O(1) cost (it shares the internal pool through `Arc`).
 pub type DbPool = sqlx::PgPool;
 
+/// Canonical transaction handle (ADR-0013 section 6).
+///
+/// Wraps a `sqlx` transaction so consumers (e.g. `ag-workers`'
+/// `enqueue_in_tx`) depend on this `ag-data` abstraction instead of leaking the
+/// raw `sqlx::Transaction` type into every call site. `ag-data` is the project's
+/// sanctioned `sqlx` boundary, so it is the one place that exposes an executor
+/// (`as_executor`) for query participation; the caller's writes and the queue
+/// insert then commit atomically (the transactional-outbox property).
+///
+/// ```ignore
+/// let mut tx = AgTx::begin(&pool).await?;
+/// // ... the caller's own writes via tx.as_executor() ...
+/// queue.enqueue_in_tx(&mut tx, job).await?;
+/// tx.commit().await?; // or tx.rollback().await? to discard both
+/// ```
+pub struct AgTx {
+    inner: sqlx::Transaction<'static, sqlx::Postgres>,
+}
+
+impl AgTx {
+    /// Begins a transaction on the pool.
+    pub async fn begin(pool: &DbPool) -> Result<Self, DataError> {
+        Ok(Self {
+            inner: pool.begin().await?,
+        })
+    }
+
+    /// Commits the transaction, persisting every write made through it.
+    pub async fn commit(self) -> Result<(), DataError> {
+        self.inner.commit().await?;
+        Ok(())
+    }
+
+    /// Rolls the transaction back, discarding every write made through it.
+    pub async fn rollback(self) -> Result<(), DataError> {
+        self.inner.rollback().await?;
+        Ok(())
+    }
+
+    /// Borrows the underlying connection so a statement can run inside this
+    /// transaction. `ag-data` is the sanctioned `sqlx` boundary, so this is the
+    /// single place that surface is exposed.
+    pub fn as_executor(&mut self) -> &mut sqlx::PgConnection {
+        &mut self.inner
+    }
+}
+
 /// Data layer error.
 #[derive(Debug, Error)]
 pub enum DataError {

--- a/crates/ag-domains/src/abuse.rs
+++ b/crates/ag-domains/src/abuse.rs
@@ -1,0 +1,304 @@
+//! Abuse controls for the domain control plane (blueprint section 15.6).
+//!
+//! Three dimensions beyond the per-registered-domain issuance counter in
+//! [`crate::issuance`]:
+//!
+//! - **Per-tenant attachment limit** — caps how many domains one tenant may
+//!   attach, bounding fan-out from a single account.
+//! - **Per-tenant issuance limit** — caps certificate issuances per tenant in a
+//!   window, complementing the per-registered-domain CA limit.
+//! - **Global ACME issuance queue** — bounds *concurrent* in-flight ACME orders
+//!   across all tenants, so a burst cannot exhaust the CA's rate budget or the
+//!   issuance worker pool. Admission is immediate accept-or-reject (a bounded
+//!   queue), returning a RAII permit that frees the slot on drop.
+//!
+//! All checks are pure, deterministic and lock-based (no clock, no network), so
+//! they are unit-tested directly.
+
+use std::collections::HashMap;
+use std::sync::{Arc, Mutex};
+
+/// Configured abuse limits. A `0` limit means "unlimited" for that dimension,
+/// so callers can enable only the controls they need.
+#[derive(Debug, Clone, Copy)]
+pub struct AbuseLimits {
+    /// Maximum live attachments per tenant (`0` = unlimited).
+    pub max_attachments_per_tenant: u32,
+    /// Maximum certificate issuances per tenant in the window (`0` = unlimited).
+    pub max_issuance_per_tenant: u32,
+    /// Maximum concurrent in-flight ACME orders, globally (`0` = unlimited).
+    pub max_global_acme_concurrency: usize,
+}
+
+impl Default for AbuseLimits {
+    fn default() -> Self {
+        // Conservative non-zero defaults; operators tune per deployment.
+        Self {
+            max_attachments_per_tenant: 100,
+            max_issuance_per_tenant: 50,
+            max_global_acme_concurrency: 16,
+        }
+    }
+}
+
+/// Why an abuse check rejected a request.
+#[derive(Debug, Clone, PartialEq, Eq, thiserror::Error)]
+pub enum AbuseRejection {
+    /// The tenant is at its attachment limit.
+    #[error("tenant '{tenant}' attachment limit reached ({count}/{max})")]
+    TenantAttachmentLimit {
+        /// Tenant identifier.
+        tenant: String,
+        /// Current count.
+        count: u32,
+        /// Configured maximum.
+        max: u32,
+    },
+    /// The tenant is at its issuance limit for the window.
+    #[error("tenant '{tenant}' issuance limit reached ({count}/{max})")]
+    TenantIssuanceLimit {
+        /// Tenant identifier.
+        tenant: String,
+        /// Current count.
+        count: u32,
+        /// Configured maximum.
+        max: u32,
+    },
+    /// The global ACME issuance queue is full.
+    #[error("global ACME issuance queue full ({in_flight}/{max})")]
+    GlobalAcmeQueueFull {
+        /// Current in-flight orders.
+        in_flight: usize,
+        /// Configured maximum.
+        max: usize,
+    },
+}
+
+#[derive(Default)]
+struct AbuseState {
+    attachments_per_tenant: HashMap<String, u32>,
+    issuance_per_tenant: HashMap<String, u32>,
+    acme_in_flight: usize,
+}
+
+/// Enforces the blueprint section 15.6 abuse controls.
+///
+/// Cheap to clone (shared inner state), so it can live in `ApiState` and be
+/// queried from multiple handlers.
+#[derive(Clone)]
+pub struct AbuseControls {
+    limits: AbuseLimits,
+    state: Arc<Mutex<AbuseState>>,
+}
+
+impl AbuseControls {
+    /// Creates abuse controls with the given limits.
+    pub fn new(limits: AbuseLimits) -> Self {
+        Self {
+            limits,
+            state: Arc::new(Mutex::new(AbuseState::default())),
+        }
+    }
+
+    fn lock(&self) -> std::sync::MutexGuard<'_, AbuseState> {
+        self.state.lock().expect("abuse controls lock poisoned")
+    }
+
+    /// Registers a new attachment for `tenant`, enforcing the per-tenant limit.
+    ///
+    /// On success the tenant's attachment count is incremented; call
+    /// [`AbuseControls::release_attachment`] when the attachment is detached.
+    pub fn register_attachment(&self, tenant: &str) -> Result<(), AbuseRejection> {
+        let max = self.limits.max_attachments_per_tenant;
+        let mut st = self.lock();
+        let count = st.attachments_per_tenant.get(tenant).copied().unwrap_or(0);
+        if max != 0 && count >= max {
+            return Err(AbuseRejection::TenantAttachmentLimit {
+                tenant: tenant.to_owned(),
+                count,
+                max,
+            });
+        }
+        *st.attachments_per_tenant
+            .entry(tenant.to_owned())
+            .or_insert(0) += 1;
+        Ok(())
+    }
+
+    /// Decrements a tenant's attachment count (on detach). Saturating at zero.
+    pub fn release_attachment(&self, tenant: &str) {
+        let mut st = self.lock();
+        if let Some(count) = st.attachments_per_tenant.get_mut(tenant) {
+            *count = count.saturating_sub(1);
+        }
+    }
+
+    /// Records a successful certificate issuance for `tenant`, enforcing the
+    /// per-tenant issuance limit for the window.
+    pub fn record_issuance(&self, tenant: &str) -> Result<(), AbuseRejection> {
+        let max = self.limits.max_issuance_per_tenant;
+        let mut st = self.lock();
+        let count = st.issuance_per_tenant.get(tenant).copied().unwrap_or(0);
+        if max != 0 && count >= max {
+            return Err(AbuseRejection::TenantIssuanceLimit {
+                tenant: tenant.to_owned(),
+                count,
+                max,
+            });
+        }
+        *st.issuance_per_tenant.entry(tenant.to_owned()).or_insert(0) += 1;
+        Ok(())
+    }
+
+    /// Current attachment count for a tenant (diagnostics/tests).
+    pub fn attachment_count(&self, tenant: &str) -> u32 {
+        self.lock()
+            .attachments_per_tenant
+            .get(tenant)
+            .copied()
+            .unwrap_or(0)
+    }
+
+    /// Acquires a slot in the global ACME issuance queue, or rejects if full.
+    ///
+    /// The returned [`AcmePermit`] frees the slot when dropped, so the global
+    /// concurrency bound is held only for the lifetime of the order.
+    pub fn acquire_acme_slot(&self) -> Result<AcmePermit, AbuseRejection> {
+        let max = self.limits.max_global_acme_concurrency;
+        let mut st = self.lock();
+        if max != 0 && st.acme_in_flight >= max {
+            return Err(AbuseRejection::GlobalAcmeQueueFull {
+                in_flight: st.acme_in_flight,
+                max,
+            });
+        }
+        st.acme_in_flight += 1;
+        Ok(AcmePermit {
+            state: Arc::clone(&self.state),
+        })
+    }
+
+    /// Current number of in-flight ACME orders (diagnostics/tests).
+    pub fn acme_in_flight(&self) -> usize {
+        self.lock().acme_in_flight
+    }
+}
+
+/// RAII permit for a slot in the global ACME issuance queue.
+///
+/// Dropping it returns the slot to the queue.
+pub struct AcmePermit {
+    state: Arc<Mutex<AbuseState>>,
+}
+
+impl std::fmt::Debug for AcmePermit {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("AcmePermit").finish_non_exhaustive()
+    }
+}
+
+impl Drop for AcmePermit {
+    fn drop(&mut self) {
+        if let Ok(mut st) = self.state.lock() {
+            st.acme_in_flight = st.acme_in_flight.saturating_sub(1);
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn limits(att: u32, iss: u32, acme: usize) -> AbuseLimits {
+        AbuseLimits {
+            max_attachments_per_tenant: att,
+            max_issuance_per_tenant: iss,
+            max_global_acme_concurrency: acme,
+        }
+    }
+
+    #[test]
+    fn attachment_limit_enforced_per_tenant() {
+        let c = AbuseControls::new(limits(2, 0, 0));
+        assert!(c.register_attachment("acme-corp").is_ok());
+        assert!(c.register_attachment("acme-corp").is_ok());
+        let err = c.register_attachment("acme-corp").unwrap_err();
+        assert!(matches!(
+            err,
+            AbuseRejection::TenantAttachmentLimit {
+                max: 2,
+                count: 2,
+                ..
+            }
+        ));
+        // A different tenant has its own budget.
+        assert!(c.register_attachment("other-corp").is_ok());
+    }
+
+    #[test]
+    fn release_attachment_frees_a_slot() {
+        let c = AbuseControls::new(limits(1, 0, 0));
+        assert!(c.register_attachment("t").is_ok());
+        assert!(c.register_attachment("t").is_err());
+        c.release_attachment("t");
+        assert_eq!(c.attachment_count("t"), 0);
+        assert!(c.register_attachment("t").is_ok());
+    }
+
+    #[test]
+    fn zero_limit_means_unlimited() {
+        let c = AbuseControls::new(limits(0, 0, 0));
+        for _ in 0..1000 {
+            c.register_attachment("t").unwrap();
+        }
+        assert_eq!(c.attachment_count("t"), 1000);
+    }
+
+    #[test]
+    fn issuance_limit_enforced_per_tenant() {
+        let c = AbuseControls::new(limits(0, 2, 0));
+        assert!(c.record_issuance("t").is_ok());
+        assert!(c.record_issuance("t").is_ok());
+        let err = c.record_issuance("t").unwrap_err();
+        assert!(matches!(
+            err,
+            AbuseRejection::TenantIssuanceLimit { max: 2, .. }
+        ));
+    }
+
+    #[test]
+    fn global_acme_queue_bounds_concurrency() {
+        let c = AbuseControls::new(limits(0, 0, 2));
+        let p1 = c.acquire_acme_slot().unwrap();
+        let p2 = c.acquire_acme_slot().unwrap();
+        assert_eq!(c.acme_in_flight(), 2);
+        // Third concurrent order is rejected.
+        let err = c.acquire_acme_slot().unwrap_err();
+        assert!(matches!(
+            err,
+            AbuseRejection::GlobalAcmeQueueFull {
+                in_flight: 2,
+                max: 2
+            }
+        ));
+        // Dropping a permit frees the slot for the next order.
+        drop(p1);
+        assert_eq!(c.acme_in_flight(), 1);
+        let _p3 = c.acquire_acme_slot().unwrap();
+        assert_eq!(c.acme_in_flight(), 2);
+        drop(p2);
+    }
+
+    #[test]
+    fn permits_release_on_drop_even_in_bulk() {
+        let c = AbuseControls::new(limits(0, 0, 3));
+        {
+            let _a = c.acquire_acme_slot().unwrap();
+            let _b = c.acquire_acme_slot().unwrap();
+            let _c = c.acquire_acme_slot().unwrap();
+            assert_eq!(c.acme_in_flight(), 3);
+            assert!(c.acquire_acme_slot().is_err());
+        }
+        assert_eq!(c.acme_in_flight(), 0, "all permits freed on scope exit");
+    }
+}

--- a/crates/ag-domains/src/acme/ari.rs
+++ b/crates/ag-domains/src/acme/ari.rs
@@ -1,0 +1,184 @@
+//! ACME Renewal Information (ARI, RFC 9773).
+//!
+//! ARI lets the CA tell clients *when* to renew, instead of clients guessing
+//! from `notAfter`. The CA publishes a `RenewalInfo` resource with a suggested
+//! renewal window; a well-behaved client schedules renewal inside that window
+//! (which also lets the CA spread load and force early renewal during
+//! incidents). When ARI is unavailable, the client falls back to the
+//! `notAfter`-minus-threshold schedule ([`super::renewal::seconds_until_renewal`]).
+//!
+//! This module is the deterministic core: parsing the `RenewalInfo` JSON and
+//! deciding how long to sleep. The HTTP fetch of the resource is the integration
+//! boundary (it needs the live CA and a credentialed environment, exercised by
+//! the staging end-to-end test, issue #87); it feeds a [`RenewalInfo`] into
+//! [`next_renewal_sleep`].
+
+use chrono::{DateTime, Utc};
+use serde::Deserialize;
+
+use crate::error::AgDomainsError;
+
+/// The CA's suggested renewal window (RFC 9773 `suggestedWindow`).
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct RenewalWindow {
+    /// Earliest time the CA suggests renewing.
+    pub start: DateTime<Utc>,
+    /// Latest time the CA suggests renewing.
+    pub end: DateTime<Utc>,
+}
+
+/// A parsed ARI `RenewalInfo` resource (RFC 9773).
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct RenewalInfo {
+    /// The suggested renewal window.
+    pub window: RenewalWindow,
+    /// Optional human-readable explanation URL (e.g. an incident notice).
+    pub explanation_url: Option<String>,
+}
+
+// Wire shape: timestamps are parsed as strings and validated as RFC 3339, so we
+// do not depend on chrono's serde integration being enabled.
+#[derive(Deserialize)]
+struct RawRenewalInfo {
+    #[serde(rename = "suggestedWindow")]
+    suggested_window: RawWindow,
+    #[serde(rename = "explanationURL")]
+    explanation_url: Option<String>,
+}
+
+#[derive(Deserialize)]
+struct RawWindow {
+    start: String,
+    end: String,
+}
+
+fn parse_rfc3339(value: &str) -> Result<DateTime<Utc>, AgDomainsError> {
+    DateTime::parse_from_rfc3339(value)
+        .map(|dt| dt.with_timezone(&Utc))
+        .map_err(|e| AgDomainsError::Acme(format!("invalid ARI timestamp '{value}': {e}")))
+}
+
+/// Parses an ARI `RenewalInfo` JSON body (RFC 9773).
+pub fn parse_renewal_info(json: &str) -> Result<RenewalInfo, AgDomainsError> {
+    let raw: RawRenewalInfo = serde_json::from_str(json)
+        .map_err(|e| AgDomainsError::Acme(format!("invalid ARI RenewalInfo JSON: {e}")))?;
+    let start = parse_rfc3339(&raw.suggested_window.start)?;
+    let end = parse_rfc3339(&raw.suggested_window.end)?;
+    if end < start {
+        return Err(AgDomainsError::Acme(
+            "ARI suggested window ends before it starts".to_owned(),
+        ));
+    }
+    Ok(RenewalInfo {
+        window: RenewalWindow { start, end },
+        explanation_url: raw.explanation_url,
+    })
+}
+
+/// Seconds to sleep before renewing, per the ARI suggested window.
+///
+/// Schedules at the window start: returns the gap until `start`, or `0` if the
+/// window has already opened (renew now), which also covers an overdue window.
+pub fn seconds_until_ari_renewal(window: &RenewalWindow, now: DateTime<Utc>) -> u64 {
+    let gap = window.start.signed_duration_since(now);
+    gap.num_seconds().max(0) as u64
+}
+
+/// Combined renewal schedule: prefer ARI when available, else fall back to the
+/// `notAfter`-minus-threshold schedule.
+pub fn next_renewal_sleep(
+    ari: Option<&RenewalInfo>,
+    not_after: DateTime<Utc>,
+    renew_before_days: u64,
+    now: DateTime<Utc>,
+) -> u64 {
+    match ari {
+        Some(info) => seconds_until_ari_renewal(&info.window, now),
+        None => super::renewal::seconds_until_renewal(not_after, renew_before_days, now),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use chrono::Duration as ChronoDuration;
+
+    const SAMPLE: &str = r#"{
+        "suggestedWindow": {
+            "start": "2025-01-02T04:00:00Z",
+            "end": "2025-01-03T04:00:00Z"
+        },
+        "explanationURL": "https://acme.example/docs/renewal"
+    }"#;
+
+    #[test]
+    fn parses_renewal_info() {
+        let info = parse_renewal_info(SAMPLE).unwrap();
+        assert_eq!(info.window.start.to_rfc3339(), "2025-01-02T04:00:00+00:00");
+        assert_eq!(info.window.end.to_rfc3339(), "2025-01-03T04:00:00+00:00");
+        assert_eq!(
+            info.explanation_url.as_deref(),
+            Some("https://acme.example/docs/renewal")
+        );
+    }
+
+    #[test]
+    fn explanation_url_is_optional() {
+        let json =
+            r#"{"suggestedWindow":{"start":"2025-01-02T04:00:00Z","end":"2025-01-03T04:00:00Z"}}"#;
+        let info = parse_renewal_info(json).unwrap();
+        assert!(info.explanation_url.is_none());
+    }
+
+    #[test]
+    fn rejects_garbage_and_inverted_window() {
+        assert!(parse_renewal_info("not json").is_err());
+        let inverted =
+            r#"{"suggestedWindow":{"start":"2025-01-03T04:00:00Z","end":"2025-01-02T04:00:00Z"}}"#;
+        assert!(parse_renewal_info(inverted).is_err());
+    }
+
+    #[test]
+    fn sleeps_until_window_start() {
+        let now = Utc::now();
+        let window = RenewalWindow {
+            start: now + ChronoDuration::hours(10),
+            end: now + ChronoDuration::hours(34),
+        };
+        let secs = seconds_until_ari_renewal(&window, now);
+        assert_eq!(secs, 10 * 3600);
+    }
+
+    #[test]
+    fn zero_when_window_already_open() {
+        let now = Utc::now();
+        let window = RenewalWindow {
+            start: now - ChronoDuration::hours(1),
+            end: now + ChronoDuration::hours(23),
+        };
+        assert_eq!(seconds_until_ari_renewal(&window, now), 0);
+    }
+
+    #[test]
+    fn next_sleep_prefers_ari_over_not_after() {
+        let now = Utc::now();
+        let not_after = now + ChronoDuration::days(60);
+        let ari = RenewalInfo {
+            window: RenewalWindow {
+                start: now + ChronoDuration::days(1),
+                end: now + ChronoDuration::days(2),
+            },
+            explanation_url: None,
+        };
+        // ARI says renew in 1 day; notAfter fallback would say ~30 days.
+        assert_eq!(next_renewal_sleep(Some(&ari), not_after, 30, now), 86_400);
+    }
+
+    #[test]
+    fn next_sleep_falls_back_to_not_after_without_ari() {
+        let now = Utc::now();
+        let not_after = now + ChronoDuration::days(30);
+        // 30 days left, renew 10 days before -> sleep 20 days.
+        assert_eq!(next_renewal_sleep(None, not_after, 10, now), 20 * 86_400);
+    }
+}

--- a/crates/ag-domains/src/acme/mod.rs
+++ b/crates/ag-domains/src/acme/mod.rs
@@ -6,6 +6,7 @@
 //! Flow: create account -> create order -> resolve DNS-01 -> wait for
 //! validation -> generate CSR with rcgen -> finalize -> download PEM.
 
+pub mod ari;
 pub mod challenge;
 pub mod renewal;
 pub mod wildcard;

--- a/crates/ag-domains/src/acme/mod.rs
+++ b/crates/ag-domains/src/acme/mod.rs
@@ -8,3 +8,4 @@
 
 pub mod challenge;
 pub mod renewal;
+pub mod wildcard;

--- a/crates/ag-domains/src/acme/renewal.rs
+++ b/crates/ag-domains/src/acme/renewal.rs
@@ -23,6 +23,7 @@ use serde::{Deserialize, Serialize};
 use tracing::{error, info, warn};
 
 use crate::{
+    acme::ari,
     acme::challenge::{remove_dns01_challenge, set_dns01_challenge},
     error::AgDomainsError,
     metrics::set_cert_days_until_expiry,
@@ -110,6 +111,37 @@ pub fn spawn_renewal_task<P>(
 where
     P: DnsProvider + 'static,
 {
+    // No ARI source: schedule purely from `notAfter`.
+    spawn_renewal_task_with_ari(
+        config,
+        credentials,
+        provider,
+        renew_before_days,
+        |_| None,
+        on_renewed,
+    )
+}
+
+/// Like [`spawn_renewal_task`], but ARI-aware (RFC 9773): after each issuance,
+/// `renewal_info_for` may return the CA's [`ari::RenewalInfo`] for the new
+/// certificate, and the next renewal is scheduled inside that window instead of
+/// from `notAfter`. Returning `None` falls back to the `notAfter` schedule.
+///
+/// `renewal_info_for` is the ARI fetch boundary: the caller performs the HTTP
+/// GET of the `RenewalInfo` resource (needing the live CA, hence not exercised
+/// in unit tests) and parses it with [`ari::parse_renewal_info`]. The scheduling
+/// decision itself is [`ari::next_renewal_sleep`], which is unit-tested.
+pub fn spawn_renewal_task_with_ari<P>(
+    config: CertConfig,
+    credentials: AccountCredentials,
+    provider: P,
+    renew_before_days: u64,
+    renewal_info_for: impl Fn(&IssuedCert) -> Option<ari::RenewalInfo> + Send + 'static,
+    on_renewed: impl Fn(IssuedCert) + Send + 'static,
+) -> tokio::task::JoinHandle<()>
+where
+    P: DnsProvider + 'static,
+{
     // AccountCredentials does not implement Clone; serialize once and
     // deserialize on each iteration for a fresh copy.
     let credentials_json =
@@ -119,11 +151,16 @@ where
 
     tokio::spawn(async move {
         let mut not_after: Option<DateTime<Utc>> = None;
+        let mut ari_info: Option<ari::RenewalInfo> = None;
 
         loop {
-            // Sleep until the renewal window, or immediately on the first run.
+            // Sleep until the renewal window. Prefer the CA's ARI window; fall
+            // back to `notAfter` minus the threshold. Run immediately on first
+            // pass (no certificate yet).
             let sleep_secs = match not_after {
-                Some(exp) => seconds_until_renewal(exp, renew_before_days, Utc::now()),
+                Some(exp) => {
+                    ari::next_renewal_sleep(ari_info.as_ref(), exp, renew_before_days, Utc::now())
+                }
                 None => 0,
             };
 
@@ -143,6 +180,9 @@ where
             match issue_with_credentials(&config, creds, &provider).await {
                 Ok(cert) => {
                     not_after = parse_not_after(&cert.cert_chain_pem).ok();
+                    // Ask the caller for the CA's ARI window for this new cert;
+                    // `None` keeps the `notAfter` schedule.
+                    ari_info = renewal_info_for(&cert);
                     if let Some(exp) = not_after {
                         let days = (exp - Utc::now()).num_days().max(0);
                         set_cert_days_until_expiry(&config.domain, days);

--- a/crates/ag-domains/src/acme/wildcard.rs
+++ b/crates/ag-domains/src/acme/wildcard.rs
@@ -1,0 +1,447 @@
+//! End-to-end DNS-01 issuance orchestration via the provider adapter SDK.
+//!
+//! Wildcard certificates (`*.example.com`) require the DNS-01 challenge: the CA
+//! validates control by reading a `_acme-challenge` TXT record. This module
+//! wires that flow on top of the declarative [`ZoneAdapter`] seam: it publishes
+//! the challenge TXT records with [`crate::provider::sdk::diff`] + `apply`,
+//! finalizes the order, and always tears the ephemeral challenge records down
+//! afterwards — success or failure.
+//!
+//! Manual DNS-01 (publish the TXT record yourself, then issue) stays fully
+//! supported through [`crate::acme::challenge`]; this is the *automated* path
+//! used only when a provider adapter is configured.
+//!
+//! The ACME interaction is abstracted behind [`Dns01OrderDriver`] so the
+//! orchestration is deterministic and unit-tested with a mock order and a mock
+//! adapter, with no network. The live driver against Let's Encrypt staging is a
+//! credentialed `#[ignore]` end-to-end test (issue #87).
+
+use async_trait::async_trait;
+use tracing::warn;
+
+use crate::{
+    error::AgDomainsError,
+    issuance::IssuedCertificate,
+    provider::sdk::{diff, ZoneAdapter},
+    record::{DnsRecord, DnsRecordSpec, RecordType},
+};
+
+/// Prefix of the DNS-01 challenge record name (RFC 8555 section 8.4).
+const ACME_CHALLENGE_PREFIX: &str = "_acme-challenge.";
+
+/// One `_acme-challenge` TXT record an ACME order needs published.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct Dns01Desired {
+    /// Full record name, e.g. `_acme-challenge.example.com`.
+    pub txt_name: String,
+    /// The key-authorization digest the CA will read.
+    pub txt_value: String,
+}
+
+impl Dns01Desired {
+    /// The declarative record spec to publish for this challenge (TTL 60s, the
+    /// record is short-lived and removed after validation).
+    fn to_spec(&self) -> DnsRecordSpec {
+        DnsRecordSpec {
+            name: self.txt_name.clone(),
+            record_type: RecordType::Txt,
+            content: self.txt_value.clone(),
+            ttl: 60,
+            proxied: false,
+        }
+    }
+}
+
+/// Abstracts the ACME side of a DNS-01 order so the orchestration stays
+/// testable without a network or the `instant-acme` types.
+///
+/// The production implementation wraps an `instant_acme::Order` (created against
+/// Let's Encrypt); tests inject a deterministic mock.
+#[async_trait]
+pub trait Dns01OrderDriver: Send {
+    /// Begin the order and return the `_acme-challenge` TXT records to publish.
+    async fn challenges(&mut self) -> Result<Vec<Dns01Desired>, AgDomainsError>;
+
+    /// After the TXT records are published and propagated, notify the CA, wait
+    /// for validation, finalize the CSR and download the certificate.
+    async fn finalize(&mut self) -> Result<IssuedCertificate, AgDomainsError>;
+}
+
+/// Whether an observed record is an ACME DNS-01 challenge TXT record.
+///
+/// This is the managed scope for challenge publication: only `_acme-challenge`
+/// TXT records are reconciled, so unrelated zone records are never touched (the
+/// [`diff`] deletion-scope contract).
+fn is_acme_challenge_txt(record: &DnsRecord) -> bool {
+    record.record_type == RecordType::Txt
+        && record
+            .name
+            .trim_end_matches('.')
+            .to_ascii_lowercase()
+            .starts_with(ACME_CHALLENGE_PREFIX)
+}
+
+/// Issue a (wildcard or multi-SAN) certificate end to end via DNS-01.
+///
+/// Steps:
+/// 1. Read the order's required `_acme-challenge` TXT records.
+/// 2. Discover the zone and read only its existing `_acme-challenge` TXT
+///    records (the managed scope).
+/// 3. `diff` desired vs observed and `apply` the plan to publish the records.
+/// 4. `finalize` the order.
+/// 5. Always tear the `_acme-challenge` subtree down, removing the challenge
+///    records whether issuance succeeded or failed.
+///
+/// The `_acme-challenge` subtree is treated as ephemeral and fully managed by
+/// this orchestration: stale challenge records left by an earlier run are
+/// reconciled away during publication, and every challenge record is removed at
+/// teardown. The managed scope is strictly `_acme-challenge` TXT records, so no
+/// other record in the zone is ever touched. (This is why cleanup is a teardown
+/// rather than a generic rollback, which would restore stale challenge records.)
+///
+/// `base_domain` is the registrable domain whose zone hosts the challenge
+/// records (e.g. `example.com` for `*.example.com`).
+pub async fn issue_dns01_with_adapter<A, D>(
+    adapter: &A,
+    base_domain: &str,
+    order: &mut D,
+) -> Result<IssuedCertificate, AgDomainsError>
+where
+    A: ZoneAdapter + ?Sized,
+    D: Dns01OrderDriver + ?Sized,
+{
+    let desired_challenges = order.challenges().await?;
+    if desired_challenges.is_empty() {
+        return Err(AgDomainsError::Acme(
+            "ACME order produced no DNS-01 challenges".to_owned(),
+        ));
+    }
+
+    let zone = adapter.discover(base_domain).await?;
+
+    // Scope the diff to the `_acme-challenge` subtree so nothing else is touched.
+    let observed = read_challenge_scope(adapter, &zone).await?;
+    let desired: Vec<DnsRecordSpec> = desired_challenges
+        .iter()
+        .map(Dns01Desired::to_spec)
+        .collect();
+
+    let plan = diff(&desired, &observed);
+    adapter.apply(&zone, &plan).await?;
+
+    // Finalize, then always tear down the ephemeral challenge records.
+    let result = order.finalize().await;
+    teardown_challenge_scope(adapter, &zone).await;
+
+    result
+}
+
+/// Read only the `_acme-challenge` TXT records in the zone (the managed scope).
+async fn read_challenge_scope<A: ZoneAdapter + ?Sized>(
+    adapter: &A,
+    zone: &crate::provider::sdk::ZoneRef,
+) -> Result<Vec<DnsRecord>, AgDomainsError> {
+    Ok(adapter
+        .read(zone)
+        .await?
+        .into_iter()
+        .filter(is_acme_challenge_txt)
+        .collect())
+}
+
+/// Best-effort removal of every `_acme-challenge` TXT record in the zone.
+///
+/// Never fails the issuance: errors are logged, since the certificate (if
+/// issued) is already valid regardless of leftover challenge records.
+async fn teardown_challenge_scope<A: ZoneAdapter + ?Sized>(
+    adapter: &A,
+    zone: &crate::provider::sdk::ZoneRef,
+) {
+    match read_challenge_scope(adapter, zone).await {
+        Ok(remaining) => {
+            // Empty desired set => the plan deletes every scoped record.
+            let teardown = diff(&[], &remaining);
+            if !teardown.is_empty() {
+                if let Err(e) = adapter.apply(zone, &teardown).await {
+                    warn!(
+                        zone = zone.domain,
+                        error = %e,
+                        "failed to clean up DNS-01 challenge records"
+                    );
+                }
+            }
+        }
+        Err(e) => warn!(
+            zone = zone.domain,
+            error = %e,
+            "could not re-read zone to clean up DNS-01 challenge records"
+        ),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::provider::sdk::ProviderAdapter;
+    use crate::provider::DnsProvider;
+    use std::collections::HashMap;
+    use std::sync::{Arc, Mutex};
+
+    /// In-memory `DnsProvider` for orchestration tests (no network).
+    ///
+    /// A cheaply-clonable handle sharing inner state, so the adapter and the
+    /// mock order observe the same zone.
+    #[derive(Clone)]
+    struct MockProvider {
+        inner: Arc<MockInner>,
+    }
+
+    struct MockInner {
+        records: Mutex<HashMap<String, DnsRecord>>,
+        seq: Mutex<u64>,
+    }
+
+    impl MockProvider {
+        fn new() -> Self {
+            Self {
+                inner: Arc::new(MockInner {
+                    records: Mutex::new(HashMap::new()),
+                    seq: Mutex::new(0),
+                }),
+            }
+        }
+
+        fn seed(&self, rec: DnsRecord) {
+            self.inner
+                .records
+                .lock()
+                .unwrap()
+                .insert(rec.id.clone(), rec);
+        }
+
+        fn names(&self) -> Vec<String> {
+            let mut v: Vec<String> = self
+                .inner
+                .records
+                .lock()
+                .unwrap()
+                .values()
+                .map(|r| format!("{}={}", r.name, r.content))
+                .collect();
+            v.sort();
+            v
+        }
+    }
+
+    #[async_trait]
+    impl DnsProvider for MockProvider {
+        fn name(&self) -> &'static str {
+            "mock"
+        }
+        async fn zone_id(&self, _domain: &str) -> Result<String, AgDomainsError> {
+            Ok("zone-1".to_owned())
+        }
+        async fn list_records(&self, _zone_id: &str) -> Result<Vec<DnsRecord>, AgDomainsError> {
+            Ok(self
+                .inner
+                .records
+                .lock()
+                .unwrap()
+                .values()
+                .cloned()
+                .collect())
+        }
+        async fn create_record(
+            &self,
+            zone_id: &str,
+            spec: &DnsRecordSpec,
+        ) -> Result<DnsRecord, AgDomainsError> {
+            let mut seq = self.inner.seq.lock().unwrap();
+            *seq += 1;
+            let id = format!("rec-{seq}");
+            let rec = DnsRecord {
+                id: id.clone(),
+                zone_id: zone_id.to_owned(),
+                name: spec.name.clone(),
+                record_type: spec.record_type.clone(),
+                content: spec.content.clone(),
+                ttl: spec.ttl,
+                proxied: spec.proxied,
+            };
+            self.inner.records.lock().unwrap().insert(id, rec.clone());
+            Ok(rec)
+        }
+        async fn update_record(
+            &self,
+            _zone_id: &str,
+            record_id: &str,
+            spec: &DnsRecordSpec,
+        ) -> Result<DnsRecord, AgDomainsError> {
+            let mut records = self.inner.records.lock().unwrap();
+            let rec = records
+                .get_mut(record_id)
+                .ok_or_else(|| AgDomainsError::RecordNotFound(record_id.to_owned()))?;
+            rec.content = spec.content.clone();
+            rec.ttl = spec.ttl;
+            Ok(rec.clone())
+        }
+        async fn delete_record(
+            &self,
+            _zone_id: &str,
+            record_id: &str,
+        ) -> Result<(), AgDomainsError> {
+            self.inner
+                .records
+                .lock()
+                .unwrap()
+                .remove(record_id)
+                .map(|_| ())
+                .ok_or_else(|| AgDomainsError::RecordNotFound(record_id.to_owned()))
+        }
+    }
+
+    /// Mock ACME order: yields fixed challenges and a configurable finalize.
+    struct MockOrder {
+        challenges: Vec<Dns01Desired>,
+        fail_finalize: bool,
+        /// Records what the zone held at finalize time, to assert the challenge
+        /// TXT records were actually published before the CA was notified.
+        observed_at_finalize: Mutex<Option<Vec<String>>>,
+        adapter_records: MockProvider,
+    }
+
+    #[async_trait]
+    impl Dns01OrderDriver for MockOrder {
+        async fn challenges(&mut self) -> Result<Vec<Dns01Desired>, AgDomainsError> {
+            Ok(self.challenges.clone())
+        }
+        async fn finalize(&mut self) -> Result<IssuedCertificate, AgDomainsError> {
+            *self.observed_at_finalize.lock().unwrap() = Some(self.adapter_records.names());
+            if self.fail_finalize {
+                return Err(AgDomainsError::Acme("order invalid".to_owned()));
+            }
+            Ok(IssuedCertificate {
+                cert_chain_pem: "CERT".to_owned(),
+                private_key_pem: "KEY".to_owned(),
+            })
+        }
+    }
+
+    fn challenge(name: &str, value: &str) -> Dns01Desired {
+        Dns01Desired {
+            txt_name: name.to_owned(),
+            txt_value: value.to_owned(),
+        }
+    }
+
+    #[tokio::test]
+    async fn wildcard_issuance_publishes_then_cleans_up() {
+        let provider = MockProvider::new();
+        let adapter = ProviderAdapter::new(provider.clone());
+        // Wildcard + apex share the `_acme-challenge.example.com` name with two
+        // distinct TXT values (RFC 8555 allows multiple values at one name).
+        let mut order = MockOrder {
+            challenges: vec![
+                challenge("_acme-challenge.example.com", "value-apex"),
+                challenge("_acme-challenge.example.com", "value-wildcard"),
+            ],
+            fail_finalize: false,
+            observed_at_finalize: Mutex::new(None),
+            adapter_records: provider.clone(),
+        };
+
+        let cert = issue_dns01_with_adapter(&adapter, "example.com", &mut order)
+            .await
+            .unwrap();
+        assert_eq!(cert.cert_chain_pem, "CERT");
+
+        // Both TXT values were present in the zone when finalize ran.
+        let at_finalize = order.observed_at_finalize.lock().unwrap().clone().unwrap();
+        assert!(at_finalize.contains(&"_acme-challenge.example.com=value-apex".to_owned()));
+        assert!(at_finalize.contains(&"_acme-challenge.example.com=value-wildcard".to_owned()));
+
+        // After issuance the challenge records are cleaned up (rollback).
+        assert!(provider.names().is_empty(), "challenge TXT must be removed");
+    }
+
+    #[tokio::test]
+    async fn cleanup_runs_even_when_finalize_fails() {
+        let provider = MockProvider::new();
+        let adapter = ProviderAdapter::new(provider.clone());
+        let mut order = MockOrder {
+            challenges: vec![challenge("_acme-challenge.example.com", "v")],
+            fail_finalize: true,
+            observed_at_finalize: Mutex::new(None),
+            adapter_records: provider.clone(),
+        };
+
+        let err = issue_dns01_with_adapter(&adapter, "example.com", &mut order)
+            .await
+            .unwrap_err();
+        assert!(matches!(err, AgDomainsError::Acme(_)));
+        // Even on failure the challenge TXT is cleaned up.
+        assert!(provider.names().is_empty());
+    }
+
+    #[tokio::test]
+    async fn unrelated_records_are_never_touched() {
+        let provider = MockProvider::new();
+        // A normal A record and a stale challenge TXT from a prior run.
+        provider.seed(DnsRecord {
+            id: "a1".to_owned(),
+            zone_id: "zone-1".to_owned(),
+            name: "api.example.com".to_owned(),
+            record_type: RecordType::A,
+            content: "192.0.2.1".to_owned(),
+            ttl: 300,
+            proxied: false,
+        });
+        provider.seed(DnsRecord {
+            id: "stale".to_owned(),
+            zone_id: "zone-1".to_owned(),
+            name: "_acme-challenge.example.com".to_owned(),
+            record_type: RecordType::Txt,
+            content: "old-value".to_owned(),
+            ttl: 60,
+            proxied: false,
+        });
+        let adapter = ProviderAdapter::new(provider.clone());
+        let mut order = MockOrder {
+            challenges: vec![challenge("_acme-challenge.example.com", "fresh-value")],
+            fail_finalize: false,
+            observed_at_finalize: Mutex::new(None),
+            adapter_records: provider.clone(),
+        };
+
+        issue_dns01_with_adapter(&adapter, "example.com", &mut order)
+            .await
+            .unwrap();
+
+        // The unrelated A record survives; only challenge TXTs were managed.
+        let names = provider.names();
+        assert!(
+            names.contains(&"api.example.com=192.0.2.1".to_owned()),
+            "unrelated A record must be preserved: {names:?}"
+        );
+        // The stale challenge value is gone (reconciled away, then cleaned up).
+        assert!(!names
+            .iter()
+            .any(|n| n.starts_with("_acme-challenge.example.com")));
+    }
+
+    #[tokio::test]
+    async fn empty_challenge_set_is_rejected() {
+        let provider = MockProvider::new();
+        let adapter = ProviderAdapter::new(provider.clone());
+        let mut order = MockOrder {
+            challenges: vec![],
+            fail_finalize: false,
+            observed_at_finalize: Mutex::new(None),
+            adapter_records: provider.clone(),
+        };
+        let err = issue_dns01_with_adapter(&adapter, "example.com", &mut order)
+            .await
+            .unwrap_err();
+        assert!(matches!(err, AgDomainsError::Acme(_)));
+    }
+}

--- a/crates/ag-domains/src/api.rs
+++ b/crates/ag-domains/src/api.rs
@@ -346,6 +346,7 @@ async fn create_attachment(
     let dto = AttachmentDto::from(&attachment);
     state.store.create(attachment).await?;
     metrics::record_attachment_created();
+    refresh_fleet_gauges_from_store(&state).await;
     state
         .events
         .emit(DomainEvent::AttachmentCreated {
@@ -360,7 +361,29 @@ async fn list_attachments(
     State(state): State<ApiState>,
 ) -> Result<Json<Vec<AttachmentDto>>, ApiError> {
     let all = state.store.list().await?;
+    refresh_fleet_gauges(&all);
     Ok(Json(all.iter().map(AttachmentDto::from).collect()))
+}
+
+/// Sets the fleet-level control-plane gauges (blueprint section 16.1) from a
+/// snapshot of attachments: the active count and the number of certificates in
+/// the renewal window. Called after control-plane mutations and on list.
+fn refresh_fleet_gauges(attachments: &[DomainAttachment]) {
+    let active = attachments.iter().filter(|a| a.is_active()).count();
+    let expiring_soon = attachments
+        .iter()
+        .filter(|a| a.tls_status == TlsStatus::RenewalDue)
+        .count();
+    metrics::set_active_attachments(active as u64);
+    metrics::set_certs_expiring_soon(expiring_soon as u64);
+}
+
+/// Re-reads the store and refreshes the fleet gauges; best-effort, never fails
+/// the surrounding control-plane operation.
+async fn refresh_fleet_gauges_from_store(state: &ApiState) {
+    if let Ok(all) = state.store.list().await {
+        refresh_fleet_gauges(&all);
+    }
 }
 
 async fn get_attachment(
@@ -420,6 +443,7 @@ async fn detach_attachment(
         .detach(attachment.hostname.ascii(), DEFAULT_TOMBSTONE_SECS)
         .await?;
     metrics::record_attachment_detached();
+    refresh_fleet_gauges_from_store(&state).await;
     state
         .events
         .emit(DomainEvent::Detached {
@@ -444,6 +468,7 @@ async fn verify_attachment(
         attachment.ownership_status = OwnershipStatus::Verified;
         attachment.recompute_lifecycle();
         state.store.update(attachment.clone()).await?;
+        refresh_fleet_gauges_from_store(&state).await;
         state
             .events
             .emit(DomainEvent::OwnershipVerified {

--- a/crates/ag-domains/src/api.rs
+++ b/crates/ag-domains/src/api.rs
@@ -25,6 +25,7 @@ use axum::routing::{get, post};
 use axum::{Json, Router};
 use serde::{Deserialize, Serialize};
 
+use crate::abuse::AbuseControls;
 use crate::attachment::{
     AttachmentLifecycle, DnsMode, DnsStatus, DomainAttachment, OwnershipMethod, OwnershipStatus,
     RoutingStatus, TargetKind, TlsMode, TlsStatus,
@@ -68,6 +69,9 @@ pub struct ApiState {
     edge: EdgeTargets,
     events: Arc<dyn EventSink>,
     verifier: Arc<dyn OwnershipVerifier>,
+    /// Optional per-tenant abuse controls (blueprint section 15.6). When unset,
+    /// attachments are unbounded (the prior default behaviour).
+    abuse: Option<AbuseControls>,
 }
 
 impl ApiState {
@@ -81,7 +85,15 @@ impl ApiState {
             edge,
             events: Arc::new(NullEventSink),
             verifier: Arc::new(NullVerifier),
+            abuse: None,
         }
+    }
+
+    /// Enables per-tenant abuse controls (blueprint section 15.6) on the create
+    /// and detach endpoints. Without this, attachments are unbounded.
+    pub fn with_abuse_controls(mut self, controls: AbuseControls) -> Self {
+        self.abuse = Some(controls);
+        self
     }
 
     /// Sets the ownership verifier used by the verify endpoint.
@@ -214,6 +226,7 @@ pub struct ErrorDto {
 }
 
 /// API error mapped to an HTTP status.
+#[derive(Debug)]
 pub struct ApiError {
     status: StatusCode,
     message: String,
@@ -322,10 +335,19 @@ async fn create_attachment(
     let ownership_name = ownership_record_name(&hostname);
     let tls_mode = parse_tls_mode(req.tls_mode.as_deref(), hostname.kind());
 
+    // Enforce the per-tenant attachment limit (blueprint section 15.6) before
+    // persisting. The tenant is the project; reserve a slot up front.
+    let tenant = req.project_id;
+    if let Some(abuse) = &state.abuse {
+        abuse
+            .register_attachment(&tenant)
+            .map_err(|e| ApiError::new(StatusCode::TOO_MANY_REQUESTS, e.to_string()))?;
+    }
+
     let mut attachment = DomainAttachment {
         id,
         hostname,
-        project: req.project_id,
+        project: tenant.clone(),
         environment: req.environment_id,
         target_kind: parse_target_kind(req.target_kind.as_deref()),
         target_ref: req.target_ref.unwrap_or_else(|| "default".to_owned()),
@@ -344,7 +366,14 @@ async fn create_attachment(
     attachment.recompute_lifecycle();
 
     let dto = AttachmentDto::from(&attachment);
-    state.store.create(attachment).await?;
+    if let Err(e) = state.store.create(attachment).await {
+        // Persistence failed: release the abuse-control slot we reserved so a
+        // failed create does not consume the tenant's budget.
+        if let Some(abuse) = &state.abuse {
+            abuse.release_attachment(&tenant);
+        }
+        return Err(e.into());
+    }
     metrics::record_attachment_created();
     refresh_fleet_gauges_from_store(&state).await;
     state
@@ -443,6 +472,9 @@ async fn detach_attachment(
         .detach(attachment.hostname.ascii(), DEFAULT_TOMBSTONE_SECS)
         .await?;
     metrics::record_attachment_detached();
+    if let Some(abuse) = &state.abuse {
+        abuse.release_attachment(&attachment.project);
+    }
     refresh_fleet_gauges_from_store(&state).await;
     state
         .events
@@ -545,5 +577,78 @@ mod tests {
     #[test]
     fn router_builds() {
         let _ = build_router(state());
+    }
+
+    fn attach_req(hostname: &str, project: &str) -> AttachRequest {
+        AttachRequest {
+            hostname: hostname.to_owned(),
+            project_id: project.to_owned(),
+            environment_id: "production".to_owned(),
+            target_kind: None,
+            target_ref: None,
+            tls_mode: None,
+        }
+    }
+
+    #[tokio::test]
+    async fn per_tenant_attachment_limit_rejects_with_429() {
+        use crate::abuse::{AbuseControls, AbuseLimits};
+        let store: Arc<dyn AttachmentStore> = Arc::new(InMemoryStore::new());
+        let controls = AbuseControls::new(AbuseLimits {
+            max_attachments_per_tenant: 1,
+            max_issuance_per_tenant: 0,
+            max_global_acme_concurrency: 0,
+        });
+        let st = ApiState::new(store, EdgeTargets::new("edge.example-cloud.net"))
+            .with_abuse_controls(controls);
+
+        // First attachment for the tenant succeeds.
+        let _ = create_attachment(
+            State(st.clone()),
+            Json(attach_req("a.example.com", "tenant-1")),
+        )
+        .await
+        .expect("first attachment within limit");
+
+        // Second attachment for the same tenant is rejected at the limit.
+        let rejected = create_attachment(
+            State(st.clone()),
+            Json(attach_req("b.example.com", "tenant-1")),
+        )
+        .await;
+        assert!(
+            matches!(rejected, Err(ref e) if e.status == StatusCode::TOO_MANY_REQUESTS),
+            "second attachment must be rejected with 429",
+        );
+
+        // A different tenant still has budget.
+        let _ = create_attachment(State(st), Json(attach_req("c.example.com", "tenant-2")))
+            .await
+            .expect("other tenant within its own limit");
+    }
+
+    #[tokio::test]
+    async fn detach_frees_tenant_attachment_budget() {
+        use crate::abuse::{AbuseControls, AbuseLimits};
+        let store: Arc<dyn AttachmentStore> = Arc::new(InMemoryStore::new());
+        let controls = AbuseControls::new(AbuseLimits {
+            max_attachments_per_tenant: 1,
+            max_issuance_per_tenant: 0,
+            max_global_acme_concurrency: 0,
+        });
+        let st = ApiState::new(store, EdgeTargets::new("edge.example-cloud.net"))
+            .with_abuse_controls(controls);
+
+        let (_, Json(dto)) =
+            create_attachment(State(st.clone()), Json(attach_req("a.example.com", "t")))
+                .await
+                .unwrap();
+        // At the limit now; detach should free the slot.
+        detach_attachment(State(st.clone()), Path(dto.id.clone()))
+            .await
+            .unwrap();
+        let _ = create_attachment(State(st), Json(attach_req("b.example.com", "t")))
+            .await
+            .expect("budget freed after detach");
     }
 }

--- a/crates/ag-domains/src/attachment.rs
+++ b/crates/ag-domains/src/attachment.rs
@@ -198,7 +198,21 @@ impl DomainAttachment {
         if self.lifecycle == AttachmentLifecycle::Detached {
             return;
         }
-        self.lifecycle = self.derive_lifecycle();
+        let previous = self.lifecycle;
+        let next = self.derive_lifecycle();
+        // Count only the transition into a DNS-caused misconfiguration, so the
+        // counter reflects events rather than the number of recomputations
+        // (blueprint section 16.1).
+        if next == AttachmentLifecycle::Misconfigured
+            && previous != AttachmentLifecycle::Misconfigured
+            && matches!(
+                self.dns_status,
+                DnsStatus::WrongTarget | DnsStatus::ConflictingRecords | DnsStatus::Failed
+            )
+        {
+            crate::metrics::record_dns_misconfigured();
+        }
+        self.lifecycle = next;
     }
 
     fn derive_lifecycle(&self) -> AttachmentLifecycle {

--- a/crates/ag-domains/src/dangling.rs
+++ b/crates/ag-domains/src/dangling.rs
@@ -1,0 +1,195 @@
+//! Dangling-DNS detection (blueprint section 15.3, subdomain-takeover hygiene).
+//!
+//! A hostname is *dangling* when it still points at the Anti-Gravital edge in
+//! DNS but no attachment owns it any more (it was detached, or was never
+//! attached). Left unaddressed, a third party could attach the same hostname and
+//! receive traffic meant for the original owner. The edge already fails closed
+//! for unattached hostnames (`ag-edge` route resolution never serves another
+//! tenant's content), so this module adds the *detection* half: scan candidate
+//! hostnames, decide which are dangling, and emit
+//! [`DomainEvent::DanglingDnsDetected`] so operators can be notified.
+//!
+//! The decision is a pure function ([`classify`]); the worker ([`scan_dangling`])
+//! feeds it from an [`AttachmentStore`] and an [`EventSink`]. Both are
+//! deterministic and unit-tested without any network: the DNS observation
+//! (`points_to_edge`) is supplied by the caller's resolver.
+
+use crate::{
+    attachment::AttachmentLifecycle,
+    events::{DomainEvent, EventSink},
+    store::{AttachmentStore, StoreError},
+};
+
+/// The result of classifying a candidate hostname.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum DanglingDecision {
+    /// Points at the edge but is not attached: a takeover risk.
+    Dangling,
+    /// Either does not point at the edge, or is legitimately attached.
+    Safe,
+}
+
+/// Pure decision: a hostname is dangling iff it points at the edge and is not
+/// attached. This is the security invariant, isolated from any I/O.
+pub fn classify(points_to_edge: bool, attached: bool) -> DanglingDecision {
+    if points_to_edge && !attached {
+        DanglingDecision::Dangling
+    } else {
+        DanglingDecision::Safe
+    }
+}
+
+/// A hostname to evaluate, with the DNS observation already made.
+///
+/// `points_to_edge` is the resolver's verdict that the hostname's A/AAAA/CNAME
+/// currently targets the Anti-Gravital edge. The worker supplies the attachment
+/// side from the store, so this type carries only the DNS half.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct DanglingCandidate {
+    /// Canonical ASCII hostname.
+    pub hostname: String,
+    /// Whether DNS currently points this hostname at the edge.
+    pub points_to_edge: bool,
+}
+
+impl DanglingCandidate {
+    /// Convenience constructor.
+    pub fn new(hostname: impl Into<String>, points_to_edge: bool) -> Self {
+        Self {
+            hostname: hostname.into(),
+            points_to_edge,
+        }
+    }
+}
+
+/// Whether the store holds a live (non-detached) attachment for `hostname`.
+///
+/// A detached attachment does not count as attached: the hostname is in the
+/// post-detach window that subdomain takeover exploits.
+async fn is_attached(store: &dyn AttachmentStore, hostname: &str) -> Result<bool, StoreError> {
+    Ok(store
+        .get(hostname)
+        .await?
+        .map(|a| a.lifecycle != AttachmentLifecycle::Detached)
+        .unwrap_or(false))
+}
+
+/// Scan candidates and return the hostnames that are dangling.
+///
+/// For each dangling hostname, emits [`DomainEvent::DanglingDnsDetected`] to the
+/// sink so operators are notified. Never serves or mutates routing; detection
+/// only. The edge continues to fail closed for these hostnames.
+pub async fn scan_dangling(
+    store: &dyn AttachmentStore,
+    sink: &dyn EventSink,
+    candidates: &[DanglingCandidate],
+) -> Result<Vec<String>, StoreError> {
+    let mut dangling = Vec::new();
+    for candidate in candidates {
+        let attached = is_attached(store, &candidate.hostname).await?;
+        if classify(candidate.points_to_edge, attached) == DanglingDecision::Dangling {
+            sink.emit(DomainEvent::DanglingDnsDetected {
+                hostname: candidate.hostname.clone(),
+            })
+            .await;
+            dangling.push(candidate.hostname.clone());
+        }
+    }
+    Ok(dangling)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::attachment::{
+        DnsMode, DnsStatus, DomainAttachment, OwnershipMethod, OwnershipStatus, RoutingStatus,
+        TargetKind, TlsMode, TlsStatus,
+    };
+    use crate::events::InMemoryEventSink;
+    use crate::hostname::Hostname;
+    use crate::store::InMemoryStore;
+
+    #[test]
+    fn classify_truth_table() {
+        assert_eq!(classify(true, false), DanglingDecision::Dangling);
+        assert_eq!(classify(true, true), DanglingDecision::Safe);
+        assert_eq!(classify(false, false), DanglingDecision::Safe);
+        assert_eq!(classify(false, true), DanglingDecision::Safe);
+    }
+
+    fn attachment(hostname: &str) -> DomainAttachment {
+        let h = Hostname::parse(hostname).unwrap();
+        DomainAttachment {
+            id: "dom_x".to_owned(),
+            hostname: h,
+            project: "p".to_owned(),
+            environment: "production".to_owned(),
+            target_kind: TargetKind::Project,
+            target_ref: "default".to_owned(),
+            dns_mode: DnsMode::Manual,
+            tls_mode: TlsMode::ManagedHttp01,
+            ownership_method: OwnershipMethod::Txt,
+            ownership_name: "_ag-domain.example.com".to_owned(),
+            ownership_value: "ag-verification=x".to_owned(),
+            ownership_status: OwnershipStatus::Verified,
+            dns_status: DnsStatus::Routable,
+            tls_status: TlsStatus::Active,
+            routing_status: RoutingStatus::Ready,
+            lifecycle: AttachmentLifecycle::Active,
+            created_at: 0,
+        }
+    }
+
+    #[tokio::test]
+    async fn points_to_edge_without_attachment_is_dangling() {
+        let store = InMemoryStore::default();
+        let sink = InMemoryEventSink::new();
+        let candidates = vec![DanglingCandidate::new("ghost.example.com", true)];
+
+        let dangling = scan_dangling(&store, &sink, &candidates).await.unwrap();
+        assert_eq!(dangling, vec!["ghost.example.com".to_owned()]);
+        assert_eq!(sink.len(), 1);
+        assert_eq!(
+            sink.events()[0].event_type(),
+            "domain.dangling_dns_detected"
+        );
+    }
+
+    #[tokio::test]
+    async fn attached_hostname_is_safe() {
+        let store = InMemoryStore::default();
+        store.create(attachment("api.example.com")).await.unwrap();
+        let sink = InMemoryEventSink::new();
+        let candidates = vec![DanglingCandidate::new("api.example.com", true)];
+
+        let dangling = scan_dangling(&store, &sink, &candidates).await.unwrap();
+        assert!(dangling.is_empty());
+        assert!(sink.is_empty(), "no event for a legitimately attached host");
+    }
+
+    #[tokio::test]
+    async fn detached_hostname_pointing_to_edge_is_dangling() {
+        let store = InMemoryStore::default();
+        store.create(attachment("api.example.com")).await.unwrap();
+        // Detach removes the live attachment and leaves a tombstone: exactly the
+        // takeover window.
+        store.detach("api.example.com", 3600).await.unwrap();
+        let sink = InMemoryEventSink::new();
+        let candidates = vec![DanglingCandidate::new("api.example.com", true)];
+
+        let dangling = scan_dangling(&store, &sink, &candidates).await.unwrap();
+        assert_eq!(dangling, vec!["api.example.com".to_owned()]);
+        assert_eq!(sink.len(), 1);
+    }
+
+    #[tokio::test]
+    async fn not_pointing_to_edge_is_safe() {
+        let store = InMemoryStore::default();
+        let sink = InMemoryEventSink::new();
+        let candidates = vec![DanglingCandidate::new("elsewhere.example.com", false)];
+
+        let dangling = scan_dangling(&store, &sink, &candidates).await.unwrap();
+        assert!(dangling.is_empty());
+        assert!(sink.is_empty());
+    }
+}

--- a/crates/ag-domains/src/domain_connect.rs
+++ b/crates/ag-domains/src/domain_connect.rs
@@ -1,0 +1,307 @@
+//! Domain Connect discovery and template application (blueprint section 12).
+//!
+//! [Domain Connect](https://www.domainconnect.org/) lets an operator authorize a
+//! DNS template at their provider instead of pasting records by hand. The flow:
+//!
+//! 1. **Discover** the provider's `_domainconnect` TXT record for the domain to
+//!    learn the Domain Connect API host ([`parse_domainconnect_record`]).
+//! 2. Fetch the provider **settings** to learn the synchronous-UX base URL
+//!    ([`parse_settings`]) — the HTTP fetch is the integration boundary; parsing
+//!    is here and unit-tested.
+//! 3. Build the **template variables** from the Anti-Gravital records, MX-safe so
+//!    existing email is never disturbed ([`template_variables`]).
+//! 4. **Redirect** the operator to the provider's synchronous authorization flow
+//!    ([`build_sync_apply_url`]).
+//! 5. **Verify independently**: Domain Connect accelerates setup, but the
+//!    ownership token and routing records it applies are the same ones
+//!    [`crate::instructions::generate_instructions`] produces, so the existing
+//!    ownership/diagnostics verification path confirms the result unchanged.
+//!
+//! Everything here is provider-agnostic and pure; no provider is reimplemented.
+
+use serde::Deserialize;
+
+use crate::error::AgDomainsError;
+use crate::instructions::DnsInstructions;
+use crate::record::RecordType;
+
+/// Discovered Domain Connect entry point for a domain.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct DomainConnectDiscovery {
+    /// The Domain Connect API host published in `_domainconnect.<domain>`.
+    pub api_host: String,
+}
+
+/// DNS name of the discovery record (Domain Connect spec section "Discovery").
+pub fn domainconnect_record_name(domain: &str) -> String {
+    format!("_domainconnect.{}", domain.trim_end_matches('.'))
+}
+
+/// Parses the value of a `_domainconnect` TXT record into the API host.
+///
+/// The record value is the hostname of the provider's Domain Connect API
+/// (e.g. `domainconnect.provider.example`). Rejects empty values, embedded
+/// schemes/paths and whitespace, so a malformed record cannot redirect the flow
+/// to an arbitrary URL.
+pub fn parse_domainconnect_record(
+    txt_value: &str,
+) -> Result<DomainConnectDiscovery, AgDomainsError> {
+    let host = txt_value.trim().trim_end_matches('.');
+    if host.is_empty()
+        || host.contains("://")
+        || host.contains('/')
+        || host.contains(char::is_whitespace)
+        || !host.contains('.')
+    {
+        return Err(AgDomainsError::Config(format!(
+            "invalid _domainconnect record value: {txt_value:?}"
+        )));
+    }
+    Ok(DomainConnectDiscovery {
+        api_host: host.to_ascii_lowercase(),
+    })
+}
+
+/// Provider settings returned by the Domain Connect API `/v2/{domain}/settings`.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct DomainConnectSettings {
+    /// Human-readable provider name.
+    pub provider_name: String,
+    /// Base URL of the synchronous (interactive) authorization UX.
+    pub url_sync_ux: String,
+    /// Base URL of the asynchronous (OAuth) authorization UX, if offered.
+    pub url_async_ux: Option<String>,
+    /// Base URL of the provider's API, if advertised.
+    pub url_api: Option<String>,
+}
+
+#[derive(Deserialize)]
+struct RawSettings {
+    #[serde(rename = "providerName")]
+    provider_name: String,
+    #[serde(rename = "urlSyncUX")]
+    url_sync_ux: String,
+    #[serde(rename = "urlAsyncUX")]
+    url_async_ux: Option<String>,
+    #[serde(rename = "urlAPI")]
+    url_api: Option<String>,
+}
+
+/// Parses the Domain Connect provider settings JSON.
+pub fn parse_settings(json: &str) -> Result<DomainConnectSettings, AgDomainsError> {
+    let raw: RawSettings = serde_json::from_str(json).map_err(|e| {
+        AgDomainsError::Config(format!("invalid Domain Connect settings JSON: {e}"))
+    })?;
+    if raw.url_sync_ux.trim().is_empty() {
+        return Err(AgDomainsError::Config(
+            "Domain Connect settings missing urlSyncUX".to_owned(),
+        ));
+    }
+    Ok(DomainConnectSettings {
+        provider_name: raw.provider_name,
+        url_sync_ux: raw.url_sync_ux.trim_end_matches('/').to_owned(),
+        url_async_ux: raw.url_async_ux,
+        url_api: raw.url_api,
+    })
+}
+
+/// A Domain Connect template to apply, identified by provider/service id.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct ApplyTemplate {
+    /// The template's provider id (registered with the DNS provider).
+    pub provider_id: String,
+    /// The template's service id.
+    pub service_id: String,
+    /// Template variables (`name` -> `value`) substituted into the template.
+    pub variables: Vec<(String, String)>,
+}
+
+/// Derives Domain Connect template variables from Anti-Gravital DNS instructions.
+///
+/// Maps the routing and ownership records to template variables. The result is
+/// **MX-safe by construction**: only A/AAAA/CNAME/TXT records are ever emitted,
+/// so applying the template never adds or removes MX records and existing email
+/// keeps working. Variable names follow a stable convention
+/// (`ip`/`ip6`/`cname`/`www`/`txtname`/`txtvalue`); the registered template
+/// references the same names.
+pub fn template_variables(instructions: &DnsInstructions) -> Vec<(String, String)> {
+    let mut vars: Vec<(String, String)> = Vec::new();
+    for rec in &instructions.routing {
+        match rec.record_type {
+            RecordType::A => vars.push(("ip".to_owned(), rec.value.clone())),
+            RecordType::Aaaa => vars.push(("ip6".to_owned(), rec.value.clone())),
+            RecordType::Cname => {
+                // Distinguish the `www` companion from the primary CNAME target.
+                let key = if rec.name.starts_with("www.") {
+                    "www"
+                } else {
+                    "cname"
+                };
+                vars.push((key.to_owned(), rec.value.clone()));
+            }
+            // MX-safe: routing never contains MX/TXT; guard anyway.
+            RecordType::Mx | RecordType::Txt => {}
+        }
+    }
+    vars.push(("txtname".to_owned(), instructions.ownership.name.clone()));
+    vars.push(("txtvalue".to_owned(), instructions.ownership.value.clone()));
+    vars
+}
+
+/// Builds the synchronous Domain Connect "apply template" URL the operator is
+/// redirected to (Domain Connect spec, synchronous flow).
+///
+/// Format: `{urlSyncUX}/v2/domainTemplates/providers/{providerId}/services/{serviceId}/apply?domain={domain}&{vars}`.
+/// All query values are percent-encoded.
+pub fn build_sync_apply_url(
+    settings: &DomainConnectSettings,
+    template: &ApplyTemplate,
+    domain: &str,
+) -> String {
+    let mut url = format!(
+        "{}/v2/domainTemplates/providers/{}/services/{}/apply?domain={}",
+        settings.url_sync_ux,
+        encode(&template.provider_id),
+        encode(&template.service_id),
+        encode(domain),
+    );
+    for (name, value) in &template.variables {
+        url.push('&');
+        url.push_str(&encode(name));
+        url.push('=');
+        url.push_str(&encode(value));
+    }
+    url
+}
+
+/// Percent-encodes a query component, leaving only the RFC 3986 unreserved set.
+fn encode(input: &str) -> String {
+    let mut out = String::with_capacity(input.len());
+    for byte in input.bytes() {
+        match byte {
+            b'A'..=b'Z' | b'a'..=b'z' | b'0'..=b'9' | b'-' | b'.' | b'_' | b'~' => {
+                out.push(byte as char)
+            }
+            _ => out.push_str(&format!("%{byte:02X}")),
+        }
+    }
+    out
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::hostname::Hostname;
+    use crate::instructions::{generate_instructions, EdgeTargets};
+    use std::net::Ipv4Addr;
+
+    #[test]
+    fn discovery_record_name() {
+        assert_eq!(
+            domainconnect_record_name("example.com"),
+            "_domainconnect.example.com"
+        );
+    }
+
+    #[test]
+    fn parses_valid_discovery_record() {
+        let d = parse_domainconnect_record("domainconnect.Provider.example.").unwrap();
+        assert_eq!(d.api_host, "domainconnect.provider.example");
+    }
+
+    #[test]
+    fn rejects_malformed_discovery_records() {
+        assert!(parse_domainconnect_record("").is_err());
+        assert!(parse_domainconnect_record("https://evil.example/x").is_err());
+        assert!(parse_domainconnect_record("has space.example").is_err());
+        assert!(parse_domainconnect_record("nolabel").is_err());
+    }
+
+    #[test]
+    fn parses_settings() {
+        let json = r#"{
+            "providerName": "Example DNS",
+            "urlSyncUX": "https://dc.example.com/sync/",
+            "urlAsyncUX": "https://dc.example.com/async",
+            "urlAPI": "https://api.dc.example.com"
+        }"#;
+        let s = parse_settings(json).unwrap();
+        assert_eq!(s.provider_name, "Example DNS");
+        // Trailing slash is normalized off so URL building does not double it.
+        assert_eq!(s.url_sync_ux, "https://dc.example.com/sync");
+        assert_eq!(s.url_api.as_deref(), Some("https://api.dc.example.com"));
+    }
+
+    #[test]
+    fn settings_require_sync_ux() {
+        let json = r#"{"providerName":"X","urlSyncUX":""}"#;
+        assert!(parse_settings(json).is_err());
+    }
+
+    fn instructions(host: &str) -> DnsInstructions {
+        let h = Hostname::parse(host).unwrap();
+        let targets =
+            EdgeTargets::new("edge.example-cloud.net").with_ipv4(Ipv4Addr::new(203, 0, 113, 10));
+        generate_instructions(&h, &targets, "ag-verification=tok123")
+    }
+
+    #[test]
+    fn template_variables_are_mx_safe_and_carry_ownership() {
+        // Apex emits A + www CNAME + ownership TXT; never MX.
+        let vars = template_variables(&instructions("example.com"));
+        assert!(vars.iter().any(|(k, v)| k == "ip" && v == "203.0.113.10"));
+        assert!(vars.iter().any(|(k, _)| k == "www"));
+        assert!(vars
+            .iter()
+            .any(|(k, v)| k == "txtvalue" && v == "ag-verification=tok123"));
+        // MX safety: no variable ever encodes an MX record.
+        assert!(!vars.iter().any(|(k, _)| k == "mx"));
+    }
+
+    #[test]
+    fn subdomain_template_uses_cname() {
+        let vars = template_variables(&instructions("api.example.com"));
+        assert!(vars
+            .iter()
+            .any(|(k, v)| k == "cname" && v == "edge.example-cloud.net"));
+    }
+
+    #[test]
+    fn builds_sync_apply_url_with_encoding() {
+        let settings = DomainConnectSettings {
+            provider_name: "X".to_owned(),
+            url_sync_ux: "https://dc.example.com/sync".to_owned(),
+            url_async_ux: None,
+            url_api: None,
+        };
+        let template = ApplyTemplate {
+            provider_id: "anti-gravital.dev".to_owned(),
+            service_id: "attach".to_owned(),
+            variables: vec![("txtvalue".to_owned(), "ag-verification=a=b".to_owned())],
+        };
+        let url = build_sync_apply_url(&settings, &template, "example.com");
+        assert!(url.starts_with(
+            "https://dc.example.com/sync/v2/domainTemplates/providers/anti-gravital.dev/services/attach/apply?domain=example.com"
+        ));
+        // The `=` inside the token is percent-encoded so it cannot break parsing.
+        assert!(url.ends_with("&txtvalue=ag-verification%3Da%3Db"));
+    }
+
+    #[test]
+    fn ownership_variable_matches_independent_verification_record() {
+        // The Domain Connect template carries exactly the ownership record the
+        // existing verification path expects, so verification is reused unchanged.
+        let ins = instructions("api.example.com");
+        let vars = template_variables(&ins);
+        let txtname = vars
+            .iter()
+            .find(|(k, _)| k == "txtname")
+            .map(|(_, v)| v.clone());
+        let txtvalue = vars
+            .iter()
+            .find(|(k, _)| k == "txtvalue")
+            .map(|(_, v)| v.clone());
+        assert_eq!(txtname, Some(ins.ownership.name.clone()));
+        assert_eq!(txtvalue, Some(ins.ownership.value.clone()));
+    }
+}

--- a/crates/ag-domains/src/events.rs
+++ b/crates/ag-domains/src/events.rs
@@ -41,6 +41,13 @@ pub enum DomainEvent {
         /// Canonical hostname.
         hostname: String,
     },
+    /// A hostname still points at the edge but is no longer attached
+    /// (subdomain-takeover hygiene, blueprint section 15.3). It has no
+    /// attachment id because, by definition, no attachment owns it.
+    DanglingDnsDetected {
+        /// Canonical hostname pointing at the edge without an attachment.
+        hostname: String,
+    },
 }
 
 impl DomainEvent {
@@ -50,6 +57,7 @@ impl DomainEvent {
             DomainEvent::AttachmentCreated { .. } => "domain.attachment.created",
             DomainEvent::OwnershipVerified { .. } => "domain.ownership.verified",
             DomainEvent::Detached { .. } => "domain.detached",
+            DomainEvent::DanglingDnsDetected { .. } => "domain.dangling_dns_detected",
         }
     }
 
@@ -58,7 +66,8 @@ impl DomainEvent {
         match self {
             DomainEvent::AttachmentCreated { hostname, .. }
             | DomainEvent::OwnershipVerified { hostname, .. }
-            | DomainEvent::Detached { hostname, .. } => hostname,
+            | DomainEvent::Detached { hostname, .. }
+            | DomainEvent::DanglingDnsDetected { hostname } => hostname,
         }
     }
 }

--- a/crates/ag-domains/src/lib.rs
+++ b/crates/ag-domains/src/lib.rs
@@ -76,3 +76,8 @@ pub use provider::sdk::{
 
 #[cfg(feature = "acme")]
 pub use acme::wildcard::{issue_dns01_with_adapter, Dns01Desired, Dns01OrderDriver};
+
+#[cfg(feature = "acme")]
+pub use acme::ari::{
+    next_renewal_sleep, parse_renewal_info, seconds_until_ari_renewal, RenewalInfo, RenewalWindow,
+};

--- a/crates/ag-domains/src/lib.rs
+++ b/crates/ag-domains/src/lib.rs
@@ -67,3 +67,7 @@ pub mod sql_store;
 pub use attachment::DomainAttachment;
 pub use error::AgDomainsError;
 pub use hostname::{Hostname, HostnameKind};
+pub use provider::sdk::{
+    diff as zone_diff, ChangeRef, ProviderAdapter, VerifyOutcome, ZoneAdapter, ZoneChange,
+    ZonePlan, ZoneRef,
+};

--- a/crates/ag-domains/src/lib.rs
+++ b/crates/ag-domains/src/lib.rs
@@ -53,6 +53,7 @@ pub mod attachment;
 pub mod caa;
 pub mod dangling;
 pub mod diagnostics;
+pub mod domain_connect;
 pub mod events;
 pub mod hostname;
 pub mod instructions;

--- a/crates/ag-domains/src/lib.rs
+++ b/crates/ag-domains/src/lib.rs
@@ -50,6 +50,7 @@ pub mod metrics;
 // native persistence.
 pub mod attachment;
 pub mod caa;
+pub mod dangling;
 pub mod diagnostics;
 pub mod events;
 pub mod hostname;

--- a/crates/ag-domains/src/lib.rs
+++ b/crates/ag-domains/src/lib.rs
@@ -71,3 +71,6 @@ pub use provider::sdk::{
     diff as zone_diff, ChangeRef, ProviderAdapter, VerifyOutcome, ZoneAdapter, ZoneChange,
     ZonePlan, ZoneRef,
 };
+
+#[cfg(feature = "acme")]
+pub use acme::wildcard::{issue_dns01_with_adapter, Dns01Desired, Dns01OrderDriver};

--- a/crates/ag-domains/src/lib.rs
+++ b/crates/ag-domains/src/lib.rs
@@ -48,6 +48,7 @@ pub mod metrics;
 // library above is unchanged. These modules add domain attachment lifecycle,
 // ownership proof, DNS instruction generation, CAA preflight, diagnostics and
 // native persistence.
+pub mod abuse;
 pub mod attachment;
 pub mod caa;
 pub mod dangling;

--- a/crates/ag-domains/src/metrics.rs
+++ b/crates/ag-domains/src/metrics.rs
@@ -72,6 +72,37 @@ pub fn record_verification_failure() {
     counter!("ag_domains_verification_failures_total").increment(1);
 }
 
+/// Reports the number of currently active domain attachments (blueprint
+/// section 16.1). Set from a fleet view (e.g. after a control-plane mutation
+/// or list), counting attachments whose four readiness dimensions are met.
+pub fn set_active_attachments(count: u64) {
+    gauge!("ag_domains_attachments_active").set(count as f64);
+}
+
+/// Reports the number of certificates inside the renewal window (blueprint
+/// section 16.1). Derived from attachments in the `RenewalDue` TLS state.
+pub fn set_certs_expiring_soon(count: u64) {
+    gauge!("ag_domains_certs_expiring_soon").set(count as f64);
+}
+
+/// Counts a TLS certificate order (blueprint section 16.1).
+///
+/// `success` separates completed orders from failures, covering both the
+/// "orders" and "failures" dimensions on a single counter.
+pub fn record_tls_order(success: bool) {
+    counter!(
+        "ag_domains_tls_orders_total",
+        "success" => success.to_string(),
+    )
+    .increment(1);
+}
+
+/// Counts a transition of an attachment into a DNS-misconfigured state
+/// (blueprint section 16.1): wrong target, conflicting records or failed DNS.
+pub fn record_dns_misconfigured() {
+    counter!("ag_domains_dns_misconfigured_total").increment(1);
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -86,5 +117,10 @@ mod tests {
         record_attachment_created();
         record_attachment_detached();
         record_verification_failure();
+        set_active_attachments(3);
+        set_certs_expiring_soon(1);
+        record_tls_order(true);
+        record_tls_order(false);
+        record_dns_misconfigured();
     }
 }

--- a/crates/ag-domains/src/provider/mod.rs
+++ b/crates/ag-domains/src/provider/mod.rs
@@ -13,6 +13,7 @@ use crate::{
 };
 
 pub mod capabilities;
+pub mod sdk;
 
 #[cfg(feature = "cloudflare")]
 pub mod cloudflare;

--- a/crates/ag-domains/src/provider/sdk.rs
+++ b/crates/ag-domains/src/provider/sdk.rs
@@ -1,0 +1,669 @@
+//! Provider adapter SDK seam: plan/diff/apply/verify/rollback (blueprint section 11).
+//!
+//! The base [`DnsProvider`] trait is intentionally a thin CRUD surface. Real
+//! provider automation needs a richer, *declarative* contract: compute the
+//! difference between a desired record set and what the zone currently holds,
+//! apply that difference as a single reviewed plan, verify the result, and roll
+//! it back if needed. This module adds that seam without changing `DnsProvider`.
+//!
+//! Manual mode stays the default (RFC-0011 / ADR-0009): nothing here runs unless
+//! a provider adapter is explicitly configured. The seam is built *on top of*
+//! the existing CRUD trait, so the Cloudflare adapter (and any future adapter)
+//! participates through [`ProviderAdapter`] with zero adapter-specific code.
+//!
+//! The core of the seam is the pure [`diff`] function, which is fully
+//! deterministic and unit-tested independently of any network.
+
+use async_trait::async_trait;
+
+use crate::{
+    error::AgDomainsError,
+    provider::DnsProvider,
+    record::{DnsRecord, DnsRecordSpec, RecordType},
+};
+
+/// Identity of a single declarative change against a zone.
+///
+/// `diff` produces these; `apply` executes them; `rollback` executes their
+/// inverse. The variants carry enough state to be both human-reviewable (a
+/// dry-run) and reversible.
+#[derive(Debug, Clone, PartialEq, Eq, serde::Serialize, serde::Deserialize)]
+pub enum ZoneChange {
+    /// Create a record that is desired but absent from the zone.
+    Create(DnsRecordSpec),
+    /// Replace an existing record whose content/TTL/proxy state drifted.
+    Update {
+        /// Provider-assigned identity of the record to replace.
+        record_id: String,
+        /// Observed state before the change (used to build the inverse).
+        from: DnsRecordSpec,
+        /// Desired state after the change.
+        to: DnsRecordSpec,
+    },
+    /// Delete a record present in the zone scope but no longer desired.
+    Delete {
+        /// Provider-assigned identity of the record to delete.
+        record_id: String,
+        /// Observed state before deletion (used to build the inverse).
+        record: DnsRecordSpec,
+    },
+}
+
+impl ZoneChange {
+    /// The inverse change that undoes this one.
+    ///
+    /// `Create` is undone by deleting the record that `apply` produced; the
+    /// caller supplies its `record_id` (unknown until creation). `Update` and
+    /// `Delete` already carry the prior state needed to reverse them.
+    fn inverse(&self, created_id: Option<&str>) -> Option<ZoneChange> {
+        match self {
+            ZoneChange::Create(spec) => created_id.map(|id| ZoneChange::Delete {
+                record_id: id.to_owned(),
+                record: spec.clone(),
+            }),
+            ZoneChange::Update {
+                record_id,
+                from,
+                to,
+            } => Some(ZoneChange::Update {
+                record_id: record_id.clone(),
+                from: to.clone(),
+                to: from.clone(),
+            }),
+            ZoneChange::Delete { record, .. } => Some(ZoneChange::Create(record.clone())),
+        }
+    }
+}
+
+/// An ordered set of changes that reconciles a zone scope to the desired state.
+///
+/// A plan is a dry-run artifact first and an execution unit second: print it,
+/// review it, then `apply` it. An empty plan means the zone already matches.
+#[derive(Debug, Clone, Default, PartialEq, Eq, serde::Serialize, serde::Deserialize)]
+pub struct ZonePlan {
+    /// Changes to execute, in apply order (deletes and updates before creates
+    /// is not required; the operations are independent per record identity).
+    pub changes: Vec<ZoneChange>,
+}
+
+impl ZonePlan {
+    /// A plan with no changes: the zone scope already matches the desired set.
+    pub fn is_empty(&self) -> bool {
+        self.changes.is_empty()
+    }
+
+    /// Number of records to create.
+    pub fn creates(&self) -> usize {
+        self.changes
+            .iter()
+            .filter(|c| matches!(c, ZoneChange::Create(_)))
+            .count()
+    }
+
+    /// Number of records to update.
+    pub fn updates(&self) -> usize {
+        self.changes
+            .iter()
+            .filter(|c| matches!(c, ZoneChange::Update { .. }))
+            .count()
+    }
+
+    /// Number of records to delete.
+    pub fn deletes(&self) -> usize {
+        self.changes
+            .iter()
+            .filter(|c| matches!(c, ZoneChange::Delete { .. }))
+            .count()
+    }
+
+    /// One-line, human-readable summary for dry-run output and logs.
+    pub fn summary(&self) -> String {
+        format!(
+            "{} change(s): +{} create, ~{} update, -{} delete",
+            self.changes.len(),
+            self.creates(),
+            self.updates(),
+            self.deletes()
+        )
+    }
+}
+
+/// A resolved zone the adapter operates on (the provider's administration unit).
+#[derive(Debug, Clone, PartialEq, Eq, serde::Serialize, serde::Deserialize)]
+pub struct ZoneRef {
+    /// The registrable domain the zone serves (e.g. `example.com`).
+    pub domain: String,
+    /// Provider-internal zone identifier resolved by `discover`.
+    pub zone_id: String,
+}
+
+/// Handle returned by `apply`, carrying the inverse plan for `rollback`.
+///
+/// Rolling back is `apply(inverse)`: this records exactly what to do to undo a
+/// committed change set, including the identities of records that `apply`
+/// created (unknown before execution).
+#[derive(Debug, Clone, PartialEq, Eq, serde::Serialize, serde::Deserialize)]
+pub struct ChangeRef {
+    /// The plan that reverses the applied changes.
+    pub inverse: ZonePlan,
+}
+
+/// Outcome of `verify`: whether the zone now matches the plan's intent.
+#[derive(Debug, Clone, PartialEq, Eq, serde::Serialize, serde::Deserialize)]
+pub enum VerifyOutcome {
+    /// Every change's post-condition holds in the observed zone.
+    Applied,
+    /// One or more changes did not take effect; the residual drift is attached.
+    Drift {
+        /// Human-readable description of what is still wrong.
+        detail: String,
+    },
+}
+
+/// Whether a record type holds a single value per name or multiple values.
+///
+/// `A`/`AAAA`/`CNAME` are single-valued per name, so a changed address is an
+/// *update* of the same record identity. `TXT`/`MX` are multi-valued: each
+/// distinct value is its own record, so a changed value is a delete + create.
+fn is_singleton(record_type: &RecordType) -> bool {
+    matches!(
+        record_type,
+        RecordType::A | RecordType::Aaaa | RecordType::Cname
+    )
+}
+
+/// Normalized matching key for a record, distinguishing singleton vs multi-value
+/// types. Names are lowercased and stripped of a trailing dot.
+fn record_key(name: &str, record_type: &RecordType, content: &str) -> (String, RecordType, String) {
+    let name = name.trim_end_matches('.').to_ascii_lowercase();
+    if is_singleton(record_type) {
+        (name, record_type.clone(), String::new())
+    } else {
+        (name, record_type.clone(), content.to_owned())
+    }
+}
+
+/// Whether two specs are observably equal for reconciliation purposes.
+fn spec_matches(desired: &DnsRecordSpec, observed: &DnsRecord) -> bool {
+    desired.content == observed.content
+        && desired.ttl == observed.ttl
+        && desired.proxied == observed.proxied
+}
+
+/// Compute the plan that reconciles `observed` to `desired` (pure, no I/O).
+///
+/// Contract: `desired` is treated as the **authoritative set for the scope that
+/// `observed` represents**. Observed records absent from `desired` are scheduled
+/// for deletion. Callers that do not own the whole zone MUST scope `observed`
+/// to the records `ag-domains` manages (e.g. the `_acme-challenge` subtree)
+/// before calling this; otherwise unrelated records would be planned for
+/// deletion. This keeps the function total and deterministic while leaving the
+/// safety boundary explicit at the call site.
+pub fn diff(desired: &[DnsRecordSpec], observed: &[DnsRecord]) -> ZonePlan {
+    let mut changes = Vec::new();
+    let mut matched_observed = vec![false; observed.len()];
+
+    for want in desired {
+        let want_key = record_key(&want.name, &want.record_type, &want.content);
+        let found = observed.iter().enumerate().find(|(i, have)| {
+            !matched_observed[*i]
+                && record_key(&have.name, &have.record_type, &have.content) == want_key
+        });
+
+        match found {
+            Some((idx, have)) => {
+                matched_observed[idx] = true;
+                if !spec_matches(want, have) {
+                    changes.push(ZoneChange::Update {
+                        record_id: have.id.clone(),
+                        from: have.spec(),
+                        to: want.clone(),
+                    });
+                }
+            }
+            None => changes.push(ZoneChange::Create(want.clone())),
+        }
+    }
+
+    for (i, have) in observed.iter().enumerate() {
+        if !matched_observed[i] {
+            changes.push(ZoneChange::Delete {
+                record_id: have.id.clone(),
+                record: have.spec(),
+            });
+        }
+    }
+
+    ZonePlan { changes }
+}
+
+/// Declarative provider adapter SDK (blueprint section 11).
+///
+/// Adapters either implement this directly or, more commonly, obtain it for
+/// free by wrapping a [`DnsProvider`] in [`ProviderAdapter`]. The default
+/// `apply`/`verify`/`rollback` implementations are written purely in terms of
+/// `read` plus the per-record operations, so a CRUD adapter needs no extra code.
+#[async_trait]
+pub trait ZoneAdapter: Send + Sync {
+    /// Adapter name for logs and diagnostics.
+    fn name(&self) -> &'static str;
+
+    /// Resolve the provider zone that administers `domain`.
+    async fn discover(&self, domain: &str) -> Result<ZoneRef, AgDomainsError>;
+
+    /// Read the records currently present in the zone.
+    async fn read(&self, zone: &ZoneRef) -> Result<Vec<DnsRecord>, AgDomainsError>;
+
+    /// Apply a plan, returning a handle that can roll it back.
+    async fn apply(&self, zone: &ZoneRef, plan: &ZonePlan) -> Result<ChangeRef, AgDomainsError>;
+
+    /// Re-read the zone and confirm every change in `plan` took effect.
+    async fn verify(
+        &self,
+        zone: &ZoneRef,
+        plan: &ZonePlan,
+    ) -> Result<VerifyOutcome, AgDomainsError>;
+
+    /// Undo a previously applied change set.
+    async fn rollback(&self, zone: &ZoneRef, change: &ChangeRef) -> Result<(), AgDomainsError>;
+}
+
+/// Bridges any [`DnsProvider`] CRUD adapter to the declarative [`ZoneAdapter`].
+///
+/// This is what lets the existing Cloudflare adapter (and any future one)
+/// participate in plan/apply/verify/rollback without provider-specific code:
+/// the plan is executed through the CRUD trait, and the inverse plan is built
+/// from the records the provider returns.
+pub struct ProviderAdapter<P: DnsProvider> {
+    provider: P,
+}
+
+impl<P: DnsProvider> ProviderAdapter<P> {
+    /// Wrap a CRUD provider in the declarative SDK seam.
+    pub fn new(provider: P) -> Self {
+        Self { provider }
+    }
+
+    /// Borrow the underlying CRUD provider.
+    pub fn provider(&self) -> &P {
+        &self.provider
+    }
+}
+
+#[async_trait]
+impl<P: DnsProvider> ZoneAdapter for ProviderAdapter<P> {
+    fn name(&self) -> &'static str {
+        self.provider.name()
+    }
+
+    async fn discover(&self, domain: &str) -> Result<ZoneRef, AgDomainsError> {
+        let zone_id = self.provider.zone_id(domain).await?;
+        Ok(ZoneRef {
+            domain: domain.to_owned(),
+            zone_id,
+        })
+    }
+
+    async fn read(&self, zone: &ZoneRef) -> Result<Vec<DnsRecord>, AgDomainsError> {
+        self.provider.list_records(&zone.zone_id).await
+    }
+
+    async fn apply(&self, zone: &ZoneRef, plan: &ZonePlan) -> Result<ChangeRef, AgDomainsError> {
+        // Build the inverse as we go: creates need the id the provider assigns.
+        let mut inverse = Vec::with_capacity(plan.changes.len());
+        for change in &plan.changes {
+            match change {
+                ZoneChange::Create(spec) => {
+                    let created = self.provider.create_record(&zone.zone_id, spec).await?;
+                    if let Some(inv) = change.inverse(Some(&created.id)) {
+                        inverse.push(inv);
+                    }
+                }
+                ZoneChange::Update { record_id, to, .. } => {
+                    self.provider
+                        .update_record(&zone.zone_id, record_id, to)
+                        .await?;
+                    if let Some(inv) = change.inverse(None) {
+                        inverse.push(inv);
+                    }
+                }
+                ZoneChange::Delete { record_id, .. } => {
+                    self.provider
+                        .delete_record(&zone.zone_id, record_id)
+                        .await?;
+                    if let Some(inv) = change.inverse(None) {
+                        inverse.push(inv);
+                    }
+                }
+            }
+        }
+        // Rollback undoes changes in reverse application order.
+        inverse.reverse();
+        Ok(ChangeRef {
+            inverse: ZonePlan { changes: inverse },
+        })
+    }
+
+    async fn verify(
+        &self,
+        zone: &ZoneRef,
+        plan: &ZonePlan,
+    ) -> Result<VerifyOutcome, AgDomainsError> {
+        let observed = self.read(zone).await?;
+        for change in &plan.changes {
+            let ok = match change {
+                ZoneChange::Create(spec) | ZoneChange::Update { to: spec, .. } => observed
+                    .iter()
+                    .any(|r| spec_matches(spec, r) && same_record(spec, r)),
+                ZoneChange::Delete { record, .. } => {
+                    !observed.iter().any(|r| same_record(record, r))
+                }
+            };
+            if !ok {
+                return Ok(VerifyOutcome::Drift {
+                    detail: format!("change not realized: {change:?}"),
+                });
+            }
+        }
+        Ok(VerifyOutcome::Applied)
+    }
+
+    async fn rollback(&self, zone: &ZoneRef, change: &ChangeRef) -> Result<(), AgDomainsError> {
+        self.apply(zone, &change.inverse).await.map(|_| ())
+    }
+}
+
+/// Whether an observed record has the same name+type+content as a spec.
+fn same_record(spec: &DnsRecordSpec, observed: &DnsRecord) -> bool {
+    record_key(&spec.name, &spec.record_type, &spec.content)
+        == record_key(&observed.name, &observed.record_type, &observed.content)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::collections::HashMap;
+    use std::sync::Mutex;
+
+    fn spec(name: &str, rt: RecordType, content: &str, ttl: u32) -> DnsRecordSpec {
+        DnsRecordSpec {
+            name: name.to_owned(),
+            record_type: rt,
+            content: content.to_owned(),
+            ttl,
+            proxied: false,
+        }
+    }
+
+    fn record(id: &str, name: &str, rt: RecordType, content: &str, ttl: u32) -> DnsRecord {
+        DnsRecord {
+            id: id.to_owned(),
+            zone_id: "zone-1".to_owned(),
+            name: name.to_owned(),
+            record_type: rt,
+            content: content.to_owned(),
+            ttl,
+            proxied: false,
+        }
+    }
+
+    #[test]
+    fn diff_empty_when_matching() {
+        let desired = vec![spec("api.example.com", RecordType::A, "192.0.2.1", 300)];
+        let observed = vec![record(
+            "r1",
+            "api.example.com",
+            RecordType::A,
+            "192.0.2.1",
+            300,
+        )];
+        assert!(diff(&desired, &observed).is_empty());
+    }
+
+    #[test]
+    fn diff_creates_missing() {
+        let desired = vec![spec("api.example.com", RecordType::A, "192.0.2.1", 300)];
+        let plan = diff(&desired, &[]);
+        assert_eq!(plan.creates(), 1);
+        assert_eq!(plan.changes.len(), 1);
+    }
+
+    #[test]
+    fn diff_updates_singleton_content_change() {
+        let desired = vec![spec("api.example.com", RecordType::A, "192.0.2.2", 300)];
+        let observed = vec![record(
+            "r1",
+            "api.example.com",
+            RecordType::A,
+            "192.0.2.1",
+            300,
+        )];
+        let plan = diff(&desired, &observed);
+        assert_eq!(plan.updates(), 1);
+        assert_eq!(plan.creates(), 0);
+        assert_eq!(plan.deletes(), 0);
+    }
+
+    #[test]
+    fn diff_updates_on_ttl_only_change() {
+        let desired = vec![spec("api.example.com", RecordType::A, "192.0.2.1", 60)];
+        let observed = vec![record(
+            "r1",
+            "api.example.com",
+            RecordType::A,
+            "192.0.2.1",
+            300,
+        )];
+        assert_eq!(diff(&desired, &observed).updates(), 1);
+    }
+
+    #[test]
+    fn diff_deletes_unmanaged_in_scope() {
+        let observed = vec![record(
+            "r1",
+            "old.example.com",
+            RecordType::A,
+            "192.0.2.9",
+            300,
+        )];
+        let plan = diff(&[], &observed);
+        assert_eq!(plan.deletes(), 1);
+    }
+
+    #[test]
+    fn diff_txt_value_change_is_delete_plus_create() {
+        // TXT is multi-valued: a changed value is a new record, not an update.
+        let desired = vec![spec(
+            "_acme-challenge.example.com",
+            RecordType::Txt,
+            "new",
+            60,
+        )];
+        let observed = vec![record(
+            "r1",
+            "_acme-challenge.example.com",
+            RecordType::Txt,
+            "old",
+            60,
+        )];
+        let plan = diff(&desired, &observed);
+        assert_eq!(plan.creates(), 1, "new TXT value created");
+        assert_eq!(plan.deletes(), 1, "old TXT value removed");
+        assert_eq!(plan.updates(), 0);
+    }
+
+    #[test]
+    fn diff_name_is_case_and_trailing_dot_insensitive() {
+        let desired = vec![spec("API.Example.com", RecordType::A, "192.0.2.1", 300)];
+        let observed = vec![record(
+            "r1",
+            "api.example.com.",
+            RecordType::A,
+            "192.0.2.1",
+            300,
+        )];
+        assert!(diff(&desired, &observed).is_empty());
+    }
+
+    /// Minimal in-memory `DnsProvider` for SDK seam tests (no network).
+    struct MockProvider {
+        records: Mutex<HashMap<String, DnsRecord>>,
+        seq: Mutex<u64>,
+    }
+
+    impl MockProvider {
+        fn new() -> Self {
+            Self {
+                records: Mutex::new(HashMap::new()),
+                seq: Mutex::new(0),
+            }
+        }
+
+        fn seed(&self, rec: DnsRecord) {
+            self.records.lock().unwrap().insert(rec.id.clone(), rec);
+        }
+    }
+
+    #[async_trait]
+    impl DnsProvider for MockProvider {
+        fn name(&self) -> &'static str {
+            "mock"
+        }
+
+        async fn zone_id(&self, _domain: &str) -> Result<String, AgDomainsError> {
+            Ok("zone-1".to_owned())
+        }
+
+        async fn list_records(&self, _zone_id: &str) -> Result<Vec<DnsRecord>, AgDomainsError> {
+            Ok(self.records.lock().unwrap().values().cloned().collect())
+        }
+
+        async fn create_record(
+            &self,
+            zone_id: &str,
+            spec: &DnsRecordSpec,
+        ) -> Result<DnsRecord, AgDomainsError> {
+            let mut seq = self.seq.lock().unwrap();
+            *seq += 1;
+            let id = format!("rec-{seq}");
+            let rec = DnsRecord {
+                id: id.clone(),
+                zone_id: zone_id.to_owned(),
+                name: spec.name.clone(),
+                record_type: spec.record_type.clone(),
+                content: spec.content.clone(),
+                ttl: spec.ttl,
+                proxied: spec.proxied,
+            };
+            self.records.lock().unwrap().insert(id, rec.clone());
+            Ok(rec)
+        }
+
+        async fn update_record(
+            &self,
+            zone_id: &str,
+            record_id: &str,
+            spec: &DnsRecordSpec,
+        ) -> Result<DnsRecord, AgDomainsError> {
+            let mut records = self.records.lock().unwrap();
+            let rec = records
+                .get_mut(record_id)
+                .ok_or_else(|| AgDomainsError::RecordNotFound(record_id.to_owned()))?;
+            rec.zone_id = zone_id.to_owned();
+            rec.name = spec.name.clone();
+            rec.record_type = spec.record_type.clone();
+            rec.content = spec.content.clone();
+            rec.ttl = spec.ttl;
+            rec.proxied = spec.proxied;
+            Ok(rec.clone())
+        }
+
+        async fn delete_record(
+            &self,
+            _zone_id: &str,
+            record_id: &str,
+        ) -> Result<(), AgDomainsError> {
+            self.records
+                .lock()
+                .unwrap()
+                .remove(record_id)
+                .map(|_| ())
+                .ok_or_else(|| AgDomainsError::RecordNotFound(record_id.to_owned()))
+        }
+    }
+
+    #[tokio::test]
+    async fn apply_verify_roundtrip_through_provider_adapter() {
+        let adapter = ProviderAdapter::new(MockProvider::new());
+        let zone = adapter.discover("example.com").await.unwrap();
+
+        let desired = vec![
+            spec("api.example.com", RecordType::A, "192.0.2.1", 300),
+            spec("_acme-challenge.example.com", RecordType::Txt, "token", 60),
+        ];
+        let observed = adapter.read(&zone).await.unwrap();
+        let plan = diff(&desired, &observed);
+        assert_eq!(plan.creates(), 2);
+
+        let change_ref = adapter.apply(&zone, &plan).await.unwrap();
+        assert_eq!(
+            adapter.verify(&zone, &plan).await.unwrap(),
+            VerifyOutcome::Applied
+        );
+
+        // Second diff is a no-op: the zone now matches desired.
+        let observed = adapter.read(&zone).await.unwrap();
+        assert!(diff(&desired, &observed).is_empty());
+
+        // Rollback restores the original (empty) state.
+        adapter.rollback(&zone, &change_ref).await.unwrap();
+        assert!(adapter.read(&zone).await.unwrap().is_empty());
+    }
+
+    #[tokio::test]
+    async fn rollback_restores_prior_record_content() {
+        let provider = MockProvider::new();
+        provider.seed(record(
+            "r1",
+            "api.example.com",
+            RecordType::A,
+            "192.0.2.1",
+            300,
+        ));
+        let adapter = ProviderAdapter::new(provider);
+        let zone = adapter.discover("example.com").await.unwrap();
+
+        let desired = vec![spec("api.example.com", RecordType::A, "192.0.2.2", 300)];
+        let observed = adapter.read(&zone).await.unwrap();
+        let plan = diff(&desired, &observed);
+        assert_eq!(plan.updates(), 1);
+
+        let change_ref = adapter.apply(&zone, &plan).await.unwrap();
+        let after = adapter.read(&zone).await.unwrap();
+        assert_eq!(after[0].content, "192.0.2.2");
+
+        adapter.rollback(&zone, &change_ref).await.unwrap();
+        let restored = adapter.read(&zone).await.unwrap();
+        assert_eq!(
+            restored[0].content, "192.0.2.1",
+            "rollback restores content"
+        );
+    }
+
+    #[test]
+    fn plan_summary_is_human_readable() {
+        let plan = ZonePlan {
+            changes: vec![
+                ZoneChange::Create(spec("a.example.com", RecordType::A, "192.0.2.1", 60)),
+                ZoneChange::Delete {
+                    record_id: "r1".to_owned(),
+                    record: spec("b.example.com", RecordType::A, "192.0.2.2", 60),
+                },
+            ],
+        };
+        assert_eq!(
+            plan.summary(),
+            "2 change(s): +1 create, ~0 update, -1 delete"
+        );
+    }
+}

--- a/crates/ag-edge/Cargo.toml
+++ b/crates/ag-edge/Cargo.toml
@@ -31,6 +31,10 @@ tls = ["server", "dep:rustls", "dep:tokio-rustls", "dep:rustls-pki-types", "dep:
 # ag-domains control plane (ADR-0012 architecture).
 ag-domains = { path = "../ag-domains", version = "0.0.0", default-features = false }
 serde = { workspace = true }
+# Native observability (blueprint section 16.1). The `metrics` facade is a no-op
+# until a recorder is registered, so it adds no runtime cost to the edge by
+# default and pulls in no external service (CLAUDE.md rule 9: native observability).
+metrics = { workspace = true }
 
 # server feature
 axum = { workspace = true, optional = true }

--- a/crates/ag-edge/src/lib.rs
+++ b/crates/ag-edge/src/lib.rs
@@ -27,6 +27,7 @@
 #![forbid(unsafe_code)]
 
 pub mod challenge;
+pub mod metrics;
 pub mod redirect;
 pub mod router;
 pub mod tls;

--- a/crates/ag-edge/src/metrics.rs
+++ b/crates/ag-edge/src/metrics.rs
@@ -1,0 +1,44 @@
+//! Edge data-plane metrics exported to `ag-observe` (blueprint section 16.1).
+//!
+//! Records route-resolution latency and the route cache hit/miss split (from
+//! which a hit-ratio is derived on the dashboard). Calls are no-ops when no
+//! recorder is registered, so the edge stays zero-cost by default.
+
+use metrics::{counter, histogram};
+
+/// Records the latency of a single hostname route resolution, labelled by the
+/// resolution outcome (`custom`, `existing`, `fallback`, `unknown`).
+pub fn record_route_resolution(outcome: &'static str, seconds: f64) {
+    histogram!(
+        "ag_edge_route_resolution_seconds",
+        "outcome" => outcome,
+    )
+    .record(seconds);
+}
+
+/// Records a route-cache lookup as a hit or a miss.
+///
+/// A hit is a hostname that matched a custom binding (exact or wildcard); a miss
+/// is a hostname with no custom binding (it falls through to the legacy resolver
+/// or the global fallback). The hit-ratio is `hits / (hits + misses)`.
+pub fn record_route_cache_lookup(hit: bool) {
+    if hit {
+        counter!("ag_edge_route_cache_hits_total").increment(1);
+    } else {
+        counter!("ag_edge_route_cache_misses_total").increment(1);
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn metrics_do_not_panic() {
+        // The calls must not panic even when no recorder is registered.
+        record_route_resolution("custom", 0.000_01);
+        record_route_resolution("fallback", 0.0);
+        record_route_cache_lookup(true);
+        record_route_cache_lookup(false);
+    }
+}

--- a/crates/ag-edge/src/router.rs
+++ b/crates/ag-edge/src/router.rs
@@ -111,6 +111,31 @@ pub fn resolve_hostname(
     hostname: &str,
     legacy: impl Fn(&str) -> Option<String>,
 ) -> RouteResolution {
+    let started = std::time::Instant::now();
+    let resolution = resolve_hostname_inner(cache, hostname, legacy);
+
+    // Edge observability (blueprint section 16.1): route-resolution latency and
+    // the cache hit/miss split. A custom binding is a cache hit; anything else
+    // (legacy, fallback) is a miss. `Unknown` is a malformed host, not a lookup.
+    let outcome = match &resolution {
+        RouteResolution::Custom(_) => "custom",
+        RouteResolution::Existing(_) => "existing",
+        RouteResolution::ExistingFallback => "fallback",
+        RouteResolution::Unknown => "unknown",
+    };
+    crate::metrics::record_route_resolution(outcome, started.elapsed().as_secs_f64());
+    if !matches!(resolution, RouteResolution::Unknown) {
+        crate::metrics::record_route_cache_lookup(matches!(resolution, RouteResolution::Custom(_)));
+    }
+
+    resolution
+}
+
+fn resolve_hostname_inner(
+    cache: &BindingCache,
+    hostname: &str,
+    legacy: impl Fn(&str) -> Option<String>,
+) -> RouteResolution {
     let normalized = match Hostname::parse(hostname) {
         Ok(h) => h.ascii().to_owned(),
         Err(_) => return RouteResolution::Unknown,

--- a/crates/ag-workers/src/admission.rs
+++ b/crates/ag-workers/src/admission.rs
@@ -14,7 +14,17 @@ pub enum AdmissionOutcome {
     RejectedQueueFull,
     /// Rejected because the payload exceeds the size limit.
     RejectedPayloadTooLarge,
-    /// Rejected by a rate limiter.
+    /// Rejected by a per-queue admission rate limiter.
+    ///
+    /// RESERVED (RFC-0012 section 18, issue #113): this is RFC-sanctioned
+    /// admission vocabulary and part of the `ag_workers_backpressure_total{reason}`
+    /// label space, but it is intentionally **not produced by any admission path
+    /// today**. The two implemented rejections are [`Self::RejectedQueueFull`]
+    /// (depth) and [`Self::RejectedPayloadTooLarge`] (size). A per-queue rate
+    /// limiter that yields this outcome changes the admission contract and is
+    /// therefore gated behind a future RFC/ADR; until then the variant is kept
+    /// reserved (not deleted) so the metric label space and the RFC vocabulary
+    /// stay stable. Its `as_str` mapping is exercised by a unit test.
     RejectedRateLimited,
     /// Rejected because the payload was invalid.
     RejectedInvalidPayload,
@@ -100,5 +110,30 @@ mod tests {
         );
         assert!(AdmissionOutcome::Accepted.is_accepted());
         assert!(!AdmissionOutcome::RejectedRateLimited.is_accepted());
+    }
+
+    /// RESERVED contract (issue #113): no `from_result` mapping yields
+    /// `RejectedRateLimited`. The variant exists only as RFC-0012 section 18
+    /// vocabulary and metric label space until a per-queue rate limiter is added
+    /// behind a future RFC. This test fails loudly if a mapping starts producing
+    /// it without the contract being revisited.
+    #[test]
+    fn rate_limited_is_reserved_and_never_produced_by_from_result() {
+        let cases: [Result<(), QueueError>; 4] = [
+            Ok(()),
+            Err(QueueError::Full("q".into())),
+            Err(QueueError::PayloadTooLarge {
+                actual: 10,
+                limit: 2,
+            }),
+            Err(QueueError::NotFound(JobId::new())),
+        ];
+        for case in &cases {
+            assert_ne!(
+                AdmissionOutcome::from_result(case),
+                AdmissionOutcome::RejectedRateLimited,
+                "RejectedRateLimited must stay reserved (not produced)"
+            );
+        }
     }
 }

--- a/crates/ag-workers/src/queue/postgres.rs
+++ b/crates/ag-workers/src/queue/postgres.rs
@@ -10,7 +10,7 @@ use ag_data::DbPool;
 use async_trait::async_trait;
 use chrono::{DateTime, Utc};
 use sqlx::postgres::PgRow;
-use sqlx::{Postgres, Row, Transaction};
+use sqlx::{Postgres, Row};
 
 use crate::ids::{JobId, JobKind, QueueName, TenantId, WorkerId};
 use crate::job::{JobEnvelope, JobPriority, JobStatus, NewJob};
@@ -68,21 +68,19 @@ impl PostgresQueue {
             .map_err(|e| QueueError::Backend(e.to_string()))
     }
 
-    /// Transactional enqueue: the job insert participates in the caller's `ag-data`
-    /// transaction, so the job and the caller's writes commit atomically (the
-    /// transactional-outbox property without a separate outbox table).
-    ///
-    /// Takes a raw `sqlx::Transaction` until `ag-data` exposes a canonical handle.
-    // TECH-DEBT (issue #110): replace the raw `sqlx::Transaction` with an `ag-data`
-    // transaction handle; decision recorded in ADR-0013 §6.
+    /// Transactional enqueue: the job insert participates in the caller's
+    /// [`ag_data::AgTx`] transaction, so the job and the caller's writes commit
+    /// atomically (the transactional-outbox property without a separate outbox
+    /// table). Going through `ag-data`'s canonical handle keeps the raw `sqlx`
+    /// transaction type out of call sites (ADR-0013 section 6).
     pub async fn enqueue_in_tx(
         &self,
-        tx: &mut Transaction<'_, Postgres>,
+        tx: &mut ag_data::AgTx,
         job: NewJob,
     ) -> Result<JobId, QueueError> {
         let env = job.into_envelope(Utc::now());
         bind_insert(&env)
-            .execute(&mut **tx)
+            .execute(tx.as_executor())
             .await
             .map_err(backend_err)?;
         Ok(env.id)

--- a/crates/ag-workers/tests/postgres_queue.rs
+++ b/crates/ag-workers/tests/postgres_queue.rs
@@ -116,7 +116,7 @@ async fn enqueue_in_tx_rolls_back_with_caller() {
     let queue = QueueName::new("mail");
 
     // Rollback: the job must not survive.
-    let mut tx = pool.begin().await.unwrap();
+    let mut tx = ag_data::AgTx::begin(&pool).await.unwrap();
     backend
         .enqueue_in_tx(&mut tx, unit_job("t", "mail"))
         .await
@@ -125,7 +125,7 @@ async fn enqueue_in_tx_rolls_back_with_caller() {
     assert_eq!(backend.depth(&queue).await.unwrap().total(), 0);
 
     // Commit: the job survives.
-    let mut tx = pool.begin().await.unwrap();
+    let mut tx = ag_data::AgTx::begin(&pool).await.unwrap();
     backend
         .enqueue_in_tx(&mut tx, unit_job("t", "mail"))
         .await

--- a/docs/adr/0013-ag-workers-execution-model.md
+++ b/docs/adr/0013-ag-workers-execution-model.md
@@ -82,11 +82,12 @@ closes.
    - **Cancellation:** add `tokio-util` (0.7, `default-features = false`) to the
      workspace and use `CancellationToken`. It is the only genuinely new dependency;
      everything else reuses existing workspace deps.
-   - **`enqueue_in_tx`:** accepts `&mut sqlx::Transaction<'_, Postgres>` behind the
-     `postgres` feature. `ag-data` exposes no canonical transaction handle (`AgTx`)
-     today; this matches `ag-mail`'s existing raw-sqlx usage and does not modify
-     `ag-data`. The gap is tracked as a GitHub Issue (label `tech-debt`, per
-     CLAUDE.md rule 29; `docs/DEBT.md` is frozen); a canonical `AgTx` is a future RFC.
+   - **`enqueue_in_tx`:** originally accepted `&mut sqlx::Transaction<'_, Postgres>`
+     behind the `postgres` feature because `ag-data` exposed no canonical
+     transaction handle. **Resolved (issue #110):** `ag-data` now exposes
+     `AgTx` (a thin wrapper over `sqlx::Transaction`, `ag-data` being the
+     sanctioned `sqlx` boundary), and `enqueue_in_tx` accepts `&mut ag_data::AgTx`.
+     Call sites no longer name the raw `sqlx` transaction type.
 
 7. **Authorization to implement before the pre-Phase-5 gate closes.** The owner
    authorizes the work now because it is additive, feature-gated, native-by-default

--- a/docs/ag-domains/README.md
+++ b/docs/ag-domains/README.md
@@ -20,7 +20,8 @@ historical DEBT-025).
 
 ## Start here
 
-- Tutorial: `tutorials/attach-first-domain.md`
+- Tutorial: `tutorials/attach-first-domain.md`,
+  `tutorials/attach-apex.md`, `tutorials/attach-subdomain.md`
 - How-to:
   - `how-to/connect-providers.md` (per-provider DNS record locations)
   - `how-to/serve-and-api.md` (run the edge listeners + REST API)
@@ -30,9 +31,12 @@ historical DEBT-025).
   `reference/dns-record-matrix.md`, `reference/events-and-metrics.md`,
   `reference/provider-capability-matrix.md`,
   `reference/provider-adapter-sdk.md` (plan/diff/apply/verify/rollback),
-  `reference/abuse-controls.md` (per-tenant limits + global ACME queue)
+  `reference/abuse-controls.md` (per-tenant limits + global ACME queue),
+  `reference/tls-lifecycle.md`, `reference/security-model.md`,
+  `reference/migration-compatibility.md`
 - Explanation: `explanation/apex-vs-subdomain.md`,
-  `explanation/why-txt-ownership.md`
+  `explanation/why-txt-ownership.md`, `explanation/http01-vs-dns01.md`,
+  `explanation/routing-host-sni.md`, `explanation/purchase-vs-attachment.md`
 
 Remaining work and technical debt are tracked in GitHub Issues (CLAUDE.md rule
 29), not in repo files: see issue #76 (ag-domains remaining work / tech debt).

--- a/docs/ag-domains/README.md
+++ b/docs/ag-domains/README.md
@@ -28,7 +28,8 @@ historical DEBT-025).
   - `how-to/troubleshoot.md` (DNS + certificate issuance)
 - Reference: `reference/cli.md`, `reference/state-machine.md`,
   `reference/dns-record-matrix.md`, `reference/events-and-metrics.md`,
-  `reference/provider-capability-matrix.md`
+  `reference/provider-capability-matrix.md`,
+  `reference/provider-adapter-sdk.md` (plan/diff/apply/verify/rollback)
 - Explanation: `explanation/apex-vs-subdomain.md`,
   `explanation/why-txt-ownership.md`
 

--- a/docs/ag-domains/README.md
+++ b/docs/ag-domains/README.md
@@ -29,7 +29,8 @@ historical DEBT-025).
 - Reference: `reference/cli.md`, `reference/state-machine.md`,
   `reference/dns-record-matrix.md`, `reference/events-and-metrics.md`,
   `reference/provider-capability-matrix.md`,
-  `reference/provider-adapter-sdk.md` (plan/diff/apply/verify/rollback)
+  `reference/provider-adapter-sdk.md` (plan/diff/apply/verify/rollback),
+  `reference/abuse-controls.md` (per-tenant limits + global ACME queue)
 - Explanation: `explanation/apex-vs-subdomain.md`,
   `explanation/why-txt-ownership.md`
 

--- a/docs/ag-domains/explanation/http01-vs-dns01.md
+++ b/docs/ag-domains/explanation/http01-vs-dns01.md
@@ -1,0 +1,43 @@
+# Explanation — HTTP-01 vs DNS-01
+
+ACME offers more than one way to prove you control a domain. `ag-domains` uses
+two: HTTP-01 and DNS-01. Understanding the difference explains why wildcards are
+treated specially.
+
+## HTTP-01
+
+The CA gives you a token; you serve it at
+`http://<host>/.well-known/acme-challenge/<token>`. The CA fetches that URL over
+HTTP. If it gets the expected content, control of *that exact hostname* is
+proven.
+
+- Pros: nothing to change in DNS; the `ag-edge` HTTP-01 responder serves it
+  automatically.
+- Limits: proves only the exact hostname requested. It **cannot** prove a
+  wildcard, because there is no single URL that represents `*.example.com`.
+
+Used for exact apex and subdomain hostnames (`tls_mode = managed_http01`).
+
+## DNS-01
+
+The CA gives you a key authorization; you publish it as a TXT record at
+`_acme-challenge.<domain>`. The CA queries DNS for that record.
+
+- Pros: proves control of the whole domain, including wildcards. Works even when
+  no HTTP server is reachable yet.
+- Cost: requires writing a DNS record. You can do it manually, or let a provider
+  adapter publish and clean it up automatically
+  (`reference/provider-adapter-sdk.md`).
+
+Used for wildcards (`tls_mode = managed_dns01`), where it is mandatory, and
+available for any hostname.
+
+## Why wildcards force DNS-01
+
+A wildcard certificate covers every single-label subdomain. The CA will only
+issue it when control of the parent domain is proven, and the only ACME challenge
+that proves the parent (not one specific host) is DNS-01. That is why attaching
+`*.example.com` sets `managed_dns01`.
+
+See `reference/tls-lifecycle.md` for how each challenge fits into issuance and
+renewal.

--- a/docs/ag-domains/explanation/purchase-vs-attachment.md
+++ b/docs/ag-domains/explanation/purchase-vs-attachment.md
@@ -1,0 +1,41 @@
+# Explanation — purchase vs attachment
+
+A frequent confusion: "attaching" a domain to Anti-Gravital is not the same as
+"buying" a domain. `ag-domains` does the second thing only.
+
+## Purchase (out of scope)
+
+Buying, transferring or renewing a domain is a commercial transaction with a
+registrar (the company that sells the name). `ag-domains` is **not** a registrar
+and deliberately does not do this (RFC-0011 §3.2). You buy your domain wherever
+you like — any registrar works.
+
+A future, separate module (`ag-registrars`) may cover purchase/transfer/renewal
+commerce; it is intentionally kept out of the attachment lifecycle so attaching
+stays provider-agnostic.
+
+## Attachment (what ag-domains does)
+
+Attachment is the operational act of pointing a domain you already own at an
+Anti-Gravital project and proving you control it:
+
+1. declare the attachment and get the exact DNS records to publish,
+2. prove ownership with the `_ag-domain` TXT record,
+3. route the hostname to the edge,
+4. secure it with a managed TLS certificate.
+
+Attachment is provider-agnostic: it works the same whether you bought the domain
+from one registrar or another, and whether you publish records by hand or via a
+provider adapter.
+
+## Why the separation matters
+
+Keeping purchase out of attachment means:
+
+- no lock-in to a particular registrar,
+- the attachment lifecycle stays simple and auditable,
+- the security model (ownership proof, tombstones, fail-closed routing) does not
+  depend on any billing relationship.
+
+See `reference/state-machine.md` for the attachment lifecycle and
+`reference/security-model.md` for the guarantees it provides.

--- a/docs/ag-domains/explanation/routing-host-sni.md
+++ b/docs/ag-domains/explanation/routing-host-sni.md
@@ -1,0 +1,43 @@
+# Explanation — routing by Host and SNI
+
+The edge has to answer one question for every request: which tenant does this
+hostname belong to? It uses two signals — the HTTP `Host` (or HTTP/2
+`:authority`) header and the TLS SNI — and a deliberately conservative
+resolution order.
+
+## Two layers, one identity
+
+- **SNI** is sent during the TLS handshake, before any HTTP bytes. The edge uses
+  it to pick the right certificate (`ag_edge::tls::SniCertStore`).
+- **Host / :authority** is the HTTP-layer hostname. The edge uses it to resolve
+  the route (`ag_edge::resolve_hostname`).
+
+Both must agree on the same attached hostname for a request to be served as that
+tenant.
+
+## Resolution precedence
+
+`resolve_hostname` tries, in order (RFC-0011 §14.2):
+
+1. an exact custom hostname binding,
+2. a wildcard custom hostname binding,
+3. the caller-supplied legacy default route,
+4. the existing global fallback.
+
+Exact wins over wildcard, so `api.example.com` and `*.example.com` can coexist
+and `api` goes to its exact target. A single-label rule applies to wildcards:
+`*.example.com` matches `a.example.com` but not `a.b.example.com`, matching TLS
+wildcard semantics.
+
+## Fail closed
+
+If a hostname matches no binding and the legacy resolver returns nothing, the
+result is the global fallback — never another tenant's binding. A malformed host
+is `Unknown`. This is the security property that prevents one tenant's request
+from being served as another's (`reference/security-model.md`).
+
+## Observability
+
+Every resolution records its latency and whether it was a cache hit (a custom
+binding matched) or a miss (`reference/events-and-metrics.md`), so the route
+cache hit-ratio is visible in dashboards.

--- a/docs/ag-domains/how-to/configure-wildcard.md
+++ b/docs/ag-domains/how-to/configure-wildcard.md
@@ -22,7 +22,11 @@ be issued via the ACME **DNS-01** challenge (HTTP-01 cannot prove a wildcard).
 
 During certificate issuance a `_acme-challenge.example.com` TXT record is also
 required (DNS-01). With the manual flow you publish it when prompted; with a
-`read_apply` provider adapter it is created and cleaned up automatically.
+provider adapter the record is created and cleaned up automatically by the
+DNS-01 orchestration (`ag_domains::issue_dns01_with_adapter`), which publishes
+the challenge records through the provider adapter SDK and tears them down once
+the order finalizes. The managed scope is strictly the `_acme-challenge` subtree,
+so no other DNS record is touched. See `reference/provider-adapter-sdk.md`.
 
 ## Why stricter validation
 

--- a/docs/ag-domains/how-to/domain-connect.md
+++ b/docs/ag-domains/how-to/domain-connect.md
@@ -4,20 +4,28 @@
 service provider and a DNS provider, so the operator authorizes a template
 instead of pasting records by hand.
 
-Status: Domain Connect automation is a later phase (RFC-0011 phase E; see
-`docs/DEBT.md`, DEBT-025). Until then, use the manual flow — it works at every
-provider, including Domain-Connect-capable ones.
+Status: the discovery and template-generation core is implemented in
+`ag_domains::domain_connect` (blueprint §12). The HTTP fetch of the provider
+settings and the live redirect are the integration boundary; the manual flow
+remains the default and works at every provider, including Domain-Connect-capable
+ones.
 
-## Intended flow (phase E)
+## Flow
 
-1. Discover the provider's `_domainconnect` record for the domain.
-2. Generate a Domain Connect template for the Anti-Gravital records (apex/www/
-   subdomain attach, `_ag-domain` TXT ownership, MX-safe so existing email is
-   preserved, wildcard where supported).
-3. Redirect the operator to the DNS provider's authorization flow.
-4. Return to Anti-Gravital after confirmation.
-5. **Verify independently** — Domain Connect accelerates setup, but Anti-Gravital
-   still confirms the resulting records with `ag domains verify` / `diagnose`.
+1. Discover the provider's `_domainconnect` record for the domain
+   (`parse_domainconnect_record`).
+2. Fetch and parse the provider settings (`parse_settings`) to learn the
+   synchronous-UX base URL.
+3. Generate the template variables from the Anti-Gravital records
+   (`template_variables`) — apex `ip`/`ip6`, `www`/`cname`, and the `_ag-domain`
+   TXT ownership. The result is **MX-safe by construction**: only A/AAAA/CNAME/TXT
+   are ever emitted, so existing email is preserved.
+4. Redirect the operator to the provider's synchronous authorization flow
+   (`build_sync_apply_url`).
+5. **Verify independently** — Domain Connect accelerates setup, but the ownership
+   token and routing records it applies are exactly those
+   `generate_instructions` produces, so `ag domains verify` / `diagnose` confirm
+   the result with the same path the manual flow uses.
 
 ## Today (manual)
 

--- a/docs/ag-domains/reference/abuse-controls.md
+++ b/docs/ag-domains/reference/abuse-controls.md
@@ -1,0 +1,38 @@
+# Reference — abuse controls (blueprint section 15.6)
+
+Status: implemented (`ag_domains::abuse`).
+
+Beyond the per-registered-domain issuance counter (`ag_domains::issuance`), the
+control plane enforces three abuse dimensions. All checks are pure, lock-based
+and deterministic (no clock, no network).
+
+| Dimension | Helper | Rejection |
+|---|---|---|
+| Per-tenant attachment limit | `register_attachment(tenant)` / `release_attachment(tenant)` | `TenantAttachmentLimit` |
+| Per-tenant issuance limit | `record_issuance(tenant)` | `TenantIssuanceLimit` |
+| Global ACME issuance queue | `acquire_acme_slot()` -> `AcmePermit` | `GlobalAcmeQueueFull` |
+
+A limit of `0` means "unlimited" for that dimension, so a deployment enables
+only the controls it needs (`AbuseLimits`).
+
+## Global ACME queue
+
+`acquire_acme_slot` bounds the number of *concurrent* in-flight ACME orders
+across all tenants, so a burst cannot exhaust the CA rate budget or the issuance
+worker pool. It returns an `AcmePermit`; the slot is held only while the permit
+is alive and is freed automatically on drop (RAII), including on panic.
+
+## REST API enforcement
+
+The REST API enforces the per-tenant attachment limit when abuse controls are
+wired in:
+
+```rust
+let state = ApiState::new(store, edge)
+    .with_abuse_controls(AbuseControls::new(AbuseLimits::default()));
+```
+
+`POST /attachments` reserves a tenant slot before persisting (returning HTTP
+`429 Too Many Requests` at the limit), and `POST /attachments/{id}/detach`
+releases it. Without `with_abuse_controls`, attachments stay unbounded (prior
+behaviour). The tenant key is the attachment's project id.

--- a/docs/ag-domains/reference/events-and-metrics.md
+++ b/docs/ag-domains/reference/events-and-metrics.md
@@ -35,6 +35,26 @@ Counters/gauges/histograms via the `metrics` crate (exported through
 | `ag_domains_acme_renewal_total` | counter | `record_acme_renewal` |
 | `ag_domains_cert_days_until_expiry` | gauge | `set_cert_days_until_expiry` |
 | `ag_domains_propagation_latency_seconds` | histogram | `record_propagation_latency` |
+| `ag_domains_attachments_active` | gauge | `set_active_attachments` |
+| `ag_domains_certs_expiring_soon` | gauge | `set_certs_expiring_soon` |
+| `ag_domains_tls_orders_total` | counter | `record_tls_order` |
+| `ag_domains_dns_misconfigured_total` | counter | `record_dns_misconfigured` |
 
-The full blueprint §16.1 set (active gauge, TLS/DNS state counters, edge cache
-hit-ratio, route-resolution latency) is partially wired; see DEBT-018.
+Emission points: the REST API refreshes `ag_domains_attachments_active` and
+`ag_domains_certs_expiring_soon` (the count of attachments in the `RenewalDue`
+TLS state) after create/detach/verify and on list; `ag_domains_dns_misconfigured_total`
+increments when an attachment transitions into a DNS-caused misconfigured state
+(`recompute_lifecycle`); `ag_domains_tls_orders_total{success}` records ACME
+certificate orders.
+
+## Edge metrics (`ag_edge::metrics`)
+
+| Metric | Kind | Helper |
+|---|---|---|
+| `ag_edge_route_resolution_seconds` | histogram (label `outcome`) | `record_route_resolution` |
+| `ag_edge_route_cache_hits_total` | counter | `record_route_cache_lookup(true)` |
+| `ag_edge_route_cache_misses_total` | counter | `record_route_cache_lookup(false)` |
+
+Emitted by `resolve_hostname`: every resolution records its latency and (unless
+the host is malformed) a cache hit when a custom binding matched, a miss
+otherwise. The cache hit-ratio is `hits / (hits + misses)`.

--- a/docs/ag-domains/reference/events-and-metrics.md
+++ b/docs/ag-domains/reference/events-and-metrics.md
@@ -11,15 +11,20 @@ discards events (`NullEventSink`); use `InMemoryEventSink` (native, ordered) or
 | `domain.attachment.created` | `AttachmentCreated { id, hostname }` | REST API create |
 | `domain.ownership.verified` | `OwnershipVerified { id, hostname }` | REST verify endpoint (`POST /attachments/{id}/verify`) |
 | `domain.detached` | `Detached { id, hostname }` | REST API detach |
+| `domain.dangling_dns_detected` | `DanglingDnsDetected { hostname }` | `dangling::scan_dangling` worker (no `id`: no attachment owns it) |
 
 Wire a sink into the REST API with `ApiState::new(store, edge).with_events(sink)`.
 Events serialize to JSON with a `event` tag, e.g.
 `{"event":"detached","id":"dom_...","hostname":"example.com"}`.
 
+The dangling-DNS worker (`ag_domains::dangling`) detects hostnames that still
+point at the edge but are no longer attached (subdomain-takeover hygiene,
+blueprint §15.3) and emits `domain.dangling_dns_detected`. The edge itself keeps
+failing closed for such hostnames, so they never serve another tenant's content.
+
 Additional blueprint events (`domain.dns.routable`, `domain.tls.active`,
-`domain.activated`, `domain.tombstoned`, `domain.dangling_dns_detected`) are
-emitted as their operations land (DEBT-018); they are intentionally not modelled
-before they can fire.
+`domain.activated`, `domain.tombstoned`) are emitted as their operations land;
+they are intentionally not modelled before they can fire.
 
 ## Metrics (`ag_domains::metrics`)
 

--- a/docs/ag-domains/reference/migration-compatibility.md
+++ b/docs/ag-domains/reference/migration-compatibility.md
@@ -1,0 +1,47 @@
+# Reference — migration and compatibility
+
+How `ag-domains` and `ag-edge` evolve without breaking users.
+
+## Native-first, additive features
+
+The control plane works with no external service (ADR-0009). Everything beyond
+the native default is an opt-in Cargo feature, so enabling one never changes
+default behavior:
+
+| Feature (crate) | Adds |
+|---|---|
+| `acme` (ag-domains, default) | ACME issuance/renewal |
+| `propagation` (ag-domains, default) | resolver-backed verification |
+| `cloudflare` (ag-domains) | a `DnsProvider` adapter |
+| `api` (ag-domains) | the REST control-plane surface |
+| `sql-store` (ag-domains) | a Postgres-backed attachment store |
+| `server` / `tls` (ag-edge) | runnable HTTP / HTTPS+SNI listeners |
+
+The default store is in-memory/JSON; the SQL store is an accelerator for
+multi-node operation, not a requirement.
+
+## Store migration
+
+Attachments serialize as stable JSON (`store::JsonFileStore`), so moving from the
+in-memory/JSON store to the SQL store (or vice versa) is a data copy, not a
+schema rewrite. Tombstones migrate with attachments to preserve anti-takeover
+guarantees.
+
+## Manual flow is always available
+
+Provider automation (adapter SDK, Domain Connect, DNS-01 wildcard automation) is
+additive over the manual flow. The manual flow — print instructions, publish
+records, verify — works at every provider and reaches the same verified state, so
+adopting automation later does not invalidate existing attachments.
+
+## API stability
+
+Public APIs follow SemVer. The `DnsProvider` trait is intentionally small and
+covered by contract tests so adapters do not drift; the declarative adapter SDK
+(`reference/provider-adapter-sdk.md`) is layered on top without changing it.
+
+## Backward-compatible routing
+
+The edge router accepts a caller-supplied legacy resolver, so pre-existing
+(non-custom-domain) routing keeps working while custom-domain bindings are added
+(`explanation/routing-host-sni.md`).

--- a/docs/ag-domains/reference/provider-adapter-sdk.md
+++ b/docs/ag-domains/reference/provider-adapter-sdk.md
@@ -1,0 +1,78 @@
+# Provider adapter SDK (plan / diff / apply / verify / rollback)
+
+Status: implemented (`ag-domains::provider::sdk`). Blueprint section 11.
+
+The base `DnsProvider` trait is a thin CRUD surface (`zone_id`, `list_records`,
+`create_record`, `update_record`, `delete_record`). Real provider automation
+needs a declarative contract on top of it. The provider adapter SDK adds that
+seam **without changing `DnsProvider`** and **without changing the default**:
+manual DNS instructions remain the default path (ADR-0009); the SDK runs only
+when a provider adapter is explicitly configured.
+
+## Model
+
+| Type | Role |
+|---|---|
+| `ZoneRef` | A resolved zone: registrable `domain` + provider `zone_id`. |
+| `ZoneChange` | One declarative change: `Create`, `Update { record_id, from, to }`, `Delete { record_id, record }`. |
+| `ZonePlan` | An ordered set of `ZoneChange`. A dry-run artifact first, an execution unit second. |
+| `ChangeRef` | Returned by `apply`; carries the inverse plan so `rollback` is `apply(inverse)`. |
+| `VerifyOutcome` | `Applied`, or `Drift { detail }` if a change did not take effect. |
+
+## The pure diff
+
+`diff(desired: &[DnsRecordSpec], observed: &[DnsRecord]) -> ZonePlan` is pure and
+deterministic (no I/O), and is the core of the seam. Matching rules:
+
+- `A` / `AAAA` / `CNAME` are **single-valued** per name: a changed value is an
+  `Update` of the same record identity.
+- `TXT` / `MX` are **multi-valued**: a changed value is a `Delete` of the old
+  value plus a `Create` of the new one.
+- Names are compared case-insensitively and with any trailing dot stripped.
+
+### Deletion-scope contract
+
+`diff` treats `desired` as the **authoritative set for the scope that
+`observed` represents**. Observed records absent from `desired` are scheduled
+for deletion. Callers that do not own the whole zone MUST scope `observed` to
+the records `ag-domains` manages (for example, the `_acme-challenge` subtree)
+before calling `diff`; otherwise unrelated records would be planned for
+deletion. The boundary is explicit at the call site by design.
+
+## The adapter trait
+
+```rust
+#[async_trait]
+pub trait ZoneAdapter: Send + Sync {
+    fn name(&self) -> &'static str;
+    async fn discover(&self, domain: &str) -> Result<ZoneRef, AgDomainsError>;
+    async fn read(&self, zone: &ZoneRef) -> Result<Vec<DnsRecord>, AgDomainsError>;
+    async fn apply(&self, zone: &ZoneRef, plan: &ZonePlan) -> Result<ChangeRef, AgDomainsError>;
+    async fn verify(&self, zone: &ZoneRef, plan: &ZonePlan) -> Result<VerifyOutcome, AgDomainsError>;
+    async fn rollback(&self, zone: &ZoneRef, change: &ChangeRef) -> Result<(), AgDomainsError>;
+}
+```
+
+Adapters rarely implement this by hand. `ProviderAdapter<P: DnsProvider>` wraps
+any existing CRUD provider and gets the full seam for free: the plan is executed
+through the CRUD trait, and the inverse plan is built from the records the
+provider returns. The Cloudflare adapter participates with zero adapter-specific
+code.
+
+```rust
+use ag_domains::{ProviderAdapter, ZoneAdapter, zone_diff};
+
+let adapter = ProviderAdapter::new(provider); // any DnsProvider
+let zone = adapter.discover("example.com").await?;
+let observed = adapter.read(&zone).await?;
+let plan = zone_diff(&desired, &observed); // review plan.summary() before applying
+let change = adapter.apply(&zone, &plan).await?;
+assert!(matches!(adapter.verify(&zone, &plan).await?, VerifyOutcome::Applied));
+// adapter.rollback(&zone, &change).await?; // if needed
+```
+
+## Tests
+
+The pure `diff` cases and the apply/verify/rollback round-trip are unit-tested
+against an in-memory mock `DnsProvider` (no network) in
+`crates/ag-domains/src/provider/sdk.rs`.

--- a/docs/ag-domains/reference/security-model.md
+++ b/docs/ag-domains/reference/security-model.md
@@ -1,0 +1,57 @@
+# Reference — security model
+
+The security properties `ag-domains` and `ag-edge` enforce. This describes
+implemented behavior.
+
+## Ownership proof
+
+A domain is not routed until ownership is proven by a `_ag-domain` TXT record
+(`ownership::ownership_record_name` + a per-attachment token), checked across
+public resolvers. Ownership cannot be granted without a real DNS check: the
+default verifier never confirms (`api::NullVerifier`). See
+`explanation/why-txt-ownership.md`.
+
+## Fail-closed routing
+
+Edge route resolution never serves an unknown custom hostname another tenant's
+content. An unmatched hostname falls through to the legacy resolver or the global
+fallback, and a malformed host resolves to `Unknown`
+(`ag_edge::resolve_hostname`). Exact bindings win over wildcards. See
+`explanation/routing-host-sni.md`.
+
+## Tombstones (anti-takeover)
+
+Detaching a hostname removes the live attachment and writes a tombstone for a
+default window, blocking immediate re-attachment by another party
+(`store::Tombstone`). This closes the post-detach takeover window.
+
+## Dangling-DNS detection
+
+The `dangling` worker detects hostnames that still point at the edge but are no
+longer attached (including detached ones in their tombstone window) and emits
+`domain.dangling_dns_detected` so operators are notified. The edge keeps failing
+closed for these hostnames (blueprint §15.3).
+
+## Abuse controls
+
+Optional per-tenant attachment and issuance limits and a global ACME issuance
+queue bound fan-out and protect the CA rate budget
+(`reference/abuse-controls.md`, blueprint §15.6). The REST API returns HTTP 429
+at the per-tenant attachment limit.
+
+## CAA preflight
+
+Issuance is gated by a CAA check (RFC 8659) so a certificate is not ordered for
+a domain that has not authorized Let's Encrypt (`caa::evaluate`).
+
+## On-demand certificate issuance is restricted
+
+The edge only allows on-demand certificate issuance for hostnames with a
+verified attachment (`ag_edge::tls`), so an attacker cannot trigger issuance for
+arbitrary hostnames by sending SNI.
+
+## Native-first, minimal trust
+
+No external service is required to use the control plane (ADR-0009): the default
+store is in-memory/JSON and provider adapters are feature-gated. Fewer moving
+parts means a smaller attack surface.

--- a/docs/ag-domains/reference/tls-lifecycle.md
+++ b/docs/ag-domains/reference/tls-lifecycle.md
@@ -1,0 +1,59 @@
+# Reference — TLS certificate lifecycle
+
+How `ag-domains` issues and renews TLS certificates via ACME (Let's Encrypt).
+This describes implemented behavior in `ag_domains::acme`.
+
+## Challenge selection
+
+| Hostname kind | TLS mode | ACME challenge |
+|---|---|---|
+| Exact (apex or subdomain) | `managed_http01` | HTTP-01 |
+| Wildcard (`*.example.com`) | `managed_dns01` | DNS-01 (required) |
+| Any | `disabled` | no managed certificate |
+
+HTTP-01 proves control of a single hostname by serving a token at
+`/.well-known/acme-challenge/...` (the `ag-edge` responder). DNS-01 proves
+control by publishing an `_acme-challenge` TXT record and is the only challenge
+that can cover a wildcard. See `explanation/http01-vs-dns01.md`.
+
+## Issuance
+
+- Single hostname: `acme::renewal::issue` (or `issue_with_credentials` to reuse
+  an ACME account) drives account creation, the order, the DNS-01 challenge via
+  a `DnsProvider`, CSR generation (`rcgen`), and certificate download.
+- Wildcard / multi-SAN automation: `issue_dns01_with_adapter` publishes the
+  `_acme-challenge` records through the provider adapter SDK, finalizes the
+  order, and tears the challenge records down afterwards
+  (`reference/provider-adapter-sdk.md`). Manual DNS-01 (publish the TXT yourself)
+  stays supported.
+- Rate protection: issuance is deduplicated by SAN set and bounded per
+  registered domain (`issuance::IssuanceLimiter`), plus the optional abuse
+  controls (`reference/abuse-controls.md`).
+
+## Renewal scheduling
+
+`acme::renewal::spawn_renewal_task` runs a background task that renews before
+expiry. The sleep until the next renewal is decided by:
+
+1. **ARI (RFC 9773)** when available: the CA's suggested renewal window is
+   honored (`acme::ari`), scheduling at the window start. ARI also lets the CA
+   force early renewal during incidents. Use `spawn_renewal_task_with_ari` to
+   feed an ARI fetch hook.
+2. **`notAfter` fallback** otherwise: renew `renew_before_days` before expiry
+   (`seconds_until_renewal`).
+
+On renewal error the task retries after 24h. After each renewal the
+`ag_domains_cert_days_until_expiry` gauge is updated
+(`reference/events-and-metrics.md`).
+
+## Certificate states
+
+The attachment's `tls_status` tracks the lifecycle: `disabled`, `pending`,
+`active`, `renewal_due`, `failed`, `expired`, `retired` (set on detach). See
+`reference/state-machine.md`.
+
+## CAA preflight
+
+Before issuance, `caa::evaluate` checks the domain's CAA records (RFC 8659) to
+confirm Let's Encrypt is authorized to issue, surfacing a clear error instead of
+a failed order when it is not.

--- a/docs/ag-domains/tutorials/attach-apex.md
+++ b/docs/ag-domains/tutorials/attach-apex.md
@@ -1,0 +1,51 @@
+# Tutorial — attach an apex domain
+
+Goal: attach an apex (root) domain such as `example.com` to an Anti-Gravital
+project. Apex domains cannot use a CNAME, so they point at the edge with
+`A`/`AAAA` records (or provider CNAME-flattening / ALIAS).
+
+## 1. Attach
+
+```
+ag domains attach example.com \
+  --project my-site \
+  --edge-host edge.my-cloud.example \
+  --ip 203.0.113.10 --ip 2001:db8::10
+```
+
+The output lists the records to publish: the apex `A`/`AAAA` records, a
+recommended `www` `CNAME`, and the `_ag-domain` TXT ownership record.
+
+## 2. Publish the records
+
+Add the `A` (and `AAAA`, if you use IPv6) records at the apex, plus the `www`
+`CNAME`. If your provider offers CNAME flattening or ALIAS at the apex, you may
+use it instead of `A`/`AAAA`.
+
+## 3. Verify ownership
+
+```
+ag domains verify example.com
+```
+
+This checks the `_ag-domain` TXT record across public resolvers. Re-run until it
+reports verified (DNS can take minutes to propagate).
+
+## 4. Status and diagnosis
+
+```
+ag domains status example.com
+ag domains diagnose example.com --edge-host edge.my-cloud.example --ip 203.0.113.10
+```
+
+`status` shows the four readiness dimensions; `diagnose` compares expected vs
+observed records and points out missing or wrong ones.
+
+## Notes
+
+- No apex IPs configured means the attach output emits a note: apex domains need
+  `A`/`AAAA` (or flattening/ALIAS) to route.
+- TLS for an exact apex hostname uses the ACME HTTP-01 challenge
+  (`explanation/http01-vs-dns01.md`).
+
+See `tutorials/attach-subdomain.md` for the subdomain (CNAME) case.

--- a/docs/ag-domains/tutorials/attach-subdomain.md
+++ b/docs/ag-domains/tutorials/attach-subdomain.md
@@ -1,0 +1,48 @@
+# Tutorial — attach a subdomain
+
+Goal: attach a subdomain such as `api.example.com` to an Anti-Gravital project.
+Subdomains point at the edge with a single `CNAME`, which is simpler than the
+apex case.
+
+## 1. Attach
+
+```
+ag domains attach api.example.com \
+  --project my-site \
+  --edge-host edge.my-cloud.example
+```
+
+The output lists one routing `CNAME` (`api.example.com -> edge.my-cloud.example`)
+and the `_ag-domain` TXT ownership record. No apex IPs are needed.
+
+## 2. Publish the records
+
+Add the `CNAME` and the TXT ownership record at your DNS provider.
+
+## 3. Verify ownership
+
+```
+ag domains verify api.example.com
+```
+
+## 4. Status and diagnosis
+
+```
+ag domains status api.example.com
+ag domains diagnose api.example.com --edge-host edge.my-cloud.example
+```
+
+## Wildcards
+
+A wildcard such as `*.example.com` is a subdomain attachment with one
+difference: TLS must use the ACME DNS-01 challenge, so the attachment is created
+with `tls_mode = managed_dns01`. See `how-to/configure-wildcard.md` and
+`explanation/http01-vs-dns01.md`.
+
+## Exact vs wildcard precedence
+
+At the edge, an exact hostname binding always wins over a wildcard, so attaching
+`api.example.com` and `*.example.com` together routes `api` to its exact target.
+See `explanation/routing-host-sni.md`.
+
+See `tutorials/attach-apex.md` for the apex (`A`/`AAAA`) case.

--- a/docs/pr-drafts/issues-solver.md
+++ b/docs/pr-drafts/issues-solver.md
@@ -1,64 +1,97 @@
-# fix(ag-realtime): bound persistent event appends
+# Resolve ag-domains / ag-workers / ag-data issues (one commit per issue)
 
 ## Summary
 
-Bounds async event-persistence work, preserves the persistent NDJSON handle, and
-adds an explicit flush barrier for graceful shutdown.
+Resolves the open, in-environment-reproducible issues, one commit per issue, in
+priority then precedence order. Issues blocked on external infrastructure (live
+PostgreSQL, real-domain ACME) or on an unapproved RFC are not closed here; for
+the RFC-gated ones a design RFC is drafted instead so the maintainer can approve
+and implement.
+
+- **#79 (p2) provider adapter SDK seam:** `provider::sdk` adds a declarative
+  plan/diff/apply/verify/rollback layer over `DnsProvider`; pure `diff` plus a
+  `ProviderAdapter<P>` bridge so Cloudflare participates with no extra code.
+- **#85 (p2) DNS-01 wildcard automation:** `acme::wildcard::issue_dns01_with_adapter`
+  publishes `_acme-challenge` records through the SDK (scoped to the challenge
+  subtree) and tears them down; mock-adapter tested.
+- **#88 (p2) control-plane metrics (blueprint 16.1):** active/expiring-soon
+  gauges, TLS-orders and DNS-misconfigured counters wired at the right
+  operations; edge route-resolution latency + cache hit/miss in `ag-edge`.
+- **#89 (p2) dangling-DNS detection:** `dangling` module + `domain.dangling_dns_detected`
+  event (subdomain-takeover hygiene).
+- **#90 (p2) abuse controls (blueprint 15.6):** per-tenant attachment/issuance
+  limits + global ACME queue; REST API returns 429 at the limit (opt-in).
+- **#110 (p3) canonical AgTx:** `ag-data` exposes `AgTx`; `enqueue_in_tx` takes it
+  instead of a raw `sqlx::Transaction`; TECH-DEBT marker removed.
+- **#113 (p3) reserved admission variant:** `RejectedRateLimited` documented as
+  reserved RFC-0012 vocabulary, with a test asserting it is never produced.
+- **#86 (p3) ARI renewal (RFC 9773):** `acme::ari` parsing + scheduling decision;
+  `spawn_renewal_task_with_ari` prefers the CA window, falls back to notAfter.
+- **#84 (p3) Domain Connect:** discovery + settings parsing, MX-safe template
+  variables, sync apply-URL builder; independent verification reused.
+- **#92 (p3) docs:** dedicated apex/subdomain tutorials, TLS-lifecycle /
+  security-model / migration references, HTTP-01-vs-DNS-01 / routing-by-Host-SNI
+  / purchase-vs-attachment explanations.
+- **#93 / #78 / #114 (RFC-gated):** RFC-0015 (ag-registrars), RFC-0016 (PSL
+  eTLD+1), RFC-0017 (bulk DLQ) drafted as proposed; no code until approved.
 
 ## Phase affected
 
-Phase 4 production hardening for ag-realtime event persistence.
+Phase 4.5 (ag-domains/ag-edge) and additive Phase 4.6 (ag-workers/ag-data).
+No phase transition; all work is additive and feature-gated where applicable.
 
 ## Type of change
 
-- [ ] Security fix
-- [x] Bug fix
+- [ ] Security fix (security-relevant: #89, #90)
+- [ ] Bug fix
 - [x] Tests
 - [x] Documentation
-- [ ] New feature
+- [x] New feature
 - [ ] Breaking public API change
-
-## Changes
-
-- Keep EventBuffer::open source-compatible with a conservative default of 64
-  pending async appends.
-- Add open_with_max_pending_appends for explicit backpressure configuration.
-- Acquire a semaphore permit before submitting blocking filesystem work.
-- Add flush_async as a barrier for submitted writes during shutdown.
-- Document replay, backpressure, flush, and handle-drop behavior.
-- Test cap enforcement, permit reuse, concurrent integrity, and flushing.
 
 ## Related documents
 
-- CLAUDE.md sections 11, 13, 18, and 36
-- docs/DEBT.md DEBT-012
-- docs/modules/ag-realtime/README.md
-- Issue #73
+- `docs/ag-domains/reference/provider-adapter-sdk.md`, `.../abuse-controls.md`,
+  `.../tls-lifecycle.md`, `.../security-model.md`, `.../migration-compatibility.md`
+- `docs/ag-domains/reference/events-and-metrics.md` (updated)
+- `docs/ag-domains/tutorials/attach-apex.md`, `.../attach-subdomain.md`
+- `docs/ag-domains/explanation/http01-vs-dns01.md`, `.../routing-host-sni.md`,
+  `.../purchase-vs-attachment.md`
+- `docs/adr/0013-ag-workers-execution-model.md` (AgTx resolution note)
+- `docs/rfc/RFC-0015-ag-registrars-design.md`, `RFC-0016-eldp1-public-suffix-list.md`,
+  `RFC-0017-ag-workers-bulk-dlq.md`
 
 ## Test plan
 
-- [x] cargo test -p ag-realtime --features event-persistence
-- [x] cargo clippy -p ag-realtime --features event-persistence --all-targets -- -D warnings
-- [x] cargo fmt --all -- --check
-- [x] git diff --check
+- [x] `cargo fmt --all --check` — no diffs
+- [x] `cargo clippy --workspace --all-targets` — clean
+- [x] `cargo test --workspace --all-features` — 0 failures
+- [x] `cargo test -p ag-domains --all-features` — SDK/wildcard/metrics/dangling/abuse/ARI/DomainConnect suites pass
+- [x] `cargo test -p ag-edge --all-features` — router metrics + TLS edge pass
+- [x] `cargo test -p ag-workers --features postgres --no-run` — AgTx enqueue_in_tx compiles
+- [x] `cargo build -p workers-postgres` — example builds against AgTx
 
 ## Exit criteria advanced
 
-- [x] Async appends do not block Tokio worker threads.
-- [x] Repeated appends reuse the persistent file handle.
-- [x] Pending blocking work is bounded and applies explicit backpressure.
-- [x] Concurrent append integrity is tested.
-- [x] Malformed and truncated replay behavior is documented and tested.
-- [x] Flush and shutdown behavior is documented and tested.
+- #76 ag-domains remaining work: #79, #85, #88, #89, #90, #84, #92 resolved;
+  #78 unblocked via RFC-0016; #93 RFC drafted.
+- ag-workers/ag-data: #110 resolved; #113 reserved; #114 unblocked via RFC-0017.
+- Still blocked on external infrastructure (untouched, documented): #108, #109,
+  #103 (live PostgreSQL), #87 (real-domain ACME staging).
 
 ## Final checklist
 
-- [x] Belongs to the approved Phase 4 scope.
-- [x] No new dependencies are introduced.
-- [x] Existing EventBuffer::open and append_async callers remain compatible.
-- [x] Tests cover the reported concurrency regressions.
-- [x] Clippy passes with warnings denied.
-- [x] No unrelated changes are included.
-- [x] PR descriptor is present.
-
-Closes #73
+- [x] Belongs to correct phase
+- [x] Respects documentation
+- [x] Does not break architecture
+- [x] No unnecessary complexity added
+- [x] No circular dependencies
+- [x] Compiles
+- [x] Tests pass (`cargo test --workspace --all-features`, exit 0)
+- [x] `cargo fmt` passes
+- [x] `cargo clippy` passes
+- [x] Documentation updated in same PR
+- [x] No emojis
+- [x] No AI attribution
+- [x] Commit messages under 256 characters
+- [x] PR descriptor present

--- a/docs/rfc/README.md
+++ b/docs/rfc/README.md
@@ -78,3 +78,4 @@ como `superseded`.
 | 0012 | ag-workers: motor de ejecucion en segundo plano (Fase 4.6-D) | aceptada | `RFC-0012-ag-workers.md` |
 | 0013 | Confinamiento de filesystem por capabilities en ag-storage | aprobada | `RFC-0013-capability-filesystem-confinement.md` |
 | 0014 | Validacion @regex ejecutable en Rust (generador DSL) | aceptada | `RFC-0014-regex-runtime-validation.md` |
+| 0015 | ag-registrars: compra/transferencia/renovacion de dominios (Fase F) | propuesta | `RFC-0015-ag-registrars-design.md` |

--- a/docs/rfc/README.md
+++ b/docs/rfc/README.md
@@ -79,3 +79,5 @@ como `superseded`.
 | 0013 | Confinamiento de filesystem por capabilities en ag-storage | aprobada | `RFC-0013-capability-filesystem-confinement.md` |
 | 0014 | Validacion @regex ejecutable en Rust (generador DSL) | aceptada | `RFC-0014-regex-runtime-validation.md` |
 | 0015 | ag-registrars: compra/transferencia/renovacion de dominios (Fase F) | propuesta | `RFC-0015-ag-registrars-design.md` |
+| 0016 | eTLD+1 via Public Suffix List en ag-domains (DEBT-024) | propuesta | `RFC-0016-eldp1-public-suffix-list.md` |
+| 0017 | ag-workers: re-drive/purga masiva de DLQ por filtro | propuesta | `RFC-0017-ag-workers-bulk-dlq.md` |

--- a/docs/rfc/RFC-0015-ag-registrars-design.md
+++ b/docs/rfc/RFC-0015-ag-registrars-design.md
@@ -1,0 +1,167 @@
+# RFC-0015 - ag-registrars: domain purchase, transfer and renewal (phase F)
+
+- Status: proposed (pending review and approval)
+- Author: Gravital Labs - Nereira Technology and Business Solutions
+- Draft date: 2026-06-11
+- Target phase: Phase F (post Phase 4.5/4.6; after the pre-Phase-5 gate)
+- Affected modules/crates: a new `ag-registrars` crate; `ag-domains` and
+  `ag-edge` are explicitly NOT modified by this RFC
+- Predecessor RFC: RFC-0011 (ag-domains control plane), RFC-0007 (ag-domains scope)
+- Comment period: minimum seven calendar days
+
+## 1. Motivation
+
+`ag-domains` attaches, verifies, secures and routes domains the operator already
+owns; it is explicitly **not** a registrar (RFC-0011 §3.2, RFC-0007). Operators
+still have to buy, transfer and renew names somewhere. A separate, optional
+module that handles that *commerce* — without contaminating the attachment
+lifecycle — closes the loop for users who want a single tool, while keeping the
+core provider-agnostic and registrar-agnostic.
+
+This RFC only proposes the design. Per issue #93, **no code is written until this
+RFC is approved.**
+
+## 2. Problem
+
+- Buying/transferring/renewing a domain is a commercial transaction with a
+  registrar (pricing, billing, EPP/auth codes, ICANN obligations, WHOIS/RDAP,
+  transfer locks, grace periods). This is a fundamentally different concern from
+  attaching a domain to a project.
+- Folding purchase into `ag-domains` would: (a) make the attachment lifecycle
+  depend on a billing relationship, (b) pull heavy registrar SDKs/credentials
+  into a core module, and (c) risk turning Anti-Gravital into a reseller/registrar
+  it is not positioned to be.
+- Yet leaving purchase completely outside means users juggle two tools and copy
+  names by hand.
+
+## 3. Alternatives considered
+
+1. **Do nothing (status quo).** Operators buy domains externally; `ag-domains`
+   only attaches. Pro: zero scope creep, zero new surface. Con: no purchase/renew
+   automation; the loop stays manual. This remains the default until this RFC is
+   approved and is the fallback if it is rejected.
+2. **Add purchase to `ag-domains`.** Rejected: violates RFC-0011 §3.2 and RFC-0007
+   (ag-domains is not a registrar), couples attachment to billing, and bloats a
+   core module. Explicitly out of bounds.
+3. **Separate optional `ag-registrars` module (this RFC).** A new crate behind its
+   own feature gates, depending on `ag-domains` (not the reverse), reusing the
+   `DnsProvider`/adapter SDK only where a registrar also hosts DNS. Pro: keeps the
+   core clean and provider-agnostic; opt-in; reversible. Con: a new module to
+   maintain and a new trust boundary (credentials, money). Chosen.
+
+## 4. Proposed design
+
+### 4.1 Scope boundary (hard constraints)
+
+- `ag-domains` core has **no dependency** on `ag-registrars`. The allowed
+  direction is `ag-registrars -> ag-domains` only (a registrar flow may, after
+  purchase, hand a name to the attachment lifecycle). This is symmetric with the
+  `ag-edge -> ag-domains` rule (ADR-0012) and prevents a dependency cycle.
+- The attachment lifecycle stays **provider-agnostic and registrar-agnostic**: a
+  domain attached through `ag-domains` behaves identically whether it was bought
+  via `ag-registrars` or anywhere else.
+- `ag-registrars` is **optional** and native-first (ADR-0009): the crate compiles
+  and the default build performs no network/commerce; every registrar is an
+  adapter behind a Cargo feature.
+
+### 4.2 Crate placement (CLAUDE.md rule 14)
+
+`ag-registrars` is classified **Optional infrastructure** (alongside
+`ag-domains`/`ag-edge`), not Core/Standard. It is never installed by default in
+official templates.
+
+### 4.3 Core abstraction (sketch, not final API)
+
+A small trait isolates the registrar commerce surface, mirroring how
+`DnsProvider` isolates DNS:
+
+```text
+trait Registrar {
+    fn name(&self) -> &'static str;
+    async fn check_availability(&self, domain) -> Availability;     // name + price
+    async fn purchase(&self, order: PurchaseOrder) -> Registration; // buy
+    async fn renew(&self, domain, period) -> Registration;          // renew
+    async fn transfer_in(&self, domain, auth_code) -> TransferState; // EPP transfer
+    async fn list_registrations(&self) -> Vec<Registration>;
+}
+```
+
+- Pricing, currency and billing identifiers are returned by the adapter; the
+  module never invents prices (CLAUDE.md rule 17 spirit: no fabricated numbers).
+- `Registration` carries expiry, auto-renew state, transfer-lock and EPP/auth
+  status — enough for renewal scheduling and transfers, nothing more.
+- After a successful `purchase`/`transfer_in`, the caller MAY hand the name to
+  `ag-domains` attachment; the module does not do it implicitly.
+
+### 4.4 Adapters
+
+Each registrar is a feature-gated adapter (e.g. `registrar-<name>`), confined to
+its module, named per ADR-0011 (a third-party brand is allowed only as an
+explicit adapter label, never as a generic component name). The default,
+no-adapter build is a no-op surface.
+
+### 4.5 Credentials and money (security)
+
+- Registrar credentials and any payment/billing tokens are read from the
+  environment/secret store, never hardcoded (CLAUDE.md rule 16), and are confined
+  to the adapter behind its feature.
+- Purchase/renew/transfer are irreversible, money-moving operations and require
+  explicit confirmation in any CLI surface (dry-run first), consistent with
+  destructive-op safety.
+
+### 4.6 No changes to: DSL, master docs (beyond a roadmap phase-F note), CI
+beyond adding the crate to the workspace matrix when implementation lands.
+
+## 5. Implementation plan (only after approval)
+
+1. PR 1: create the empty `ag-registrars` crate (native, no adapters), the
+   `Registrar` trait, `Availability`/`Registration`/`PurchaseOrder` types, and
+   contract tests against a mock registrar. No real adapter.
+2. PR 2: one reference adapter behind a feature, with `wiremock` unit tests and
+   `#[ignore]` real-credential tests.
+3. PR 3: optional renewal scheduling that reuses `ag-domains` ARI-aware renewal
+   patterns where applicable; CLI surface with dry-run.
+4. Each PR ships docs and a capability matrix; no PR couples `ag-domains` to
+   `ag-registrars`.
+
+## 6. Risks
+
+| Risk | Probability | Impact | Mitigation |
+|---|---|---|---|
+| Scope creep into a full reseller/registrar | Medium | High | Hard boundary in §4.1; trait stays minimal; optional crate |
+| Dependency cycle with `ag-domains` | Low | High | One-way `ag-registrars -> ag-domains`; CI cycle check |
+| Credential/payment mishandling | Low | High | Env/secret-store only, confined adapters, explicit confirmation, dry-run |
+| Maintenance burden of many adapters | Medium | Medium | Adapters are opt-in and community-extensible behind features |
+| Fabricated pricing/availability | Low | Medium | Prices come only from the adapter's live API; never synthesized |
+
+## 7. Impact
+
+- Product scope: adds an optional commerce surface without changing the core's
+  positioning; `ag-domains` stays "attach, not buy".
+- Roadmap: a Phase-F item; does not affect the pre-Phase-5 gate.
+- Operational complexity: none by default (no-op build); opt-in only.
+- Public APIs: a new crate surface; no change to `ag-domains`/`ag-edge`.
+- Documentation: a new module card and capability matrix; a roadmap phase-F note.
+
+## 8. Rollback
+
+Because `ag-registrars` is optional and nothing depends on it, rollback is
+removing the crate (or leaving it unbuilt). No core module unwinds. Signals to
+roll back: adapter maintenance cost outweighs adoption, or a credential/payment
+incident.
+
+## 9. Decision
+
+To be completed after the comment period.
+
+- Decider: BDFL or technical committee.
+- Decision date: YYYY-MM-DD.
+- Outcome: accepted / rejected / deferred.
+- Brief rationale.
+
+## 10. References
+
+- Issue #93 (this RFC's tracking issue), issue #76 (ag-domains remaining work).
+- RFC-0011 (ag-domains control plane), RFC-0007 (ag-domains scope), ADR-0012
+  (ag-domains control plane), ADR-0009 (native-first), ADR-0011 (third-party
+  brand policy), CLAUDE.md rules 12, 14, 15, 16, 28.

--- a/docs/rfc/RFC-0016-eldp1-public-suffix-list.md
+++ b/docs/rfc/RFC-0016-eldp1-public-suffix-list.md
@@ -1,0 +1,100 @@
+# RFC-0016 - eTLD+1 via the Public Suffix List (ag-domains)
+
+- Status: proposed (pending review and approval)
+- Author: Gravital Labs - Nereira Technology and Business Solutions
+- Draft date: 2026-06-11
+- Target phase: maintenance of Phase 4.5 ag-domains (correctness fix)
+- Affected modules/crates: `ag-domains` (`hostname`, `issuance`); a new optional
+  dependency
+- Predecessor RFC: RFC-0011 (ag-domains control plane)
+- Comment period: minimum seven calendar days
+
+## 1. Motivation
+
+`ag-domains` derives the registrable domain (eTLD+1) with a two-label heuristic
+in two places — `hostname::registrable_domain` and `issuance::counting_key`.
+Multi-label public suffixes (`co.uk`, `com.br`, `gov.au`, ...) are misclassified:
+`example.co.uk` is treated as registrable `co.uk`. This skews apex/subdomain
+classification, the generated DNS instructions, and — most importantly — the
+per-registered-domain issuance rate-limit key, which protects against hitting the
+CA's certificates-per-registered-domain cap. This is issue #78 (DEBT-024).
+
+This RFC is required because the fix introduces a new dependency, which CLAUDE.md
+rule 15/28 gates behind an approved RFC.
+
+## 2. Problem
+
+- The two-label heuristic is correct only for single-label TLDs (`example.com`).
+- For multi-label suffixes it both over-counts (collapsing distinct registrable
+  domains under `co.uk`) and misclassifies apex vs subdomain.
+- The Public Suffix List (PSL) is the authoritative source for this and is not
+  expressible as a simple rule; it must be embedded or loaded.
+
+## 3. Alternatives considered
+
+1. **Do nothing.** Keep the heuristic. Pro: no dependency. Con: incorrect for a
+   large, common class of domains; the issuance counter is security-relevant.
+   Rejected.
+2. **Hand-maintain a suffix table.** Rejected: the PSL changes frequently;
+   hand-maintenance is error-prone and is exactly what the PSL exists to avoid.
+3. **Adopt a PSL-backed crate, feature-gated (this RFC).** Candidates: `psl`
+   (compile-time embedded list, no runtime fetch, `no_std`-friendly) or
+   `publicsuffix` (loads a list, supports updates). Pro: correct, well-maintained.
+   Con: a new dependency and a larger binary (embedded list). Chosen, with `psl`
+   preferred for offline/native-first operation (ADR-0009).
+
+## 4. Proposed design
+
+- Add an optional Cargo feature `psl` (default OFF to keep the native build
+  minimal and offline) that pulls the chosen PSL crate.
+- Introduce a single internal function `registrable_domain(host) -> String` that
+  is **the only** eTLD+1 source, shared by `hostname` and `issuance::counting_key`
+  (DRY). With the `psl` feature it uses the PSL; without it, it falls back to the
+  current two-label heuristic, so the default build keeps working offline exactly
+  as today.
+- No public API shape change: the function's signature and the existing fields
+  (`registered_domain`, counting key) stay the same; only the derivation improves.
+- Dependency justification (rule 15): the PSL crate is mature, widely used,
+  permissively licensed, and pure-Rust; it adds no external service.
+
+## 5. Implementation plan (only after approval)
+
+1. PR 1: add the `psl` feature and the shared `registrable_domain` function with
+   the heuristic fallback; route `hostname` and `issuance` through it; add tests
+   for `co.uk`/`com.br`-style suffixes under both feature states.
+2. PR 2 (optional): wire `cargo deny`/`audit` entries and document the feature in
+   the capability/installation notes.
+
+## 6. Risks
+
+| Risk | Probability | Impact | Mitigation |
+|---|---|---|---|
+| Binary-size increase from the embedded list | Medium | Low | Feature-gated, OFF by default |
+| PSL crate staleness | Low | Medium | Pin + `cargo update` cadence; both candidate crates are actively maintained |
+| Behaviour divergence feature on/off | Medium | Low | Single shared function; tests assert both paths; document that the heuristic is a best-effort offline fallback |
+
+## 7. Impact
+
+- Correctness: fixes apex/subdomain classification, generated instructions and
+  the issuance counter for multi-label suffixes.
+- Public APIs: unchanged.
+- Operational complexity: none by default (feature OFF); opt-in correctness.
+- Documentation: a note in the ag-domains reference and installation features.
+
+## 8. Rollback
+
+Disable the `psl` feature: the crate reverts to the heuristic fallback with no
+API change. No data migration is involved.
+
+## 9. Decision
+
+To be completed after the comment period.
+
+- Decider: BDFL or technical committee.
+- Decision date: YYYY-MM-DD.
+- Outcome: accepted / rejected / deferred.
+
+## 10. References
+
+- Issue #78 (DEBT-024), issue #76. RFC-0011, ADR-0009. CLAUDE.md rules 15, 21, 28.
+- `crates/ag-domains/src/hostname.rs`, `crates/ag-domains/src/issuance.rs`.

--- a/docs/rfc/RFC-0017-ag-workers-bulk-dlq.md
+++ b/docs/rfc/RFC-0017-ag-workers-bulk-dlq.md
@@ -1,0 +1,104 @@
+# RFC-0017 - ag-workers: bulk DLQ re-drive and purge-by-filter
+
+- Status: proposed (pending review and approval)
+- Author: Gravital Labs - Nereira Technology and Business Solutions
+- Draft date: 2026-06-11
+- Target phase: maintenance of Phase 4.6-D ag-workers (CLI surface extension)
+- Affected modules/crates: `ag-cli` (`Dlq` subcommands), `ag-workers` (DLQ query
+  /re-drive API)
+- Predecessor RFC: RFC-0012 (ag-workers)
+- Comment period: minimum seven calendar days
+
+## 1. Motivation
+
+The DLQ CLI (RFC-0012 §20/§27) operates one job at a time for re-drive
+(`ag workers dlq retry JOB_ID`) and purges only by age
+(`ag workers dlq purge --older-than 30d`). When a downstream dependency recovers,
+an operator typically needs to re-drive *many* dead-lettered jobs of one
+`kind`/`queue` at once, not paste IDs one by one. This is a standard day-2 DLQ
+operation. This is issue #114.
+
+This RFC is required because it extends the CLI surface, which CLAUDE.md rule 28
+gates behind an approved RFC.
+
+## 2. Problem
+
+- RFC-0012 §27 specifies single-ID re-drive and age-based purge only.
+- Bulk re-drive/purge by `queue`/`kind` is missing, so recovery from a
+  dependency outage is tedious and error-prone.
+- Bulk operations are destructive/large-effect and need a safety rail.
+
+## 3. Alternatives considered
+
+1. **Do nothing.** Operators script around the single-ID commands. Pro: no new
+   surface. Con: poor day-2 ergonomics; scripting re-drive loops is exactly what
+   the tool should provide. Rejected.
+2. **External tooling only.** Rejected: pushes a common operation outside the
+   product and duplicates DLQ knowledge.
+3. **Add bounded bulk subcommands with a dry-run (this RFC).** Chosen.
+
+## 4. Proposed design
+
+Extend the existing `Dlq` subcommands (behind the existing `workers-runtime`
+feature), adding filtered, bounded bulk variants:
+
+```text
+ag workers dlq retry  --queue mail [--kind send_receipt] [--limit N] [--dry-run]
+ag workers dlq purge  --queue mail [--kind X] [--older-than 30d] [--dry-run]
+```
+
+- `--queue` is required for bulk operations; `--kind` narrows further.
+- `--limit N` bounds how many entries one invocation affects (default a
+  conservative value, e.g. 100) so a single command cannot re-drive an unbounded
+  flood.
+- `--dry-run` prints exactly which entries would be affected (count + sample) and
+  makes no change — required before any destructive bulk action.
+- `purge` keeps `--older-than` and now also accepts the filter, so age and filter
+  compose.
+
+`ag-workers` gains a small bulk query/re-drive API on the DLQ store
+(filter by queue/kind, with a limit), reused by both the in-memory and Postgres
+backends. Single-ID `retry`/`purge` stay unchanged (backward compatible).
+
+No DSL, master-doc or CI changes beyond documenting the new flags.
+
+## 5. Implementation plan (only after approval)
+
+1. PR 1: `ag-workers` DLQ filter+limit query and bulk re-drive/purge API, with
+   unit tests on the in-memory backend and `#[ignore]` Postgres parity tests.
+2. PR 2: `ag-cli` flag surface (`--queue`/`--kind`/`--limit`/`--dry-run`), dry-run
+   output, and docs (modules/ag-workers + README CLI table).
+
+## 6. Risks
+
+| Risk | Probability | Impact | Mitigation |
+|---|---|---|---|
+| Mass re-drive overwhelms a still-degraded dependency | Medium | Medium | `--limit` bound + `--dry-run` preview; default conservative limit |
+| Accidental over-broad purge | Low | High | `--dry-run` required workflow; filter is explicit; single-ID path unchanged |
+| Backend divergence (memory vs Postgres) | Low | Medium | Shared API + parity tests |
+
+## 7. Impact
+
+- Product scope: an additive CLI ergonomics improvement; no new concept.
+- Public APIs: new CLI flags and a small `ag-workers` DLQ API; existing commands
+  unchanged.
+- Operational complexity: lower (recovery is one command, safely previewed).
+- Documentation: ag-workers module docs + README CLI table.
+
+## 8. Rollback
+
+Remove the bulk flags and the bulk API; single-ID `retry`/`purge` remain. No
+state migration is involved.
+
+## 9. Decision
+
+To be completed after the comment period.
+
+- Decider: BDFL or technical committee.
+- Decision date: YYYY-MM-DD.
+- Outcome: accepted / rejected / deferred.
+
+## 10. References
+
+- Issue #114. RFC-0012 §18/§20/§27. CLAUDE.md rule 28.
+- `crates/ag-cli/src/main.rs` (`Dlq`), `crates/ag-workers/src/queue/dlq.rs`.

--- a/docs/roadmap/STATUS.md
+++ b/docs/roadmap/STATUS.md
@@ -361,9 +361,14 @@ ejerce (tests `#[ignore]`): seguimiento en los Issues #108 (verificacion PG),
   retry/backoff, timeout, DLQ en memoria, poison guard, shutdown gracioso, telemetria.
 - [x] S3 Persistencia (codigo): `PostgresQueue` via `ag-data`, migraciones
   (`0001`-`0003`), leasing `FOR UPDATE SKIP LOCKED`, heartbeat + reaper,
-  `enqueue_in_tx`, DLQ persistente, admision/backpressure (feature `postgres`). La
-  verificacion contra una base viva es criterio de salida y se rastrea en el
-  Issue #108 (el entorno de CI por defecto no levanta PostgreSQL).
+  `enqueue_in_tx` (acepta `ag_data::AgTx`, Issue #110), DLQ persistente,
+  admision/backpressure (feature `postgres`). La verificacion contra una base
+  viva es criterio de salida y se rastrea en el Issue #108 (el entorno de CI por
+  defecto no levanta PostgreSQL). La variante de admision `RejectedRateLimited`
+  (RFC-0012 seccion 18) queda **reservada**: es vocabulario sancionado por la RFC
+  y parte del espacio de etiquetas de `ag_workers_backpressure_total`, pero
+  ningun camino de admision la produce hoy; un limitador de tasa por cola que la
+  genere cambia el contrato de admision y va tras una RFC/ADR futura (Issue #113).
 - [x] S4 Scheduling + dinamico: jobs por intervalo con claim singleton; pools dinamicos
   acotados; pool CPU-bound (`spawn_blocking` + semaforo).
 - [x] S5 Superficies: declaracion `worker` en el Anti-DSL (v0.8) + generador

--- a/examples/workers-postgres/Cargo.toml
+++ b/examples/workers-postgres/Cargo.toml
@@ -16,6 +16,7 @@ workspace = true
 
 [dependencies]
 ag-workers = { path = "../../crates/ag-workers", version = "0.0.0", features = ["postgres"] }
+ag-data = { path = "../../crates/ag-data", version = "0.0.0" }
 async-trait = { workspace = true }
 serde = { workspace = true }
 sqlx = { workspace = true }

--- a/examples/workers-postgres/README.md
+++ b/examples/workers-postgres/README.md
@@ -3,9 +3,9 @@
 Durable `ag-workers` backend with transactional enqueue (RFC-0012 sections 13.2-13.3).
 
 Demonstrates the PostgreSQL backend and `enqueue_in_tx`: the job insert participates in
-the caller's transaction, so a domain write and its follow-up job commit atomically (the
-transactional-outbox property without a separate outbox table). A worker pool then leases
-and runs the durably-enqueued job.
+the caller's `ag_data::AgTx` transaction, so a domain write and its follow-up job commit
+atomically (the transactional-outbox property without a separate outbox table). A worker
+pool then leases and runs the durably-enqueued job.
 
 Requires a reachable PostgreSQL instance via `DATABASE_URL`; without it the example prints
 how to run and exits cleanly.

--- a/examples/workers-postgres/src/main.rs
+++ b/examples/workers-postgres/src/main.rs
@@ -73,7 +73,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
     // Transactional enqueue: in a real app the domain writes (e.g. inserting the order)
     // happen on the same `tx`, so the order and its receipt job commit atomically -- or
     // neither does. Here we show only the job insert participating in the transaction.
-    let mut tx = pool.begin().await?;
+    let mut tx = ag_data::AgTx::begin(&pool).await?;
     let job = NewJob::encode::<SendReceipt>("send_receipt", "mail", &SendReceipt { order_id: 42 })?;
     let job_id = queue.enqueue_in_tx(&mut tx, job).await?;
     tx.commit().await?;


### PR DESCRIPTION
# Resolve ag-domains / ag-workers / ag-data issues (one commit per issue)

## Summary

Resolves the open, in-environment-reproducible issues, one commit per issue, in
priority then precedence order. Issues blocked on external infrastructure (live
PostgreSQL, real-domain ACME) or on an unapproved RFC are not closed here; for
the RFC-gated ones a design RFC is drafted instead so the maintainer can approve
and implement.

- **#79 (p2) provider adapter SDK seam:** `provider::sdk` adds a declarative
  plan/diff/apply/verify/rollback layer over `DnsProvider`; pure `diff` plus a
  `ProviderAdapter<P>` bridge so Cloudflare participates with no extra code.
- **#85 (p2) DNS-01 wildcard automation:** `acme::wildcard::issue_dns01_with_adapter`
  publishes `_acme-challenge` records through the SDK (scoped to the challenge
  subtree) and tears them down; mock-adapter tested.
- **#88 (p2) control-plane metrics (blueprint 16.1):** active/expiring-soon
  gauges, TLS-orders and DNS-misconfigured counters wired at the right
  operations; edge route-resolution latency + cache hit/miss in `ag-edge`.
- **#89 (p2) dangling-DNS detection:** `dangling` module + `domain.dangling_dns_detected`
  event (subdomain-takeover hygiene).
- **#90 (p2) abuse controls (blueprint 15.6):** per-tenant attachment/issuance
  limits + global ACME queue; REST API returns 429 at the limit (opt-in).
- **#110 (p3) canonical AgTx:** `ag-data` exposes `AgTx`; `enqueue_in_tx` takes it
  instead of a raw `sqlx::Transaction`; TECH-DEBT marker removed.
- **#113 (p3) reserved admission variant:** `RejectedRateLimited` documented as
  reserved RFC-0012 vocabulary, with a test asserting it is never produced.
- **#86 (p3) ARI renewal (RFC 9773):** `acme::ari` parsing + scheduling decision;
  `spawn_renewal_task_with_ari` prefers the CA window, falls back to notAfter.
- **#84 (p3) Domain Connect:** discovery + settings parsing, MX-safe template
  variables, sync apply-URL builder; independent verification reused.
- **#92 (p3) docs:** dedicated apex/subdomain tutorials, TLS-lifecycle /
  security-model / migration references, HTTP-01-vs-DNS-01 / routing-by-Host-SNI
  / purchase-vs-attachment explanations.
- **#93 / #78 / #114 (RFC-gated):** RFC-0015 (ag-registrars), RFC-0016 (PSL
  eTLD+1), RFC-0017 (bulk DLQ) drafted as proposed; no code until approved.

## Phase affected

Phase 4.5 (ag-domains/ag-edge) and additive Phase 4.6 (ag-workers/ag-data).
No phase transition; all work is additive and feature-gated where applicable.

## Type of change

- [ ] Security fix (security-relevant: #89, #90)
- [ ] Bug fix
- [x] Tests
- [x] Documentation
- [x] New feature
- [ ] Breaking public API change

## Related documents

- `docs/ag-domains/reference/provider-adapter-sdk.md`, `.../abuse-controls.md`,
  `.../tls-lifecycle.md`, `.../security-model.md`, `.../migration-compatibility.md`
- `docs/ag-domains/reference/events-and-metrics.md` (updated)
- `docs/ag-domains/tutorials/attach-apex.md`, `.../attach-subdomain.md`
- `docs/ag-domains/explanation/http01-vs-dns01.md`, `.../routing-host-sni.md`,
  `.../purchase-vs-attachment.md`
- `docs/adr/0013-ag-workers-execution-model.md` (AgTx resolution note)
- `docs/rfc/RFC-0015-ag-registrars-design.md`, `RFC-0016-eldp1-public-suffix-list.md`,
  `RFC-0017-ag-workers-bulk-dlq.md`

## Test plan

- [x] `cargo fmt --all --check` — no diffs
- [x] `cargo clippy --workspace --all-targets` — clean
- [x] `cargo test --workspace --all-features` — 0 failures
- [x] `cargo test -p ag-domains --all-features` — SDK/wildcard/metrics/dangling/abuse/ARI/DomainConnect suites pass
- [x] `cargo test -p ag-edge --all-features` — router metrics + TLS edge pass
- [x] `cargo test -p ag-workers --features postgres --no-run` — AgTx enqueue_in_tx compiles
- [x] `cargo build -p workers-postgres` — example builds against AgTx

## Exit criteria advanced

- #76 ag-domains remaining work: #79, #85, #88, #89, #90, #84, #92 resolved;
  #78 unblocked via RFC-0016; #93 RFC drafted.
- ag-workers/ag-data: #110 resolved; #113 reserved; #114 unblocked via RFC-0017.
- Still blocked on external infrastructure (untouched, documented): #108, #109,
  #103 (live PostgreSQL), #87 (real-domain ACME staging).

## Final checklist

- [x] Belongs to correct phase
- [x] Respects documentation
- [x] Does not break architecture
- [x] No unnecessary complexity added
- [x] No circular dependencies
- [x] Compiles
- [x] Tests pass (`cargo test --workspace --all-features`, exit 0)
- [x] `cargo fmt` passes
- [x] `cargo clippy` passes
- [x] Documentation updated in same PR
- [x] No emojis
- [x] No AI attribution
- [x] Commit messages under 256 characters
- [x] PR descriptor present
