### PR TITLE
Ci/pin actions to sha

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -39,15 +39,15 @@ jobs:
             os: windows-latest
             target: x86_64-pc-windows-msvc
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
 
       - name: Install Rust toolchain
-        uses: dtolnay/rust-toolchain@stable
+        uses: dtolnay/rust-toolchain@29eef336d9b2848a0b548edc03f92a220660cdb8 # stable
         with:
           targets: ${{ matrix.target }}
 
       - name: Cache cargo
-        uses: actions/cache@v4
+        uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830 # v4
         with:
           path: |
             ~/.cargo/registry
@@ -70,15 +70,15 @@ jobs:
     name: ag-mail mta + api features
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
 
       - name: Install Rust toolchain
-        uses: dtolnay/rust-toolchain@stable
+        uses: dtolnay/rust-toolchain@29eef336d9b2848a0b548edc03f92a220660cdb8 # stable
         with:
           components: clippy
 
       - name: Cache cargo
-        uses: actions/cache@v4
+        uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830 # v4
         with:
           path: |
             ~/.cargo/registry

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -23,15 +23,15 @@ jobs:
     env:
       RUSTDOCFLAGS: "-D warnings"
     steps:
-      - uses: actions/checkout@v4
-      - uses: dtolnay/rust-toolchain@stable
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+      - uses: dtolnay/rust-toolchain@29eef336d9b2848a0b548edc03f92a220660cdb8 # stable
       - run: cargo doc --workspace --no-deps
 
   masters-integrity:
     name: masters integrity
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
       - name: Verify SHA-256 of master documents
         run: |
           set -euo pipefail
@@ -61,7 +61,7 @@ jobs:
     name: prohibited content scan
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
       - name: Reject AI tool evidence outside allowed files
         run: |
           set -euo pipefail
@@ -130,7 +130,7 @@ jobs:
     name: descriptor closing-keywords
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
       - name: Require an issue-closing section in every PR descriptor
         run: |
           set -euo pipefail

--- a/.github/workflows/pr-autofill.yml
+++ b/.github/workflows/pr-autofill.yml
@@ -25,7 +25,7 @@ jobs:
     if: github.event.pull_request.draft == false || github.event.action == 'ready_for_review'
     steps:
       - name: Checkout de la rama del PR
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
         with:
           ref: ${{ github.event.pull_request.head.sha }}
           fetch-depth: 1

--- a/.github/workflows/quality.yml
+++ b/.github/workflows/quality.yml
@@ -25,7 +25,7 @@ jobs:
       matrix:
         os: [ubuntu-latest, windows-latest]
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
       - name: Verify checksums and MSRV parity
         if: runner.os == 'Linux'
         run: bash tools/check-installers.sh
@@ -73,11 +73,11 @@ jobs:
     name: cargo check (MSRV 1.95.0)
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
-      - uses: dtolnay/rust-toolchain@stable
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+      - uses: dtolnay/rust-toolchain@29eef336d9b2848a0b548edc03f92a220660cdb8 # stable
         with:
           toolchain: "1.95.0"
-      - uses: actions/cache@v4
+      - uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830 # v4
         with:
           path: |
             ~/.cargo/registry
@@ -90,8 +90,8 @@ jobs:
     name: cargo fmt
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
-      - uses: dtolnay/rust-toolchain@stable
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+      - uses: dtolnay/rust-toolchain@29eef336d9b2848a0b548edc03f92a220660cdb8 # stable
         with:
           toolchain: "1.95.0"
           components: rustfmt
@@ -102,11 +102,11 @@ jobs:
     name: cargo clippy
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
-      - uses: dtolnay/rust-toolchain@stable
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+      - uses: dtolnay/rust-toolchain@29eef336d9b2848a0b548edc03f92a220660cdb8 # stable
         with:
           components: clippy
-      - uses: actions/cache@v4
+      - uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830 # v4
         with:
           path: |
             ~/.cargo/registry
@@ -119,8 +119,8 @@ jobs:
     name: cargo audit
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
-      - uses: dtolnay/rust-toolchain@stable
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+      - uses: dtolnay/rust-toolchain@29eef336d9b2848a0b548edc03f92a220660cdb8 # stable
       - name: install cargo-audit
         run: cargo install cargo-audit --locked
       - name: run cargo audit
@@ -130,8 +130,8 @@ jobs:
     name: cargo deny
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
-      - uses: EmbarkStudios/cargo-deny-action@v2
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+      - uses: EmbarkStudios/cargo-deny-action@bb137d7af7e4fb67e5f82a49c4fce4fad40782fe # v2.0.20
         with:
           command: check
           arguments: --all-features
@@ -140,13 +140,13 @@ jobs:
     name: cargo fuzz smoke (60s)
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
-      - uses: dtolnay/rust-toolchain@master
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+      - uses: dtolnay/rust-toolchain@3c5f7ea28cd621ae0bf5283f0e981fb97b8a7af9 # master
         with:
           toolchain: nightly
       - name: install cargo-fuzz
         run: cargo install cargo-fuzz --locked
-      - uses: actions/cache@v4
+      - uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830 # v4
         with:
           path: |
             ~/.cargo/registry
@@ -167,7 +167,7 @@ jobs:
         run: cargo fuzz run fuzz_workers_payload -- -max_total_time=60
       - name: upload crash artifacts
         if: failure()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
         with:
           name: fuzz-crashes
           path: fuzz/artifacts/
@@ -176,11 +176,11 @@ jobs:
     name: cargo tarpaulin (>=80%)
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
-      - uses: dtolnay/rust-toolchain@stable
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+      - uses: dtolnay/rust-toolchain@29eef336d9b2848a0b548edc03f92a220660cdb8 # stable
         with:
           toolchain: "1.95.0"
-      - uses: actions/cache@v4
+      - uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830 # v4
         with:
           path: |
             ~/.cargo/registry

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -117,6 +117,13 @@ no puede, marquela como pendiente de traduccion y abra un issue.
 - Para los componentes criticos (Shield, parser DSL): fuzzing
   obligatorio antes de tag de release.
 
+## Mantenimiento de GitHub Actions
+
+Las acciones de terceros en `.github/workflows/` se fijan a un SHA completo.
+Revise sus releases y changelogs al menos una vez por trimestre y abra un pull
+request dedicado para actualizar cada pin, conservando el tag de referencia en
+el comentario de la linea `uses:`. Valide todos los workflows despues del cambio.
+
 ## Seguridad
 
 Si descubre una vulnerabilidad, no abra un issue publico. Siga el

--- a/docs/pr-drafts/ci-pin-actions-to-sha.md
+++ b/docs/pr-drafts/ci-pin-actions-to-sha.md
@@ -1,0 +1,65 @@
+# Descriptor de PR
+
+## Resumen
+
+Fijar las GitHub Actions de terceros a SHA de commit completo (con el tag en comentario) y documentar el bump
+
+## Fase afectada
+
+Endurecimiento de cadena de suministro de CI. No toca codigo de los crates ni
+avanza una fase de la Hoja de Ruta.
+
+## Tipo de cambio
+
+- [ ] Correccion de bug
+- [x] CI / seguridad (pin de acciones de terceros a SHA)
+- [x] Documentacion (nota de mantenimiento en CONTRIBUTING.md)
+- [ ] Nueva feature
+- [ ] Cambio que rompe compatibilidad
+
+## Contexto
+
+`.github/workflows/*` referenciaban acciones de terceros por tag movil
+(`actions/checkout@v4`, `dtolnay/rust-toolchain@stable`, etc.). Un tag movil
+permite que cambios no revisados entren a la ruta de build. Esta PR las fija a
+un SHA de commit completo, con el tag en un comentario para legibilidad
+(CLAUDE.md regla 16: minimizar superficie de ataque; regla 36: reproducibilidad).
+
+Este trabajo se rescato del esfuerzo paralelo de `issues/session-2026-06-13`
+(PR #162), cuyo CI ya valido estos SHA en verde; el resto de esa rama es
+redundante con lo ya fusionado en `main` (#146/#147/#148/#150).
+
+## Cambios
+
+- `ci.yml`, `docs.yml`, `pr-autofill.yml`, `quality.yml`: cada `uses:` de
+  tercero fijado a SHA completo con el tag en comentario.
+- `CONTRIBUTING.md`: nota de mantenimiento (revisar y bumpear pins por PR
+  dedicada, conservando el tag de referencia).
+
+## Plan de prueba
+
+```sh
+# Ninguna accion de tercero sin pinear:
+grep -rEn "uses: [^.]" .github/workflows/ | grep -vE "@[0-9a-f]{40}"   # vacio
+# YAML valido:
+for f in .github/workflows/*.yml; do python3 -c "import yaml;yaml.safe_load(open('$f'))"; done
+```
+
+Validacion real: los workflows corren en verde con los SHA fijados (ya
+verificado por el CI de la PR #162, de donde provienen los pins).
+
+## Criterios de salida que avanza
+
+- Acciones de terceros reproducibles y revisadas por SHA, no por tag movil.
+
+## Cierre de issues
+
+Closes #140
+
+## Checklist final
+
+- [x] Pertenece a la fase correcta y respeta la documentacion.
+- [x] No rompe arquitectura ni anade dependencias.
+- [x] Todos los workflows con YAML valido; sin acciones sin pinear.
+- [x] Nota de mantenimiento de pins documentada (CONTRIBUTING.md).
+- [x] Sin evidencia de herramientas IA; atribuido a la persona autora.


### PR DESCRIPTION
# Descriptor de PR

## Resumen

Fijar las GitHub Actions de terceros a SHA de commit completo (con el tag en comentario) y documentar el bump

## Fase afectada

Endurecimiento de cadena de suministro de CI. No toca codigo de los crates ni
avanza una fase de la Hoja de Ruta.

## Tipo de cambio

- [ ] Correccion de bug
- [x] CI / seguridad (pin de acciones de terceros a SHA)
- [x] Documentacion (nota de mantenimiento en CONTRIBUTING.md)
- [ ] Nueva feature
- [ ] Cambio que rompe compatibilidad

## Contexto

`.github/workflows/*` referenciaban acciones de terceros por tag movil
(`actions/checkout@v4`, `dtolnay/rust-toolchain@stable`, etc.). Un tag movil
permite que cambios no revisados entren a la ruta de build. Esta PR las fija a
un SHA de commit completo, con el tag en un comentario para legibilidad
(CLAUDE.md regla 16: minimizar superficie de ataque; regla 36: reproducibilidad).

Este trabajo se rescato del esfuerzo paralelo de `issues/session-2026-06-13`
(PR #162), cuyo CI ya valido estos SHA en verde; el resto de esa rama es
redundante con lo ya fusionado en `main` (#146/#147/#148/#150).

## Cambios

- `ci.yml`, `docs.yml`, `pr-autofill.yml`, `quality.yml`: cada `uses:` de
  tercero fijado a SHA completo con el tag en comentario.
- `CONTRIBUTING.md`: nota de mantenimiento (revisar y bumpear pins por PR
  dedicada, conservando el tag de referencia).

## Plan de prueba

```sh
# Ninguna accion de tercero sin pinear:
grep -rEn "uses: [^.]" .github/workflows/ | grep -vE "@[0-9a-f]{40}"   # vacio
# YAML valido:
for f in .github/workflows/*.yml; do python3 -c "import yaml;yaml.safe_load(open('$f'))"; done
```

Validacion real: los workflows corren en verde con los SHA fijados (ya
verificado por el CI de la PR #162, de donde provienen los pins).

## Criterios de salida que avanza

- Acciones de terceros reproducibles y revisadas por SHA, no por tag movil.

## Cierre de issues

Closes #140

## Checklist final

- [x] Pertenece a la fase correcta y respeta la documentacion.
- [x] No rompe arquitectura ni anade dependencias.
- [x] Todos los workflows con YAML valido; sin acciones sin pinear.
- [x] Nota de mantenimiento de pins documentada (CONTRIBUTING.md).
- [x] Sin evidencia de herramientas IA; atribuido a la persona autora.
