### PR TITLE
feat(ag-mail): add durable PostgreSQL spool for the native MTA queue

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -246,6 +246,7 @@ dependencies = [
  "ag-workers",
  "async-trait",
  "base64 0.22.1",
+ "getrandom 0.2.17",
  "hickory-resolver",
  "hmac",
  "lettre",

--- a/README.md
+++ b/README.md
@@ -383,7 +383,7 @@ Current state, phase by phase (evidence in
 | 3 | Anti-DSL v0.1-v0.4: parser, diagnostics, Rust/SQL/TypeScript/OpenAPI generators, LSP, VS Code extension | Implemented; gate open | 24-hour fuzz gate, direct generated-vs-manual benchmark, generator consolidation (issue #70), adoption criteria |
 | 4 | Standard modules: `ag-auth`, `ag-cache`, `ag-realtime`, `ag-storage`, `ag-observe`; DSL v0.5-v0.6 | Implemented; gate open | crates.io releases, scale benchmarks (50K WebSocket connections, 1M cache ops/s), community criteria |
 | 4.5 (additive) | `ag-mail` transactional email; `ag-domains` DNS/ACME/SPF-DKIM-DMARC; DSL v0.7 | Implemented; gate open | Gate re-run on the final consolidation commit; `ag-domains` has active ongoing work |
-| 4.6 (additive) | Pre-Phase-5 hardening: native outbound MTA + signed webhooks in `ag-mail` (A/B/C); `ag-workers` engine (D); DSL v0.8 | In progress | `ag-edge` producer wiring (issue #112); MTA durable spool and live-delivery evidence. Stages S1-S5 and the S7 `ag-mail` migration are done; the PostgreSQL backend was verified against a live database (issues #108/#109/#103) |
+| 4.6 (additive) | Pre-Phase-5 hardening: native outbound MTA + signed webhooks in `ag-mail` (A/B/C); `ag-workers` engine (D); DSL v0.8 | In progress | `ag-edge` producer wiring (issue #112); MTA live-delivery evidence (issue #153). The MTA durable spool now ships behind the `queue-postgres` feature (issue #151; its live PostgreSQL test is `#[ignore]`). Stages S1-S5 and the S7 `ag-mail` migration are done; the `ag-workers` PostgreSQL backend was verified against a live database (issues #108/#109/#103) |
 | 5 | `ag-cloud`: simplified build/deploy, secrets, logs, rollback, domains, TLS | Pending | Opens when the pre-Phase-5 gate closes. Milestone: public beta v0.5 |
 | 6 | `ag-ai` and Knowledge Graph: providers, retrieval, graph-assisted workflows | Pending | Phase 5 completion and beta feedback |
 | 7 | `ag-migrate`: importers and assisted migration from other backend frameworks | Pending | Phase 6 completion and importer acceptance tests |
@@ -410,9 +410,12 @@ Stated plainly, because hiding them would violate the project's own rules:
 - Generated Rust handlers are intentional stubs; the framework does not
   write your business logic.
 - `ag-domains` has active, ongoing development.
-- The durable PostgreSQL paths of `ag-workers` and `ag-mail` were verified
-  manually against a live PostgreSQL 16; their integration tests remain
-  `#[ignore]` because default CI provisions no database.
+- The durable PostgreSQL paths of `ag-workers` and `ag-mail`'s workers-backed
+  delivery were verified manually against a live PostgreSQL 16; their
+  integration tests remain `#[ignore]` because default CI provisions no
+  database. The native MTA scheduled-queue spool (feature `queue-postgres`,
+  issue #151) adds its own `#[ignore]` PostgreSQL test, pending a live run; its
+  in-memory durability mechanism is covered by passing tests.
 - Open technical debt is tracked as GitHub Issues (label `tech-debt`);
   [docs/DEBT.md](docs/DEBT.md) is a frozen historical record.
 - The release gate must be re-evaluated on the final consolidation commit
@@ -539,7 +542,10 @@ tests en CI:
   auth para verificacion/recuperacion/magic links) y gestionar registros DNS,
   certificados ACME/Let's Encrypt y SPF/DKIM/DMARC (`ag-domains`) (Fase 4.5).
 - Ejecutar el MTA outbound nativo opt-in y los webhooks firmados de `ag-mail`
-  (features `mta`/`api`, Fase 4.6-A/B/C).
+  (features `mta`/`api`, Fase 4.6-A/B/C). La cola de entrega del MTA admite un
+  spool durable opt-in en PostgreSQL (feature `queue-postgres`) para que los
+  jobs programados sobrevivan a un reinicio; el nivel en memoria sigue siendo el
+  default.
 - Ejecutar jobs en segundo plano con `ag-workers` (Fase 4.6-D): jobs tipados,
   reintentos con backoff, dead-letter queue, scheduling por intervalo y
   worker pools. El backend en memoria es el default; el backend PostgreSQL
@@ -811,9 +817,13 @@ proyecto:
 - Los handlers Rust generados son stubs intencionales; el framework no
   escribe la logica de negocio.
 - `ag-domains` tiene desarrollo activo en curso.
-- Los caminos durables PostgreSQL de `ag-workers` y `ag-mail` se verificaron
-  manualmente contra una PostgreSQL 16 viva; sus tests de integracion siguen
-  `#[ignore]` porque el CI por defecto no provisiona base de datos.
+- Los caminos durables PostgreSQL de `ag-workers` y de la entrega de `ag-mail`
+  respaldada por workers se verificaron manualmente contra una PostgreSQL 16
+  viva; sus tests de integracion siguen `#[ignore]` porque el CI por defecto no
+  provisiona base de datos. El spool de la cola programada del MTA nativo
+  (feature `queue-postgres`, issue #151) anade su propio test PostgreSQL
+  `#[ignore]`, pendiente de una ejecucion en vivo; su mecanismo de durabilidad
+  en memoria esta cubierto por tests que pasan.
 - La deuda tecnica abierta se rastrea como GitHub Issues (etiqueta
   `tech-debt`); [docs/DEBT.md](docs/DEBT.md) es un registro historico
   congelado.

--- a/crates/ag-mail/Cargo.toml
+++ b/crates/ag-mail/Cargo.toml
@@ -33,7 +33,12 @@ metrics = ["dep:metrics"]
 # Motor MTA outbound nativo (Fase 4.6-A): resolucion MX, entrega ESMTP+STARTTLS
 # directa al MX destino, firma DKIM y clasificacion de bounces. Opt-in; el
 # sender por defecto sigue siendo SmtpSender (relay). Ver RFC-0009 / ADR-0010.
-mta = ["dep:mail-send", "dep:mail-auth", "dep:mail-parser", "dep:hickory-resolver", "dep:rustls-pki-types"]
+mta = ["dep:mail-send", "dep:mail-auth", "dep:mail-parser", "dep:hickory-resolver", "dep:rustls-pki-types", "dep:getrandom"]
+# Durable PostgreSQL spool for the native MTA scheduled queue (RFC-0009 section
+# 4.2). Opt-in mirror so scheduled jobs survive a restart; the in-memory tier
+# stays the default (ADR-0009 rule 2). Uses the runtime sqlx API (no DB needed
+# at build time). Implies `mta`.
+queue-postgres = ["mta", "dep:sqlx"]
 # Superficie de API gestionada (Fase 4.6-C). Por ahora: firma de webhooks
 # HMAC-SHA256. Opt-in; ver RFC-0009. Las rutas REST llegan en pasos posteriores.
 api = ["dep:hmac", "dep:sha2", "dep:base64"]
@@ -90,6 +95,9 @@ mail-auth = { version = "0.9", optional = true, default-features = false, featur
 mail-parser = { version = "0.11", optional = true, default-features = false }
 hickory-resolver = { version = "0.26.1", optional = true, default-features = false, features = ["tokio"] }
 rustls-pki-types = { workspace = true, optional = true }
+
+# Random job ids for the MTA scheduled queue (feature "mta"). Tiny, no-std-friendly.
+getrandom = { workspace = true, optional = true }
 
 # Firma de webhooks (feature "api").
 hmac = { workspace = true, optional = true }

--- a/crates/ag-mail/src/sender/mta/mod.rs
+++ b/crates/ag-mail/src/sender/mta/mod.rs
@@ -14,8 +14,9 @@
 //! ([`shaping`]), a two-tier scheduled/ready delivery queue with retry/backoff
 //! and automatic suppression ([`queue`], [`suppress`]), and `ag-observe`
 //! metrics. `MtaSender` is the direct sender and also a [`queue::DeliveryBackend`].
-//! A durable queue spool (JetStream / PostgreSQL) and asynchronous DSN/FBL
-//! intake are later, optional parts of Phase 4.6-B (`RFC-0009`, `docs/DEBT.md`).
+//! An opt-in durable queue spool ([`spool`], PostgreSQL behind the
+//! `queue-postgres` feature) lets scheduled jobs survive a restart while the
+//! in-memory tier stays the default (`RFC-0009` section 4.2, `ADR-0009`).
 //!
 //! Governing decision: `ADR-0010`; technical plan: `RFC-0009`.
 
@@ -26,6 +27,7 @@ pub mod egress;
 pub mod queue;
 pub mod resolve;
 pub mod shaping;
+pub mod spool;
 pub mod suppress;
 
 use std::collections::BTreeMap;
@@ -53,7 +55,11 @@ pub use queue::{
 };
 pub use resolve::ResolverConfigMta;
 pub use shaping::{Shaper, ShapingConfig, ShapingLimits};
+pub use spool::{InMemorySpool, PersistedJob, Spool, SpoolError};
 pub use suppress::{SuppressionList, SuppressionReason};
+
+#[cfg(feature = "queue-postgres")]
+pub use spool::PostgresSpool;
 
 /// Configuration for the native MTA sender.
 #[derive(Debug, Clone)]

--- a/crates/ag-mail/src/sender/mta/queue.rs
+++ b/crates/ag-mail/src/sender/mta/queue.rs
@@ -10,24 +10,53 @@
 //!
 //! Delivery is abstracted behind [`DeliveryBackend`] so the scheduling logic is
 //! deterministic and unit-tested with a mock; [`super::MtaSender`] implements
-//! the trait for real delivery. This is the native, in-memory tier; a durable
-//! spool (JetStream / PostgreSQL) is a later, optional backing (see
-//! `docs/DEBT.md`).
+//! the trait for real delivery. This is the native, in-memory tier; an opt-in
+//! durable spool ([`super::spool`], PostgreSQL behind the `queue-postgres`
+//! feature) mirrors the scheduled set so jobs survive a restart, while the
+//! in-memory tier stays the default (ADR-0009 rule 2).
 
 use std::cmp::Ordering;
 use std::collections::BinaryHeap;
 use std::sync::atomic::{AtomicU64, Ordering as AtomicOrdering};
-use std::sync::Mutex;
-use std::time::{Duration, Instant};
+use std::sync::{Arc, Mutex};
+use std::time::{Duration, Instant, SystemTime, UNIX_EPOCH};
 
 use async_trait::async_trait;
 
 use super::shaping::Shaper;
+use super::spool::{PersistedJob, Spool, SpoolError};
 use super::suppress::{SuppressionList, SuppressionReason};
+
+/// Generates a stable, durable-unique job id (128 random bits, hex-encoded).
+///
+/// Uniqueness must hold across process restarts and across instances writing to
+/// a shared spool, so the id is random rather than a per-process counter. On the
+/// (essentially impossible) event that the OS RNG fails, it falls back to a
+/// wall-clock + counter mix, which is still unique within and across restarts.
+fn new_job_id() -> String {
+    static FALLBACK_SEQ: AtomicU64 = AtomicU64::new(0);
+    let mut bytes = [0u8; 16];
+    if getrandom::getrandom(&mut bytes).is_err() {
+        let nanos = SystemTime::now()
+            .duration_since(UNIX_EPOCH)
+            .map(|d| d.as_nanos())
+            .unwrap_or(0);
+        let seq = u128::from(FALLBACK_SEQ.fetch_add(1, AtomicOrdering::Relaxed));
+        bytes = (nanos ^ (seq << 64)).to_be_bytes();
+    }
+    let mut id = String::with_capacity(32);
+    for b in bytes {
+        id.push_str(&format!("{b:02x}"));
+    }
+    id
+}
 
 /// A unit of work: one rendered message destined for one recipient domain.
 #[derive(Debug, Clone)]
 pub struct DeliveryJob {
+    /// Stable, durable-unique id. Assigned at construction and preserved across
+    /// reschedules; the durable spool keys rows on it.
+    pub id: String,
     /// Tenant that owns the message (part of the scheduled-queue key).
     pub tenant: String,
     /// Campaign / stream (part of the scheduled-queue key).
@@ -66,6 +95,7 @@ impl DeliveryJob {
         now: Instant,
     ) -> Self {
         Self {
+            id: new_job_id(),
             tenant: tenant.into(),
             campaign: campaign.into(),
             domain: domain.into(),
@@ -201,17 +231,24 @@ impl PartialOrd for Scheduled {
     }
 }
 
-/// Native in-memory two-tier delivery queue.
+/// Native in-memory two-tier delivery queue, with an optional durable spool.
 pub struct MtaQueue {
     scheduled: Mutex<BinaryHeap<Scheduled>>,
     seq: AtomicU64,
     config: QueueConfig,
     shaper: Shaper,
     suppress: SuppressionList,
+    /// Opt-in durable mirror. `None` keeps the pure in-memory behaviour.
+    spool: Option<Arc<dyn Spool>>,
+    /// Reference pair to convert this process's monotonic `Instant`s to
+    /// wall-clock for persistence (`Instant`s are meaningless across restarts).
+    base_instant: Instant,
+    base_wall: SystemTime,
 }
 
 impl MtaQueue {
-    /// Builds a queue with the given configuration and shaper.
+    /// Builds a queue with the given configuration and shaper. No durable spool:
+    /// the queue is purely in-memory (the native default, ADR-0009 rule 2).
     pub fn new(config: QueueConfig, shaper: Shaper) -> Self {
         Self {
             scheduled: Mutex::new(BinaryHeap::new()),
@@ -219,7 +256,22 @@ impl MtaQueue {
             config,
             shaper,
             suppress: SuppressionList::new(),
+            spool: None,
+            base_instant: Instant::now(),
+            base_wall: SystemTime::now(),
         }
+    }
+
+    /// Attaches a durable [`Spool`]. The queue then mirrors its scheduled set to
+    /// the spool (write-through) so jobs survive a restart; call [`recover`] on
+    /// startup to repopulate from it. The in-memory heap stays the runtime
+    /// source of truth.
+    ///
+    /// [`recover`]: MtaQueue::recover
+    #[must_use]
+    pub fn with_spool(mut self, spool: Arc<dyn Spool>) -> Self {
+        self.spool = Some(spool);
+        self
     }
 
     /// Access to the suppression list (shared by inbound DSN/FBL processing).
@@ -241,6 +293,94 @@ impl MtaQueue {
     pub fn enqueue(&self, job: DeliveryJob) {
         crate::metrics::queue_depth_inc();
         self.push(job);
+    }
+
+    /// Enqueues a job and persists it to the durable spool, if one is attached.
+    ///
+    /// Unlike the best-effort mirroring during a delivery cycle, the initial
+    /// persist is strict: a spool error is returned so the caller knows the job
+    /// is not yet durable. With no spool attached this behaves like [`enqueue`]
+    /// and never errors.
+    ///
+    /// [`enqueue`]: MtaQueue::enqueue
+    pub async fn enqueue_persistent(&self, job: DeliveryJob) -> Result<(), SpoolError> {
+        let persisted = self.to_persisted(&job);
+        crate::metrics::queue_depth_inc();
+        self.push(job);
+        if let Some(spool) = &self.spool {
+            spool.upsert(&persisted).await?;
+        }
+        Ok(())
+    }
+
+    /// Repopulates the scheduled queue from the durable spool. Call once on
+    /// startup, before the delivery loop runs. Returns the number of jobs
+    /// recovered (zero when no spool is attached).
+    pub async fn recover(&self) -> Result<usize, SpoolError> {
+        let Some(spool) = &self.spool else {
+            return Ok(0);
+        };
+        let jobs = spool.load_all().await?;
+        let now = Instant::now();
+        let now_wall_ms = now_wall_ms();
+        let count = jobs.len();
+        for persisted in jobs {
+            let job = persisted_to_job(persisted, now, now_wall_ms);
+            crate::metrics::queue_depth_inc();
+            self.push(job);
+        }
+        Ok(count)
+    }
+
+    /// Best-effort spool upsert during a delivery cycle: logs and swallows
+    /// errors, since the in-memory queue remains the source of truth.
+    async fn mirror_upsert(&self, persisted: &PersistedJob) {
+        if let Some(spool) = &self.spool {
+            if let Err(e) = spool.upsert(persisted).await {
+                tracing::warn!(error = %e, id = %persisted.id, "mta spool upsert failed");
+            }
+        }
+    }
+
+    /// Best-effort spool removal for a job that has left the queue.
+    async fn mirror_remove(&self, id: &str) {
+        if let Some(spool) = &self.spool {
+            if let Err(e) = spool.remove(id).await {
+                tracing::warn!(error = %e, id, "mta spool remove failed");
+            }
+        }
+    }
+
+    /// Converts a job's monotonic timing into the wall-clock representation the
+    /// spool stores, using this process's reference pair.
+    fn to_persisted(&self, job: &DeliveryJob) -> PersistedJob {
+        PersistedJob {
+            id: job.id.clone(),
+            tenant: job.tenant.clone(),
+            campaign: job.campaign.clone(),
+            domain: job.domain.clone(),
+            site_name: job.site_name.clone(),
+            recipients: job.recipients.clone(),
+            from: job.from.clone(),
+            content: job.content.clone(),
+            attempts: job.attempts,
+            enqueued_at_ms: self.instant_to_wall_ms(job.enqueued_at),
+            next_attempt_at_ms: self.instant_to_wall_ms(job.next_attempt_at),
+        }
+    }
+
+    /// Maps a monotonic `Instant` to wall-clock UNIX millis via the reference
+    /// pair captured when the queue was built.
+    fn instant_to_wall_ms(&self, i: Instant) -> i64 {
+        let wall = if i >= self.base_instant {
+            self.base_wall.checked_add(i - self.base_instant)
+        } else {
+            self.base_wall.checked_sub(self.base_instant - i)
+        };
+        let ms = wall
+            .and_then(|w| w.duration_since(UNIX_EPOCH).ok())
+            .map_or(0, |d| d.as_millis());
+        i64::try_from(ms).unwrap_or(i64::MAX)
     }
 
     fn push(&self, job: DeliveryJob) {
@@ -292,6 +432,7 @@ impl MtaQueue {
             if job.recipients.is_empty() {
                 report.skipped_suppressed += 1;
                 crate::metrics::queue_depth_dec();
+                self.mirror_remove(&job.id).await;
                 continue;
             }
 
@@ -299,7 +440,9 @@ impl MtaQueue {
             let wait = self.shaper.acquire_rate(&job.site_name, now);
             if wait > Duration::ZERO {
                 job.next_attempt_at = now + wait;
+                let persisted = self.to_persisted(&job);
                 self.push(job);
+                self.mirror_upsert(&persisted).await;
                 report.throttled += 1;
                 continue;
             }
@@ -311,6 +454,7 @@ impl MtaQueue {
                 DeliveryOutcome::Delivered => {
                     report.delivered += 1;
                     crate::metrics::queue_depth_dec();
+                    self.mirror_remove(&job.id).await;
                 }
                 DeliveryOutcome::Permanent(_) => {
                     for r in &job.recipients {
@@ -318,6 +462,7 @@ impl MtaQueue {
                     }
                     report.suppressed += 1;
                     crate::metrics::queue_depth_dec();
+                    self.mirror_remove(&job.id).await;
                 }
                 DeliveryOutcome::Transient(_) => {
                     job.attempts += 1;
@@ -331,9 +476,12 @@ impl MtaQueue {
                         }
                         report.expired += 1;
                         crate::metrics::queue_depth_dec();
+                        self.mirror_remove(&job.id).await;
                     } else {
                         job.next_attempt_at = now + self.config.retry.backoff(job.attempts);
+                        let persisted = self.to_persisted(&job);
                         self.push(job);
+                        self.mirror_upsert(&persisted).await;
                         report.retried += 1;
                     }
                 }
@@ -355,6 +503,46 @@ impl MtaQueue {
             };
             tokio::time::sleep(sleep).await;
         }
+    }
+}
+
+/// Current wall-clock time as UNIX milliseconds.
+fn now_wall_ms() -> i64 {
+    let ms = SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .map_or(0, |d| d.as_millis());
+    i64::try_from(ms).unwrap_or(i64::MAX)
+}
+
+/// Rebuilds a [`DeliveryJob`] from its persisted form, mapping wall-clock
+/// timestamps back to monotonic `Instant`s relative to `now`. A time already in
+/// the past becomes due immediately.
+fn persisted_to_job(p: PersistedJob, now: Instant, now_wall_ms: i64) -> DeliveryJob {
+    DeliveryJob {
+        id: p.id,
+        tenant: p.tenant,
+        campaign: p.campaign,
+        domain: p.domain,
+        site_name: p.site_name,
+        recipients: p.recipients,
+        from: p.from,
+        content: p.content,
+        attempts: p.attempts,
+        enqueued_at: wall_ms_to_instant(now, now_wall_ms, p.enqueued_at_ms),
+        next_attempt_at: wall_ms_to_instant(now, now_wall_ms, p.next_attempt_at_ms),
+    }
+}
+
+/// Maps a wall-clock UNIX-millis timestamp to a monotonic `Instant` relative to
+/// `now`/`now_wall_ms`. Past timestamps clamp to at-or-before `now` (due now).
+fn wall_ms_to_instant(now: Instant, now_wall_ms: i64, ms: i64) -> Instant {
+    if ms >= now_wall_ms {
+        now + Duration::from_millis(u64::try_from(ms - now_wall_ms).unwrap_or(0))
+    } else {
+        now.checked_sub(Duration::from_millis(
+            u64::try_from(now_wall_ms - ms).unwrap_or(0),
+        ))
+        .unwrap_or(now)
     }
 }
 
@@ -565,5 +753,81 @@ mod tests {
         let report = q.process_due(now, &backend).await;
         assert_eq!(report.delivered, 2);
         assert_eq!(q.len(), 3);
+    }
+
+    // ---- durable spool mechanism (backend-agnostic, in-process) -------------
+
+    use super::super::spool::InMemorySpool;
+
+    #[tokio::test]
+    async fn scheduled_jobs_survive_restart_via_spool() {
+        let spool = Arc::new(InMemorySpool::new());
+        let now = Instant::now();
+
+        // First process lifetime: enqueue two jobs due in the future.
+        {
+            let q =
+                MtaQueue::new(QueueConfig::default(), shaper_unlimited()).with_spool(spool.clone());
+            let mut j1 = job(now);
+            j1.next_attempt_at = now + Duration::from_secs(3600);
+            let mut j2 = job(now);
+            j2.next_attempt_at = now + Duration::from_secs(7200);
+            q.enqueue_persistent(j1).await.unwrap();
+            q.enqueue_persistent(j2).await.unwrap();
+            assert_eq!(q.len(), 2);
+            assert_eq!(spool.len(), 2);
+        } // queue dropped == process crash
+
+        // Second process lifetime: a fresh queue recovers from the same spool.
+        let q2 =
+            MtaQueue::new(QueueConfig::default(), shaper_unlimited()).with_spool(spool.clone());
+        assert_eq!(q2.len(), 0);
+        let recovered = q2.recover().await.unwrap();
+        assert_eq!(recovered, 2);
+        assert_eq!(q2.len(), 2);
+    }
+
+    #[tokio::test]
+    async fn delivered_job_is_removed_from_spool() {
+        let spool = Arc::new(InMemorySpool::new());
+        let now = Instant::now();
+        let q = MtaQueue::new(QueueConfig::default(), shaper_unlimited()).with_spool(spool.clone());
+        q.enqueue_persistent(job(now)).await.unwrap();
+        assert_eq!(spool.len(), 1);
+
+        let backend =
+            ScriptBackend::new(vec![DeliveryOutcome::Delivered], DeliveryOutcome::Delivered);
+        q.process_due(now, &backend).await;
+
+        assert!(q.is_empty());
+        assert_eq!(spool.len(), 0);
+    }
+
+    #[tokio::test]
+    async fn retried_job_is_updated_in_spool() {
+        let spool = Arc::new(InMemorySpool::new());
+        let now = Instant::now();
+        let q = MtaQueue::new(QueueConfig::default(), shaper_unlimited()).with_spool(spool.clone());
+        q.enqueue_persistent(job(now)).await.unwrap();
+
+        let backend = ScriptBackend::new(
+            vec![DeliveryOutcome::Transient("451 4.7.0".into())],
+            DeliveryOutcome::Delivered,
+        );
+        q.process_due(now, &backend).await;
+
+        // Rescheduled (not delivered): still persisted, attempts bumped to 1.
+        assert_eq!(spool.len(), 1);
+        let jobs = spool.load_all().await.unwrap();
+        assert_eq!(jobs[0].attempts, 1);
+    }
+
+    #[tokio::test]
+    async fn enqueue_persistent_without_spool_is_inmemory() {
+        let now = Instant::now();
+        let q = MtaQueue::new(QueueConfig::default(), shaper_unlimited());
+        q.enqueue_persistent(job(now)).await.unwrap();
+        assert_eq!(q.len(), 1);
+        assert_eq!(q.recover().await.unwrap(), 0);
     }
 }

--- a/crates/ag-mail/src/sender/mta/spool.rs
+++ b/crates/ag-mail/src/sender/mta/spool.rs
@@ -1,0 +1,253 @@
+//! Durable spool backing for the native MTA scheduled queue (RFC-0009 section 4.2).
+//!
+//! The in-memory [`super::queue::MtaQueue`] is the runtime source of truth; a
+//! [`Spool`] is an opt-in write-through mirror so that scheduled
+//! (not-yet-delivered) jobs survive a process restart. Two backends ship:
+//!
+//! - [`InMemorySpool`]: a process-local map. It is the reference implementation
+//!   and is used by the queue's own tests; it does not outlive the process, so
+//!   it documents the [`Spool`] contract rather than providing real durability.
+//! - [`PostgresSpool`] (feature `queue-postgres`): a durable PostgreSQL mirror.
+//!
+//! Keeping the in-memory queue as the native default honours ADR-0009 rule 2:
+//! the durable backend is opt-in and never required to use the MTA.
+
+use std::collections::HashMap;
+use std::sync::Mutex;
+
+use async_trait::async_trait;
+
+/// Error from a spool backend.
+#[derive(Debug, thiserror::Error)]
+#[non_exhaustive]
+pub enum SpoolError {
+    /// The backing store rejected or failed an operation.
+    #[error("spool backend error: {0}")]
+    Backend(String),
+}
+
+/// A delivery job as persisted in a spool.
+///
+/// Identical to a [`super::queue::DeliveryJob`] except that the two timing
+/// fields are wall-clock UNIX-epoch milliseconds instead of monotonic
+/// `Instant`s, which are meaningless across a restart. The queue converts
+/// between the two representations.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct PersistedJob {
+    /// Stable job id (primary key).
+    pub id: String,
+    /// Owning tenant.
+    pub tenant: String,
+    /// Campaign / stream.
+    pub campaign: String,
+    /// Recipient domain.
+    pub domain: String,
+    /// Destination `site_name` (MX rollup) used for shaping.
+    pub site_name: String,
+    /// Envelope recipients at this domain.
+    pub recipients: Vec<String>,
+    /// Envelope sender.
+    pub from: String,
+    /// Rendered RFC 5322 message bytes.
+    pub content: Vec<u8>,
+    /// Attempts made so far.
+    pub attempts: u32,
+    /// Wall-clock time the job first entered the queue (UNIX millis).
+    pub enqueued_at_ms: i64,
+    /// Wall-clock earliest next attempt (UNIX millis).
+    pub next_attempt_at_ms: i64,
+}
+
+/// A durable backing store for the MTA scheduled queue.
+///
+/// Implementations mirror the in-memory scheduled set: [`upsert`](Spool::upsert)
+/// on enqueue and on every reschedule, [`remove`](Spool::remove) when a job
+/// leaves the queue (delivered, suppressed or expired), and
+/// [`load_all`](Spool::load_all) to repopulate the queue on startup. After the
+/// initial enqueue, mirroring is best-effort: a failed mirror write is logged
+/// and does not fail delivery, since the in-memory queue remains the runtime
+/// source of truth.
+#[async_trait]
+pub trait Spool: Send + Sync {
+    /// Persists or updates a job, keyed by [`PersistedJob::id`].
+    async fn upsert(&self, job: &PersistedJob) -> Result<(), SpoolError>;
+    /// Removes a job that has left the queue.
+    async fn remove(&self, id: &str) -> Result<(), SpoolError>;
+    /// Loads every persisted job, for recovery on startup.
+    async fn load_all(&self) -> Result<Vec<PersistedJob>, SpoolError>;
+}
+
+/// Process-local reference spool.
+///
+/// Useful as a default and in tests; it does not survive the process, so it
+/// documents the [`Spool`] contract rather than providing real cross-restart
+/// durability.
+#[derive(Debug, Default)]
+pub struct InMemorySpool {
+    jobs: Mutex<HashMap<String, PersistedJob>>,
+}
+
+impl InMemorySpool {
+    /// Creates an empty spool.
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    /// Number of jobs currently held (inspection/test helper).
+    pub fn len(&self) -> usize {
+        self.jobs.lock().expect("spool lock poisoned").len()
+    }
+
+    /// Whether the spool is empty.
+    pub fn is_empty(&self) -> bool {
+        self.len() == 0
+    }
+}
+
+#[async_trait]
+impl Spool for InMemorySpool {
+    async fn upsert(&self, job: &PersistedJob) -> Result<(), SpoolError> {
+        self.jobs
+            .lock()
+            .expect("spool lock poisoned")
+            .insert(job.id.clone(), job.clone());
+        Ok(())
+    }
+
+    async fn remove(&self, id: &str) -> Result<(), SpoolError> {
+        self.jobs.lock().expect("spool lock poisoned").remove(id);
+        Ok(())
+    }
+
+    async fn load_all(&self) -> Result<Vec<PersistedJob>, SpoolError> {
+        Ok(self
+            .jobs
+            .lock()
+            .expect("spool lock poisoned")
+            .values()
+            .cloned()
+            .collect())
+    }
+}
+
+#[cfg(feature = "queue-postgres")]
+pub use postgres::PostgresSpool;
+
+#[cfg(feature = "queue-postgres")]
+mod postgres {
+    use super::{PersistedJob, Spool, SpoolError};
+    use async_trait::async_trait;
+    use sqlx::postgres::PgPoolOptions;
+    use sqlx::{PgPool, Row};
+
+    fn backend_err(e: sqlx::Error) -> SpoolError {
+        SpoolError::Backend(e.to_string())
+    }
+
+    const CREATE_SQL: &str = "CREATE TABLE IF NOT EXISTS ag_mail_mta_spool (\
+        id TEXT PRIMARY KEY, tenant TEXT NOT NULL, campaign TEXT NOT NULL, \
+        domain TEXT NOT NULL, site_name TEXT NOT NULL, recipients TEXT[] NOT NULL, \
+        sender TEXT NOT NULL, content BYTEA NOT NULL, attempts INTEGER NOT NULL, \
+        enqueued_at_ms BIGINT NOT NULL, next_attempt_at_ms BIGINT NOT NULL)";
+
+    /// Durable PostgreSQL mirror of the MTA scheduled queue (RFC-0009 section 4.2).
+    ///
+    /// Uses the runtime `sqlx` API (not the compile-time macros) so the crate
+    /// builds without a live `DATABASE_URL`. The backing table is created on
+    /// demand. Recipients map to a `TEXT[]` column and the message bytes to
+    /// `BYTEA`, so no extra serialization is needed.
+    pub struct PostgresSpool {
+        pool: PgPool,
+    }
+
+    impl PostgresSpool {
+        /// Connects to `database_url`, opening a small pool, and ensures the
+        /// spool table exists.
+        pub async fn connect(database_url: &str) -> Result<Self, SpoolError> {
+            let pool = PgPoolOptions::new()
+                .max_connections(4)
+                .connect(database_url)
+                .await
+                .map_err(backend_err)?;
+            Self::from_pool(pool).await
+        }
+
+        /// Builds the spool over an existing pool, ensuring the table exists.
+        pub async fn from_pool(pool: PgPool) -> Result<Self, SpoolError> {
+            sqlx::query(CREATE_SQL)
+                .execute(&pool)
+                .await
+                .map_err(backend_err)?;
+            Ok(Self { pool })
+        }
+    }
+
+    #[async_trait]
+    impl Spool for PostgresSpool {
+        async fn upsert(&self, job: &PersistedJob) -> Result<(), SpoolError> {
+            // Only `attempts` and `next_attempt_at_ms` change across reschedules;
+            // the rest of the row is immutable for a given job id.
+            sqlx::query(
+                "INSERT INTO ag_mail_mta_spool \
+                 (id, tenant, campaign, domain, site_name, recipients, sender, content, \
+                  attempts, enqueued_at_ms, next_attempt_at_ms) \
+                 VALUES ($1,$2,$3,$4,$5,$6,$7,$8,$9,$10,$11) \
+                 ON CONFLICT (id) DO UPDATE SET \
+                  attempts = EXCLUDED.attempts, \
+                  next_attempt_at_ms = EXCLUDED.next_attempt_at_ms",
+            )
+            .bind(&job.id)
+            .bind(&job.tenant)
+            .bind(&job.campaign)
+            .bind(&job.domain)
+            .bind(&job.site_name)
+            .bind(&job.recipients)
+            .bind(&job.from)
+            .bind(&job.content)
+            .bind(i32::try_from(job.attempts).unwrap_or(i32::MAX))
+            .bind(job.enqueued_at_ms)
+            .bind(job.next_attempt_at_ms)
+            .execute(&self.pool)
+            .await
+            .map_err(backend_err)?;
+            Ok(())
+        }
+
+        async fn remove(&self, id: &str) -> Result<(), SpoolError> {
+            sqlx::query("DELETE FROM ag_mail_mta_spool WHERE id = $1")
+                .bind(id)
+                .execute(&self.pool)
+                .await
+                .map_err(backend_err)?;
+            Ok(())
+        }
+
+        async fn load_all(&self) -> Result<Vec<PersistedJob>, SpoolError> {
+            let rows = sqlx::query(
+                "SELECT id, tenant, campaign, domain, site_name, recipients, sender, \
+                 content, attempts, enqueued_at_ms, next_attempt_at_ms \
+                 FROM ag_mail_mta_spool",
+            )
+            .fetch_all(&self.pool)
+            .await
+            .map_err(backend_err)?;
+
+            Ok(rows
+                .into_iter()
+                .map(|row| PersistedJob {
+                    id: row.get("id"),
+                    tenant: row.get("tenant"),
+                    campaign: row.get("campaign"),
+                    domain: row.get("domain"),
+                    site_name: row.get("site_name"),
+                    recipients: row.get("recipients"),
+                    from: row.get("sender"),
+                    content: row.get("content"),
+                    attempts: u32::try_from(row.get::<i32, _>("attempts")).unwrap_or(0),
+                    enqueued_at_ms: row.get("enqueued_at_ms"),
+                    next_attempt_at_ms: row.get("next_attempt_at_ms"),
+                })
+                .collect())
+        }
+    }
+}

--- a/crates/ag-mail/tests/mta_spool_postgres.rs
+++ b/crates/ag-mail/tests/mta_spool_postgres.rs
@@ -1,0 +1,75 @@
+//! Live PostgreSQL durable-spool test for the native MTA (RFC-0009 section 4.2).
+//!
+//! Ignored by default: it needs a reachable PostgreSQL through `DATABASE_URL`.
+//! Run it explicitly, e.g.:
+//!
+//! ```sh
+//! DATABASE_URL=postgres://user:pass@localhost/db \
+//!   cargo test -p ag-mail --features queue-postgres --test mta_spool_postgres -- --ignored
+//! ```
+//!
+//! The test is self-isolating: it asserts on the ids it inserts (so leftover
+//! rows from other runs do not affect it) and removes them at the end.
+#![cfg(feature = "queue-postgres")]
+
+use std::sync::Arc;
+use std::time::{Duration, Instant};
+
+use ag_mail::sender::mta::{
+    DeliveryJob, MtaQueue, PostgresSpool, QueueConfig, Shaper, ShapingConfig, ShapingLimits, Spool,
+};
+
+fn shaper() -> Shaper {
+    Shaper::new(ShapingConfig::new(ShapingLimits::UNLIMITED))
+}
+
+fn job(now: Instant) -> DeliveryJob {
+    DeliveryJob::new(
+        "tenant-a",
+        "welcome",
+        "example.com",
+        "mx.example.com",
+        "from@send.example",
+        vec!["a@example.com".to_owned()],
+        b"From: from@send.example\r\nSubject: hi\r\n\r\nbody\r\n".to_vec(),
+        now,
+    )
+}
+
+#[tokio::test]
+#[ignore = "requires DATABASE_URL pointing at a live PostgreSQL"]
+async fn jobs_survive_restart_against_postgres() {
+    let url = std::env::var("DATABASE_URL")
+        .expect("DATABASE_URL must point at a live PostgreSQL for this test");
+
+    // First process lifetime: enqueue a future-dated job through the queue,
+    // mirrored to PostgreSQL, then drop everything (simulating a crash).
+    let id = {
+        let spool = Arc::new(PostgresSpool::connect(&url).await.unwrap());
+        let queue = MtaQueue::new(QueueConfig::default(), shaper()).with_spool(spool.clone());
+        let now = Instant::now();
+        let mut j = job(now);
+        j.next_attempt_at = now + Duration::from_secs(3600);
+        let id = j.id.clone();
+        queue.enqueue_persistent(j).await.unwrap();
+        id
+    };
+
+    // Second process lifetime: a fresh connection over the same table sees it.
+    let spool2 = Arc::new(PostgresSpool::connect(&url).await.unwrap());
+    let all = spool2.load_all().await.unwrap();
+    assert!(
+        all.iter().any(|p| p.id == id),
+        "the scheduled job must survive a restart in PostgreSQL"
+    );
+
+    // A fresh queue recovers it from the durable backend.
+    let recovered_queue =
+        MtaQueue::new(QueueConfig::default(), shaper()).with_spool(spool2.clone());
+    let recovered = recovered_queue.recover().await.unwrap();
+    assert!(recovered >= 1, "recover() must repopulate the queue");
+    assert!(!recovered_queue.is_empty());
+
+    // Clean up this test's row so reruns stay isolated.
+    spool2.remove(&id).await.unwrap();
+}

--- a/docs/DEBT.md
+++ b/docs/DEBT.md
@@ -91,7 +91,13 @@ For current, actionable debt see the GitHub Issues board filtered by the
   dev image) and a self-hosted NATS/JetStream binary both run as ephemeral
   services / CI service containers; neither requires a third party. The debt is
   the unimplemented backend, not a missing environment.
-- Status: migrated to GitHub issue #151 (live tracking). Owning plan: RFC-0009 section 4.2. Target: Phase 4.6-B.
+- Status: migrated to GitHub issue #151 (live tracking). A durable PostgreSQL
+  spool now ships behind the `queue-postgres` feature
+  (`sender::mta::spool::PostgresSpool`), mirroring the scheduled queue so jobs
+  survive a restart; the in-memory tier stays the default (ADR-0009 rule 2). The
+  backend-agnostic recover mechanism is covered by in-process tests; the live
+  PostgreSQL round-trip is an `#[ignore]` test gated on `DATABASE_URL`. Owning
+  plan: RFC-0009 section 4.2. Target: Phase 4.6-B.
 
 ### DEBT-021 — Native MTA: REST API, webhooks, marketing (Phases 4.6-C/D)
 - Reason: the multi-tenant REST surface and the marketing objects

--- a/docs/pr-drafts/feat-ag-mail-mta-durable-spool.md
+++ b/docs/pr-drafts/feat-ag-mail-mta-durable-spool.md
@@ -1,0 +1,94 @@
+# Descriptor de PR
+
+## Resumen
+
+ag-mail: spool durable opt-in para la cola programada del MTA nativo (PostgreSQL tras feature `queue-postgres`)
+
+## Fase afectada
+
+Fase 4.6-B (motor MTA nativo de `ag-mail`). Trabajo aditivo gobernado por
+RFC-0009 section 4.2; no avanza una fase de la Hoja de Ruta.
+
+## Tipo de cambio
+
+- [ ] Correccion de bug
+- [x] Nueva feature (spool durable del MTA tras feature Cargo)
+- [x] Documentacion (cabeceras de modulo, README, DEBT-023)
+- [ ] CI / seguridad
+- [ ] Cambio que rompe compatibilidad
+
+## Contexto
+
+La cola de dos niveles del MTA nativo (`sender::mta::queue::MtaQueue`) era solo
+en memoria: un reinicio perdia los jobs programados (no entregados todavia)
+(DEBT-023 / issue #151). Esta PR anade un spool durable opt-in.
+
+El mecanismo de durabilidad es agnostico del backend: la cola en memoria sigue
+siendo la fuente de verdad en runtime y espeja (write-through) su conjunto
+programado a un `Spool` (`upsert` al encolar y en cada reprogramacion, `remove`
+al salir de la cola, `load_all` para recuperar al arrancar). El nivel en memoria
+se mantiene como default (ADR-0009 regla 2): sin spool adjunto, el comportamiento
+es identico al anterior.
+
+## Cambios
+
+- `crates/ag-mail/src/sender/mta/spool.rs` (nuevo): trait `Spool`, tipo
+  `PersistedJob` (timestamps wall-clock en vez de `Instant`), `InMemorySpool`
+  (referencia + tests) y `PostgresSpool` tras feature `queue-postgres`. Usa la
+  API `sqlx` en runtime (no las macros), asi el crate compila sin `DATABASE_URL`.
+  `recipients` mapea a `TEXT[]` y el mensaje a `BYTEA` (sin serializacion extra).
+- `crates/ag-mail/src/sender/mta/queue.rs`: `DeliveryJob` gana un `id` estable
+  (128 bits aleatorios) para indexar el spool; `MtaQueue` gana un
+  `Option<Arc<dyn Spool>>` y un par base `Instant`/`SystemTime` para convertir
+  monotonic a wall-clock; metodos `with_spool`, `enqueue_persistent`, `recover`
+  y el espejado best-effort en `process_due`. Cuatro tests del mecanismo.
+- `crates/ag-mail/Cargo.toml`: feature `queue-postgres = ["mta", "dep:sqlx"]`;
+  `getrandom` opcional anadido a `mta`.
+- `crates/ag-mail/tests/mta_spool_postgres.rs` (nuevo): test live `#[ignore]`
+  contra PostgreSQL via `DATABASE_URL`, autolimpiante.
+- `README.md` (EN + mirror ES) y `docs/DEBT.md` DEBT-023 sincronizados.
+
+## Plan de prueba
+
+```sh
+cargo fmt --check -p ag-mail
+cargo clippy -p ag-mail -- -D warnings
+cargo clippy -p ag-mail --features mta -- -D warnings
+cargo clippy -p ag-mail --features queue-postgres --tests -- -D warnings
+cargo build  -p ag-mail --features queue-postgres   # sqlx runtime: sin DB en build
+cargo test   -p ag-mail --features mta              # incluye los 4 tests del spool
+# Test live (requiere PostgreSQL):
+DATABASE_URL=postgres://... \
+  cargo test -p ag-mail --features queue-postgres --test mta_spool_postgres -- --ignored
+```
+
+## Alcance de verificacion (honesto)
+
+- Verificado en este entorno: el mecanismo de durabilidad
+  (`scheduled_jobs_survive_restart_via_spool`, `delivered_job_is_removed_from_spool`,
+  `retried_job_is_updated_in_spool`, `enqueue_persistent_without_spool_is_inmemory`)
+  pasa en proceso con `InMemorySpool`; `fmt`/`clippy`/`build`/109 tests en verde
+  con y sin features.
+- NO ejecutado aqui: el round-trip live contra PostgreSQL. El sandbox no tiene
+  daemon Docker ni servidor PostgreSQL local, asi que ese test queda `#[ignore]`
+  + `DATABASE_URL` documentado (CLAUDE.md section 29.2 lo admite para
+  dependencias de servicio externo). Debe correrse en CI/entorno con credenciales.
+
+## Criterios de salida que avanza
+
+- Spool durable tras feature con el nivel en memoria como default (ADR-0009).
+- Jobs programados sobreviven a un reinicio (cubierto por test; live `#[ignore]`).
+- DEBT-023 referencia y describe la implementacion.
+
+## Cierre de issues
+
+Closes #151
+
+## Checklist final
+
+- [x] Pertenece a la fase correcta (4.6-B) y respeta RFC-0009 section 4.2.
+- [x] No rompe arquitectura; el camino en memoria por defecto es identico.
+- [x] No crea dependencias circulares; `getrandom`/`sqlx` ya estaban en el workspace.
+- [x] Compila; pasa fmt, clippy y tests con y sin features.
+- [x] Documentacion sincronizada (modulo, README EN+ES, DEBT-023).
+- [x] Sin evidencia de herramientas IA; atribuido a la persona autora.


### PR DESCRIPTION
# Descriptor de PR

## Resumen

ag-mail: spool durable opt-in para la cola programada del MTA nativo (PostgreSQL tras feature `queue-postgres`)

## Fase afectada

Fase 4.6-B (motor MTA nativo de `ag-mail`). Trabajo aditivo gobernado por
RFC-0009 section 4.2; no avanza una fase de la Hoja de Ruta.

## Tipo de cambio

- [ ] Correccion de bug
- [x] Nueva feature (spool durable del MTA tras feature Cargo)
- [x] Documentacion (cabeceras de modulo, README, DEBT-023)
- [ ] CI / seguridad
- [ ] Cambio que rompe compatibilidad

## Contexto

La cola de dos niveles del MTA nativo (`sender::mta::queue::MtaQueue`) era solo
en memoria: un reinicio perdia los jobs programados (no entregados todavia)
(DEBT-023 / issue #151). Esta PR anade un spool durable opt-in.

El mecanismo de durabilidad es agnostico del backend: la cola en memoria sigue
siendo la fuente de verdad en runtime y espeja (write-through) su conjunto
programado a un `Spool` (`upsert` al encolar y en cada reprogramacion, `remove`
al salir de la cola, `load_all` para recuperar al arrancar). El nivel en memoria
se mantiene como default (ADR-0009 regla 2): sin spool adjunto, el comportamiento
es identico al anterior.

## Cambios

- `crates/ag-mail/src/sender/mta/spool.rs` (nuevo): trait `Spool`, tipo
  `PersistedJob` (timestamps wall-clock en vez de `Instant`), `InMemorySpool`
  (referencia + tests) y `PostgresSpool` tras feature `queue-postgres`. Usa la
  API `sqlx` en runtime (no las macros), asi el crate compila sin `DATABASE_URL`.
  `recipients` mapea a `TEXT[]` y el mensaje a `BYTEA` (sin serializacion extra).
- `crates/ag-mail/src/sender/mta/queue.rs`: `DeliveryJob` gana un `id` estable
  (128 bits aleatorios) para indexar el spool; `MtaQueue` gana un
  `Option<Arc<dyn Spool>>` y un par base `Instant`/`SystemTime` para convertir
  monotonic a wall-clock; metodos `with_spool`, `enqueue_persistent`, `recover`
  y el espejado best-effort en `process_due`. Cuatro tests del mecanismo.
- `crates/ag-mail/Cargo.toml`: feature `queue-postgres = ["mta", "dep:sqlx"]`;
  `getrandom` opcional anadido a `mta`.
- `crates/ag-mail/tests/mta_spool_postgres.rs` (nuevo): test live `#[ignore]`
  contra PostgreSQL via `DATABASE_URL`, autolimpiante.
- `README.md` (EN + mirror ES) y `docs/DEBT.md` DEBT-023 sincronizados.

## Plan de prueba

```sh
cargo fmt --check -p ag-mail
cargo clippy -p ag-mail -- -D warnings
cargo clippy -p ag-mail --features mta -- -D warnings
cargo clippy -p ag-mail --features queue-postgres --tests -- -D warnings
cargo build  -p ag-mail --features queue-postgres   # sqlx runtime: sin DB en build
cargo test   -p ag-mail --features mta              # incluye los 4 tests del spool
# Test live (requiere PostgreSQL):
DATABASE_URL=postgres://... \
  cargo test -p ag-mail --features queue-postgres --test mta_spool_postgres -- --ignored
```

## Alcance de verificacion (honesto)

- Verificado en este entorno: el mecanismo de durabilidad
  (`scheduled_jobs_survive_restart_via_spool`, `delivered_job_is_removed_from_spool`,
  `retried_job_is_updated_in_spool`, `enqueue_persistent_without_spool_is_inmemory`)
  pasa en proceso con `InMemorySpool`; `fmt`/`clippy`/`build`/109 tests en verde
  con y sin features.
- NO ejecutado aqui: el round-trip live contra PostgreSQL. El sandbox no tiene
  daemon Docker ni servidor PostgreSQL local, asi que ese test queda `#[ignore]`
  + `DATABASE_URL` documentado (CLAUDE.md section 29.2 lo admite para
  dependencias de servicio externo). Debe correrse en CI/entorno con credenciales.

## Criterios de salida que avanza

- Spool durable tras feature con el nivel en memoria como default (ADR-0009).
- Jobs programados sobreviven a un reinicio (cubierto por test; live `#[ignore]`).
- DEBT-023 referencia y describe la implementacion.

## Cierre de issues

Closes #151

## Checklist final

- [x] Pertenece a la fase correcta (4.6-B) y respeta RFC-0009 section 4.2.
- [x] No rompe arquitectura; el camino en memoria por defecto es identico.
- [x] No crea dependencias circulares; `getrandom`/`sqlx` ya estaban en el workspace.
- [x] Compila; pasa fmt, clippy y tests con y sin features.
- [x] Documentacion sincronizada (modulo, README EN+ES, DEBT-023).
- [x] Sin evidencia de herramientas IA; atribuido a la persona autora.
