### PR TITLE
Pre-Phase-5 backlog: ag-cache external Redis L2 and native MTA STARTTLS protocol test

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -47,8 +47,10 @@ name = "ag-cache"
 version = "0.0.0"
 dependencies = [
  "ag-core",
+ "async-trait",
  "dashmap 6.2.1",
  "moka",
+ "redis",
  "serde",
  "serde_json",
  "testcontainers",
@@ -502,6 +504,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "arc-swap"
+version = "1.9.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6a3a1fd6f75306b68087b831f025c712524bcb19aad54e557b1129cfa0a2b207"
+dependencies = [
+ "rustversion",
+]
+
+[[package]]
 name = "arrayref"
 version = "0.3.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -799,6 +810,15 @@ dependencies = [
  "sync_wrapper",
  "tower-layer",
  "tower-service",
+]
+
+[[package]]
+name = "backon"
+version = "1.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cffb0e931875b666fc4fcb20fee52e9bbd1ef836fd9e9e04ec21555f9f85f7ef"
+dependencies = [
+ "fastrand",
 ]
 
 [[package]]
@@ -1187,7 +1207,11 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ba5a308b75df32fe02788e748662718f03fde005016435c444eea572398219fd"
 dependencies = [
  "bytes",
+ "futures-core",
  "memchr",
+ "pin-project-lite",
+ "tokio",
+ "tokio-util",
 ]
 
 [[package]]
@@ -4259,6 +4283,30 @@ dependencies = [
  "tokio",
  "tokio-stream",
  "tracing",
+]
+
+[[package]]
+name = "redis"
+version = "0.27.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "09d8f99a4090c89cc489a94833c901ead69bfbf3877b4867d5482e321ee875bc"
+dependencies = [
+ "arc-swap",
+ "async-trait",
+ "backon",
+ "bytes",
+ "combine",
+ "futures",
+ "futures-util",
+ "itertools 0.13.0",
+ "itoa",
+ "num-bigint",
+ "percent-encoding",
+ "pin-project-lite",
+ "ryu",
+ "tokio",
+ "tokio-util",
+ "url",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -257,6 +257,8 @@ dependencies = [
  "metrics",
  "minijinja",
  "proptest",
+ "rcgen",
+ "rustls",
  "rustls-pki-types",
  "serde",
  "serde_json",
@@ -264,6 +266,7 @@ dependencies = [
  "sqlx",
  "thiserror 1.0.69",
  "tokio",
+ "tokio-rustls",
  "tracing",
 ]
 

--- a/README.md
+++ b/README.md
@@ -94,7 +94,8 @@ in CI:
 - Use the standard modules (Phase 4):
   - `ag-auth`: WebAuthn/FIDO2, OAuth2 PKCE, JWT Ed25519, API keys, refresh
     tokens.
-  - `ag-cache`: in-process L1 cache plus a native RESP2 L2 server.
+  - `ag-cache`: in-process L1 cache plus a native RESP2 L2 server, with an
+    optional external Redis L2 for multi-instance setups (feature `redis-l2`).
   - `ag-realtime`: in-process event bus, WebSocket/SSE helpers, optional
     external NATS client.
   - `ag-storage`: filesystem store, image processing, signed URLs, optional
@@ -529,7 +530,8 @@ tests en CI:
 - Usar los modulos estandar (Fase 4):
   - `ag-auth`: WebAuthn/FIDO2, OAuth2 PKCE, JWT Ed25519, API keys, refresh
     tokens.
-  - `ag-cache`: cache L1 en proceso mas un servidor L2 RESP2 nativo.
+  - `ag-cache`: cache L1 en proceso mas un servidor L2 RESP2 nativo, con un L2
+    Redis externo opcional para despliegues multi-instancia (feature `redis-l2`).
   - `ag-realtime`: bus de eventos en proceso, helpers WebSocket/SSE, cliente
     NATS externo opcional.
   - `ag-storage`: store de filesystem, procesamiento de imagenes, URLs

--- a/crates/ag-cache/Cargo.toml
+++ b/crates/ag-cache/Cargo.toml
@@ -9,7 +9,7 @@ repository.workspace = true
 homepage.workspace = true
 documentation.workspace = true
 readme = "README.md"
-description = "Cache multinivel L1 (moka) + L2 opcional (Redis/fred) con invalidacion por tags"
+description = "Cache multinivel L1 (moka) + L2 opcional (servidor RESP2 nativo o Redis externo) con invalidacion por tags"
 keywords.workspace = true
 categories.workspace = true
 publish = false
@@ -19,9 +19,13 @@ workspace = true
 
 [features]
 native-server = ["dep:dashmap"]
+# External Redis L2 backing for multi-instance deployments (RFC-0005 alt A as an
+# opt-in adapter; ADR-0009 rule 2). The in-process path stays the default.
+redis-l2 = ["dep:redis"]
 
 [dependencies]
 ag-core = { workspace = true }
+async-trait = { workspace = true }
 moka = { workspace = true }
 serde = { workspace = true }
 serde_json = { workspace = true }
@@ -30,6 +34,11 @@ tracing = { workspace = true }
 
 # Native RESP2 server: per-key expiry tracking and key registry
 dashmap = { version = "6", optional = true }
+
+# External Redis L2 adapter (feature "redis-l2"). Mature MIT client; the
+# auto-reconnecting multiplexed ConnectionManager backs the L2 trait. The
+# crate's native default does not require it (ADR-0009 rule 2).
+redis = { version = "0.27", optional = true, default-features = false, features = ["tokio-comp", "connection-manager"] }
 
 [[test]]
 name = "resp2_compat"

--- a/crates/ag-cache/README.md
+++ b/crates/ag-cache/README.md
@@ -1,11 +1,14 @@
 # ag-cache
 
 Two-level cache for Anti-Gravital: in-process L1 with tag-based invalidation (moka),
-and optional native L2 RESP2 server compatible with any Redis client.
+an optional native L2 RESP2 server compatible with any Redis client, and an
+optional external Redis L2 for multi-instance deployments.
 
 > Status: Phase 4 — L1 implemented (in-process, tag-based invalidation, moka).
 > Native RESP2 L2 server implemented under feature `native-server` (RFC-0005).
-> External Redis L2 remains deferred (issue #144).
+> External Redis L2 implemented under feature `redis-l2`: read-through populates
+> L1, writes and invalidations go through the shared store, and the in-process
+> path stays the default (ADR-0009 rule 2).
 
 ## Minimal usage (L1 only)
 
@@ -58,6 +61,35 @@ PING, FLUSHDB, DBSIZE, COMMAND.
 - **No AUTH.** The server listens only on `127.0.0.1` (loopback) by default.
 - **No TLS.** Use a real Redis for encrypted connections.
 - **KEYS pattern** only supports `*` (all keys). Prefix patterns are not implemented.
+
+## External Redis L2 (multi-instance)
+
+Enable the `redis-l2` Cargo feature and set `redis_url` (or `REDIS_URL`) to back
+the cache with an external Redis shared across instances. The L2 is the shared
+source of truth: reads populate L1 on a miss (read-through), and writes, deletes
+and tag invalidations go through the shared store, so an invalidation on one
+instance propagates to the others on their next read-through. The L1 staleness
+window is bounded by `l1_ttl_secs`. The in-process path stays the default
+(ADR-0009 rule 2): without the feature, the cache is L1-only and a set
+`REDIS_URL` only logs a warning.
+
+```toml
+[dependencies]
+ag-cache = { version = "0.0.0", features = ["redis-l2"] }
+```
+
+```rust
+use ag_cache::{AgCache, CacheConfig};
+
+# async fn run() -> Result<(), Box<dyn std::error::Error>> {
+let mut cfg = CacheConfig::default();
+cfg.redis_url = Some("redis://localhost:6379".to_owned());
+
+let cache = AgCache::new(cfg).await?; // connects the external Redis L2
+cache.set("user:123", b"data".to_vec(), &["users"]).await;
+# Ok(())
+# }
+```
 
 ## Capabilities
 

--- a/crates/ag-cache/src/l2.rs
+++ b/crates/ag-cache/src/l2.rs
@@ -1,0 +1,203 @@
+//! L2 distributed cache backing.
+//!
+//! RFC-0005 chose an in-process RESP2 server as the *default* L2 to avoid an
+//! operational Redis dependency. This module adds the complementary option that
+//! RFC-0005 left for multi-instance deployments: an external Redis L2 as an
+//! opt-in adapter behind the `redis-l2` feature, with the in-process path kept
+//! as the native default (ADR-0009 rule 2).
+//!
+//! # Consistency model
+//!
+//! The L2 is the shared source of truth across instances. [`AgCache`] reads
+//! through it on an L1 miss (populating L1) and writes through it on
+//! set/delete/invalidate. A cross-instance invalidation therefore propagates by
+//! removing the entry from the shared L2; other instances observe it on their
+//! next read-through. The L1 staleness window is bounded by the L1 TTL
+//! (`l1_ttl_secs`): an instance that already cached a value in L1 keeps serving
+//! it until that TTL elapses. Active L1 invalidation broadcast is intentionally
+//! out of scope here (RFC-0005 keeps pub/sub in `ag-realtime`).
+//!
+//! [`AgCache`]: crate::AgCache
+
+use std::time::Duration;
+
+use async_trait::async_trait;
+
+use crate::CacheError;
+
+/// A distributed L2 cache backing shared across instances.
+#[async_trait]
+pub trait L2Cache: Send + Sync {
+    /// Fetches the raw bytes for `key`, if present.
+    async fn get(&self, key: &str) -> Result<Option<Vec<u8>>, CacheError>;
+
+    /// Stores `value` under `key` with the given `ttl`, registering `tags` for
+    /// group invalidation.
+    async fn set(
+        &self,
+        key: &str,
+        value: &[u8],
+        ttl: Duration,
+        tags: &[&str],
+    ) -> Result<(), CacheError>;
+
+    /// Removes the entry with `key`.
+    async fn delete(&self, key: &str) -> Result<(), CacheError>;
+
+    /// Removes every entry registered under `tag`.
+    async fn invalidate_tag(&self, tag: &str) -> Result<(), CacheError>;
+}
+
+/// Process-local reference L2.
+///
+/// It is the reference implementation and powers the distributed-invalidation
+/// tests: two [`AgCache`](crate::AgCache) instances sharing one `InMemoryL2`
+/// behave like two instances sharing one Redis. It does not survive the process
+/// and is not distributed, so production multi-instance setups use
+/// [`RedisL2`] (feature `redis-l2`).
+#[derive(Debug, Default)]
+pub struct InMemoryL2 {
+    store: std::sync::Mutex<std::collections::HashMap<String, Vec<u8>>>,
+    tags: std::sync::Mutex<std::collections::HashMap<String, std::collections::HashSet<String>>>,
+}
+
+impl InMemoryL2 {
+    /// Creates an empty L2.
+    pub fn new() -> Self {
+        Self::default()
+    }
+}
+
+#[async_trait]
+impl L2Cache for InMemoryL2 {
+    async fn get(&self, key: &str) -> Result<Option<Vec<u8>>, CacheError> {
+        Ok(self
+            .store
+            .lock()
+            .expect("l2 lock poisoned")
+            .get(key)
+            .cloned())
+    }
+
+    async fn set(
+        &self,
+        key: &str,
+        value: &[u8],
+        _ttl: Duration,
+        tags: &[&str],
+    ) -> Result<(), CacheError> {
+        self.store
+            .lock()
+            .expect("l2 lock poisoned")
+            .insert(key.to_owned(), value.to_vec());
+        if !tags.is_empty() {
+            let mut idx = self.tags.lock().expect("l2 lock poisoned");
+            for tag in tags {
+                idx.entry((*tag).to_owned())
+                    .or_default()
+                    .insert(key.to_owned());
+            }
+        }
+        Ok(())
+    }
+
+    async fn delete(&self, key: &str) -> Result<(), CacheError> {
+        self.store.lock().expect("l2 lock poisoned").remove(key);
+        Ok(())
+    }
+
+    async fn invalidate_tag(&self, tag: &str) -> Result<(), CacheError> {
+        let keys = self
+            .tags
+            .lock()
+            .expect("l2 lock poisoned")
+            .remove(tag)
+            .unwrap_or_default();
+        let mut store = self.store.lock().expect("l2 lock poisoned");
+        for key in keys {
+            store.remove(&key);
+        }
+        Ok(())
+    }
+}
+
+#[cfg(feature = "redis-l2")]
+pub use redis_backend::RedisL2;
+
+#[cfg(feature = "redis-l2")]
+mod redis_backend {
+    use super::{CacheError, L2Cache};
+    use async_trait::async_trait;
+    use redis::aio::ConnectionManager;
+    use redis::AsyncCommands;
+    use std::time::Duration;
+
+    fn redis_err(e: redis::RedisError) -> CacheError {
+        CacheError::Redis(e.to_string())
+    }
+
+    /// Tag set key prefix in Redis (`ag:tag:{tag}` -> set of member keys).
+    fn tag_key(tag: &str) -> String {
+        format!("ag:tag:{tag}")
+    }
+
+    /// External Redis L2 adapter (feature `redis-l2`).
+    ///
+    /// Uses a multiplexed [`ConnectionManager`] that reconnects automatically.
+    /// Tags are tracked as Redis sets so a tag invalidation can delete every
+    /// member key in one round trip.
+    pub struct RedisL2 {
+        conn: ConnectionManager,
+    }
+
+    impl RedisL2 {
+        /// Connects to the Redis instance at `url` (e.g. `redis://host:6379`).
+        pub async fn connect(url: &str) -> Result<Self, CacheError> {
+            let client = redis::Client::open(url).map_err(redis_err)?;
+            let conn = ConnectionManager::new(client).await.map_err(redis_err)?;
+            Ok(Self { conn })
+        }
+    }
+
+    #[async_trait]
+    impl L2Cache for RedisL2 {
+        async fn get(&self, key: &str) -> Result<Option<Vec<u8>>, CacheError> {
+            let mut conn = self.conn.clone();
+            let value: Option<Vec<u8>> = conn.get(key).await.map_err(redis_err)?;
+            Ok(value)
+        }
+
+        async fn set(
+            &self,
+            key: &str,
+            value: &[u8],
+            ttl: Duration,
+            tags: &[&str],
+        ) -> Result<(), CacheError> {
+            let mut conn = self.conn.clone();
+            let secs = ttl.as_secs().max(1);
+            let _: () = conn.set_ex(key, value, secs).await.map_err(redis_err)?;
+            for tag in tags {
+                let _: i64 = conn.sadd(tag_key(tag), key).await.map_err(redis_err)?;
+            }
+            Ok(())
+        }
+
+        async fn delete(&self, key: &str) -> Result<(), CacheError> {
+            let mut conn = self.conn.clone();
+            let _: i64 = conn.del(key).await.map_err(redis_err)?;
+            Ok(())
+        }
+
+        async fn invalidate_tag(&self, tag: &str) -> Result<(), CacheError> {
+            let mut conn = self.conn.clone();
+            let set_key = tag_key(tag);
+            let members: Vec<String> = conn.smembers(&set_key).await.map_err(redis_err)?;
+            if !members.is_empty() {
+                let _: i64 = conn.del(members).await.map_err(redis_err)?;
+            }
+            let _: i64 = conn.del(set_key).await.map_err(redis_err)?;
+            Ok(())
+        }
+    }
+}

--- a/crates/ag-cache/src/lib.rs
+++ b/crates/ag-cache/src/lib.rs
@@ -1,14 +1,19 @@
 //! Multilevel cache for the Anti-Gravital ecosystem.
 //!
-//! Offers two transparent levels:
+//! Offers transparent levels:
 //! - **L1**: moka in memory (TinyLFU, no contended locks, always available).
 //! - **L2 native**: optional in-process RESP2 server (feature `native-server`),
 //!   compatible with any Redis client. Backed by the same L1 store.
+//! - **L2 distributed**: optional external Redis backing (feature `redis-l2`)
+//!   for multi-instance deployments. Read-through populates L1; writes and
+//!   invalidations go through the shared store (see [`l2`]).
 //!
 //! # Status
 //!
-//! L1 fully operational. Native RESP2 server (RFC-0005) implemented under
-//! the `native-server` feature. External Redis L2 remains deferred (issue #144).
+//! L1 fully operational. Native RESP2 server (RFC-0005) under the
+//! `native-server` feature. External Redis L2 under the `redis-l2` feature: the
+//! in-process path stays the default, the external backing is opt-in (ADR-0009
+//! rule 2).
 //!
 //! # Minimal usage (L1 only)
 //!
@@ -40,12 +45,17 @@
 
 pub mod config;
 pub mod l1;
+pub mod l2;
 pub mod tags;
 
 #[cfg(feature = "native-server")]
 pub mod server;
 
 pub use config::CacheConfig;
+pub use l2::{InMemoryL2, L2Cache};
+
+#[cfg(feature = "redis-l2")]
+pub use l2::RedisL2;
 
 use l1::L1Cache;
 use std::sync::Arc;
@@ -74,26 +84,25 @@ impl std::fmt::Display for CacheError {
 
 impl std::error::Error for CacheError {}
 
-/// Multilevel cache with L1 (moka) and optional native RESP2 server.
+/// Multilevel cache with L1 (moka), an optional native RESP2 server and an
+/// optional external Redis L2 (feature `redis-l2`).
 pub struct AgCache {
     l1: Arc<L1Cache>,
-    // TECH-DEBT (issue #144): external Redis L2 distributed layer deferred.
+    l2: Option<Arc<dyn L2Cache>>,
+    ttl: Duration,
 }
 
 impl AgCache {
     /// Creates a new [`AgCache`] with the given configuration.
     ///
     /// If `native_server_enabled` is `true` and feature `native-server` is active,
-    /// spawns the RESP2 server in a background task.
+    /// spawns the RESP2 server in a background task. If `redis_url` is set and
+    /// feature `redis-l2` is active, connects the external Redis L2; otherwise
+    /// the cache is L1-only (the native default, ADR-0009 rule 2).
     pub async fn new(config: CacheConfig) -> Result<Self, CacheError> {
         let ttl = Duration::from_secs(config.l1_ttl_secs);
         let l1 = Arc::new(L1Cache::new(config.l1_max_capacity, ttl));
-
-        if config.redis_url.is_some() {
-            tracing::warn!(
-                "REDIS_URL set but external Redis L2 is not active in this version (issue #144)"
-            );
-        }
+        let l2 = connect_l2(&config).await?;
 
         #[cfg(feature = "native-server")]
         if config.native_server_enabled {
@@ -103,38 +112,102 @@ impl AgCache {
             tokio::spawn(srv.serve());
         }
 
-        Ok(Self { l1 })
+        Ok(Self { l1, l2, ttl })
+    }
+
+    /// Injects a custom [`L2Cache`] backing, overriding any configured one.
+    ///
+    /// Used to plug a non-default distributed backing (and by tests that share
+    /// one [`InMemoryL2`] across instances).
+    #[must_use]
+    pub fn with_l2(mut self, l2: Arc<dyn L2Cache>) -> Self {
+        self.l2 = Some(l2);
+        self
     }
 
     /// Gets raw bytes from the cache.
+    ///
+    /// On an L1 miss, reads through the L2 (if configured) and, on an L2 hit,
+    /// populates L1 before returning. An L2 backend error is logged and treated
+    /// as a miss, so a transient L2 outage degrades to L1-only rather than
+    /// failing the read.
     pub async fn get(&self, key: &str) -> Option<Vec<u8>> {
-        let result = self.l1.get_bytes(key).await;
-        if result.is_some() {
+        if let Some(value) = self.l1.get_bytes(key).await {
             tracing::debug!(key, "cache hit L1");
-        } else {
-            tracing::debug!(key, "cache miss");
+            return Some(value);
         }
-        result
+        if let Some(l2) = &self.l2 {
+            match l2.get(key).await {
+                Ok(Some(value)) => {
+                    tracing::debug!(key, "cache hit L2");
+                    self.l1.set_bytes(key, value.clone()).await;
+                    return Some(value);
+                }
+                Ok(None) => {}
+                Err(e) => tracing::warn!(key, error = %e, "L2 get failed; serving as L1 miss"),
+            }
+        }
+        tracing::debug!(key, "cache miss");
+        None
     }
 
-    /// Stores bytes in the cache with optional tags for invalidation.
+    /// Stores bytes in the cache with optional tags for invalidation, writing
+    /// through to the L2 when configured.
     pub async fn set(&self, key: &str, value: Vec<u8>, tags: &[&str]) {
         if tags.is_empty() {
-            self.l1.set_bytes(key, value).await;
+            self.l1.set_bytes(key, value.clone()).await;
         } else {
-            self.l1.set_bytes_tagged(key, value, tags).await;
+            self.l1.set_bytes_tagged(key, value.clone(), tags).await;
+        }
+        if let Some(l2) = &self.l2 {
+            if let Err(e) = l2.set(key, &value, self.ttl, tags).await {
+                tracing::warn!(key, error = %e, "L2 set failed; value cached in L1 only");
+            }
         }
     }
 
-    /// Invalidates all entries associated with the given tag in L1.
+    /// Invalidates all entries associated with the given tag, in L1 and the L2.
     pub async fn invalidate_tag(&self, tag: &str) {
         self.l1.invalidate_tag(tag).await;
+        if let Some(l2) = &self.l2 {
+            if let Err(e) = l2.invalidate_tag(tag).await {
+                tracing::warn!(tag, error = %e, "L2 tag invalidation failed");
+            }
+        }
     }
 
-    /// Removes the entry with the given key.
+    /// Removes the entry with the given key, from L1 and the L2.
     pub async fn delete(&self, key: &str) {
         self.l1.delete(key).await;
+        if let Some(l2) = &self.l2 {
+            if let Err(e) = l2.delete(key).await {
+                tracing::warn!(key, error = %e, "L2 delete failed");
+            }
+        }
     }
+}
+
+/// Connects the external Redis L2 when the `redis-l2` feature is on and
+/// `redis_url` is set; otherwise returns `None` (the native default).
+#[cfg(feature = "redis-l2")]
+async fn connect_l2(config: &CacheConfig) -> Result<Option<Arc<dyn L2Cache>>, CacheError> {
+    match &config.redis_url {
+        Some(url) => {
+            let backing = l2::RedisL2::connect(url).await?;
+            Ok(Some(Arc::new(backing) as Arc<dyn L2Cache>))
+        }
+        None => Ok(None),
+    }
+}
+
+#[cfg(not(feature = "redis-l2"))]
+async fn connect_l2(config: &CacheConfig) -> Result<Option<Arc<dyn L2Cache>>, CacheError> {
+    if config.redis_url.is_some() {
+        tracing::warn!(
+            "REDIS_URL is set but the `redis-l2` feature is not enabled; running L1-only"
+        );
+    }
+    Ok(None)
 }
 
 #[cfg(test)]
@@ -170,5 +243,78 @@ mod tests {
     async fn get_returns_none_for_missing_key() {
         let cache = AgCache::new(CacheConfig::default()).await.unwrap();
         assert!(cache.get("nonexistent").await.is_none());
+    }
+
+    // ---- L2 backing (backend-agnostic, in-process via a shared InMemoryL2) ---
+
+    #[tokio::test]
+    async fn l2_read_through_populates_l1() {
+        let shared = Arc::new(InMemoryL2::new());
+        shared
+            .set("k", b"v", Duration::from_secs(60), &[])
+            .await
+            .unwrap();
+        let cache = AgCache::new(CacheConfig::default())
+            .await
+            .unwrap()
+            .with_l2(shared.clone());
+        // L1 miss -> L2 hit -> value returned (and L1 populated).
+        assert_eq!(cache.get("k").await, Some(b"v".to_vec()));
+        // Subsequent read now served by L1 even if L2 is emptied.
+        shared.delete("k").await.unwrap();
+        assert_eq!(cache.get("k").await, Some(b"v".to_vec()));
+    }
+
+    #[tokio::test]
+    async fn set_writes_through_to_l2() {
+        let shared = Arc::new(InMemoryL2::new());
+        let cache = AgCache::new(CacheConfig::default())
+            .await
+            .unwrap()
+            .with_l2(shared.clone());
+        cache.set("k", b"v".to_vec(), &[]).await;
+        assert_eq!(shared.get("k").await.unwrap(), Some(b"v".to_vec()));
+    }
+
+    #[tokio::test]
+    async fn distributed_invalidation_via_shared_l2() {
+        // Two instances sharing one L2 stand in for two instances sharing one
+        // Redis. Invalidation on A propagates to a fresh instance through L2.
+        let shared = Arc::new(InMemoryL2::new());
+        let a = AgCache::new(CacheConfig::default())
+            .await
+            .unwrap()
+            .with_l2(shared.clone());
+        let b = AgCache::new(CacheConfig::default())
+            .await
+            .unwrap()
+            .with_l2(shared.clone());
+
+        a.set("u:1", b"x".to_vec(), &["users"]).await;
+        // B sees A's write through the shared L2 (B's L1 was empty).
+        assert_eq!(b.get("u:1").await, Some(b"x".to_vec()));
+
+        // A invalidates the tag, removing it from the shared L2.
+        a.invalidate_tag("users").await;
+
+        // A brand-new instance (empty L1) no longer finds it: the invalidation
+        // propagated across instances through the shared L2.
+        let c = AgCache::new(CacheConfig::default())
+            .await
+            .unwrap()
+            .with_l2(shared.clone());
+        assert_eq!(c.get("u:1").await, None);
+    }
+
+    #[tokio::test]
+    async fn delete_propagates_to_l2() {
+        let shared = Arc::new(InMemoryL2::new());
+        let cache = AgCache::new(CacheConfig::default())
+            .await
+            .unwrap()
+            .with_l2(shared.clone());
+        cache.set("k", b"v".to_vec(), &[]).await;
+        cache.delete("k").await;
+        assert_eq!(shared.get("k").await.unwrap(), None);
     }
 }

--- a/crates/ag-cache/tests/redis_l2.rs
+++ b/crates/ag-cache/tests/redis_l2.rs
@@ -1,0 +1,58 @@
+//! Live external-Redis L2 test for `ag-cache` (issue #144).
+//!
+//! Ignored by default: it needs a reachable Redis through `REDIS_URL`. Run with:
+//!
+//! ```sh
+//! REDIS_URL=redis://localhost:6379 \
+//!   cargo test -p ag-cache --features redis-l2 --test redis_l2 -- --ignored
+//! ```
+//!
+//! Self-isolating: it uses time-unique keys and cleans them up.
+#![cfg(feature = "redis-l2")]
+
+use std::sync::Arc;
+use std::time::{Duration, SystemTime, UNIX_EPOCH};
+
+use ag_cache::{AgCache, CacheConfig, L2Cache, RedisL2};
+
+fn unique() -> u128 {
+    SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .map(|d| d.as_nanos())
+        .unwrap_or(0)
+}
+
+#[tokio::test]
+#[ignore = "requires REDIS_URL pointing at a live Redis"]
+async fn redis_l2_roundtrip_and_distributed_invalidation() {
+    let url = std::env::var("REDIS_URL").expect("REDIS_URL must point at a live Redis");
+    let l2 = Arc::new(RedisL2::connect(&url).await.unwrap());
+
+    let key = format!("ag:test:k:{}", unique());
+    let tag = format!("ag:test:tag:{}", unique());
+
+    // Direct adapter round-trip.
+    l2.set(&key, b"v", Duration::from_secs(60), &[tag.as_str()])
+        .await
+        .unwrap();
+    assert_eq!(l2.get(&key).await.unwrap(), Some(b"v".to_vec()));
+
+    // A fresh AgCache (empty L1) reads it through the shared Redis.
+    let cache = AgCache::new(CacheConfig::default())
+        .await
+        .unwrap()
+        .with_l2(l2.clone());
+    assert_eq!(cache.get(&key).await, Some(b"v".to_vec()));
+
+    // Tag invalidation removes it from the shared store; a brand-new instance
+    // no longer finds it (distributed invalidation through Redis).
+    l2.invalidate_tag(&tag).await.unwrap();
+    let fresh = AgCache::new(CacheConfig::default())
+        .await
+        .unwrap()
+        .with_l2(l2.clone());
+    assert_eq!(fresh.get(&key).await, None);
+
+    // Cleanup (key already gone via tag invalidation; idempotent).
+    l2.delete(&key).await.unwrap();
+}

--- a/crates/ag-mail/Cargo.toml
+++ b/crates/ag-mail/Cargo.toml
@@ -99,6 +99,11 @@ base64 = { version = "0.22", optional = true }
 [dev-dependencies]
 proptest = { workspace = true }
 tokio = { workspace = true, features = ["test-util"] }
+# In-process STARTTLS SMTP sink for the native-MTA protocol-path tests: a
+# self-signed cert (rcgen) plus a rustls/tokio-rustls acceptor. Test-only.
+rcgen = { workspace = true }
+rustls = { workspace = true }
+tokio-rustls = { workspace = true }
 # Self dev-dependency so integration tests in `tests/` compile the library with
 # `test-utils` on, exposing `NullSender`. Without this the `#[ignore]` Postgres
 # parity suites (persistent_queue, workers_postgres) fail to compile under their

--- a/crates/ag-mail/src/sender/mta/mod.rs
+++ b/crates/ag-mail/src/sender/mta/mod.rs
@@ -541,4 +541,209 @@ mod tests {
         assert!(!gmail.content.is_empty());
         assert_eq!(gmail.scheduled_key(), "tenant-a:welcome:gmail.com");
     }
+
+    // ---- ESMTP + STARTTLS protocol path against a local in-process sink -----
+    //
+    // The direct-MX submit path used to be exercised only by `#[ignore]` tests
+    // needing real DNS/port-25 egress. These tests stand up a minimal SMTP sink
+    // on loopback that advertises STARTTLS and upgrades with a self-signed
+    // certificate, then drive `MtaSender::submit` against it. So the EHLO ->
+    // STARTTLS -> EHLO -> MAIL -> RCPT -> DATA dialogue (and the DKIM-signed body
+    // on the wire) runs in CI with no external services. Real external-MX
+    // delivery stays a manual gate (the `#[ignore]` live resolver test), since
+    // port 25 egress is blocked here.
+
+    /// What the sink observed during one SMTP session (post-STARTTLS).
+    #[derive(Default)]
+    struct SinkCapture {
+        mail_from: String,
+        rcpts: Vec<String>,
+        data: Vec<u8>,
+    }
+
+    /// Builds a `tokio-rustls` acceptor with a throwaway self-signed cert for
+    /// `127.0.0.1`. The client accepts it via opportunistic TLS
+    /// (`allow_invalid_certs`).
+    fn test_tls_acceptor() -> tokio_rustls::TlsAcceptor {
+        use rustls::ServerConfig;
+        use rustls_pki_types::{PrivateKeyDer, PrivatePkcs8KeyDer};
+        use std::sync::Arc;
+
+        let ck = rcgen::generate_simple_self_signed(vec!["127.0.0.1".to_owned()]).unwrap();
+        let cert = ck.cert.der().clone();
+        let key = PrivateKeyDer::Pkcs8(PrivatePkcs8KeyDer::from(ck.key_pair.serialize_der()));
+        let provider = Arc::new(rustls::crypto::ring::default_provider());
+        let config = ServerConfig::builder_with_provider(provider)
+            .with_safe_default_protocol_versions()
+            .unwrap()
+            .with_no_client_auth()
+            .with_single_cert(vec![cert], key)
+            .unwrap();
+        tokio_rustls::TlsAcceptor::from(Arc::new(config))
+    }
+
+    /// Reads one CRLF-terminated line without buffering past it, so the raw
+    /// stream is left intact for the TLS handshake after `STARTTLS`.
+    async fn read_line<S: tokio::io::AsyncRead + Unpin>(stream: &mut S) -> Option<String> {
+        use tokio::io::AsyncReadExt;
+        let mut buf = Vec::new();
+        let mut byte = [0u8; 1];
+        loop {
+            match stream.read(&mut byte).await {
+                Ok(0) => {
+                    return (!buf.is_empty()).then(|| String::from_utf8_lossy(&buf).into_owned());
+                }
+                Ok(_) => {
+                    buf.push(byte[0]);
+                    if byte[0] == b'\n' {
+                        return Some(String::from_utf8_lossy(&buf).into_owned());
+                    }
+                }
+                Err(_) => return None,
+            }
+        }
+    }
+
+    /// Drives the post-STARTTLS SMTP dialogue over the (now TLS) stream.
+    async fn serve_smtp<S>(mut stream: S, capture: &mut SinkCapture)
+    where
+        S: tokio::io::AsyncRead + tokio::io::AsyncWrite + Unpin,
+    {
+        use tokio::io::AsyncWriteExt;
+        while let Some(line) = read_line(&mut stream).await {
+            let cmd = line.trim_end();
+            let upper = cmd.to_ascii_uppercase();
+            if upper.starts_with("EHLO") || upper.starts_with("HELO") {
+                stream.write_all(b"250-sink\r\n250 OK\r\n").await.unwrap();
+            } else if upper.starts_with("MAIL FROM") {
+                capture.mail_from = cmd.to_owned();
+                stream.write_all(b"250 OK\r\n").await.unwrap();
+            } else if upper.starts_with("RCPT TO") {
+                capture.rcpts.push(cmd.to_owned());
+                stream.write_all(b"250 OK\r\n").await.unwrap();
+            } else if upper.starts_with("DATA") {
+                stream
+                    .write_all(b"354 End data with <CR><LF>.<CR><LF>\r\n")
+                    .await
+                    .unwrap();
+                while let Some(dl) = read_line(&mut stream).await {
+                    if dl == ".\r\n" {
+                        break;
+                    }
+                    capture.data.extend_from_slice(dl.as_bytes());
+                }
+                stream.write_all(b"250 OK queued\r\n").await.unwrap();
+            } else if upper.starts_with("QUIT") {
+                stream.write_all(b"221 Bye\r\n").await.unwrap();
+                break;
+            } else {
+                stream.write_all(b"250 OK\r\n").await.unwrap();
+            }
+        }
+    }
+
+    /// One-session SMTP sink: greets, advertises STARTTLS, upgrades to TLS, then
+    /// accepts one message over the encrypted channel.
+    async fn run_smtp_sink(
+        listener: tokio::net::TcpListener,
+        acceptor: tokio_rustls::TlsAcceptor,
+    ) -> SinkCapture {
+        use tokio::io::AsyncWriteExt;
+
+        let (mut stream, _) = listener.accept().await.expect("sink accepts a connection");
+        let mut capture = SinkCapture::default();
+
+        stream.write_all(b"220 sink ESMTP\r\n").await.unwrap();
+        // Plaintext phase: greet EHLO, advertise STARTTLS, then upgrade.
+        loop {
+            let Some(line) = read_line(&mut stream).await else {
+                return capture;
+            };
+            let upper = line.trim_end().to_ascii_uppercase();
+            if upper.starts_with("EHLO") || upper.starts_with("HELO") {
+                stream
+                    .write_all(b"250-sink\r\n250-STARTTLS\r\n250 OK\r\n")
+                    .await
+                    .unwrap();
+            } else if upper.starts_with("STARTTLS") {
+                stream.write_all(b"220 Go ahead\r\n").await.unwrap();
+                break;
+            } else if upper.starts_with("QUIT") {
+                stream.write_all(b"221 Bye\r\n").await.unwrap();
+                return capture;
+            } else {
+                stream.write_all(b"250 OK\r\n").await.unwrap();
+            }
+        }
+
+        let tls = acceptor.accept(stream).await.expect("TLS handshake");
+        serve_smtp(tls, &mut capture).await;
+        capture
+    }
+
+    #[tokio::test]
+    async fn submit_speaks_esmtp_over_starttls_to_local_sink() {
+        let listener = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
+        let port = listener.local_addr().unwrap().port();
+        let sink = tokio::spawn(run_smtp_sink(listener, test_tls_acceptor()));
+
+        // Default config: opportunistic STARTTLS, accepting the self-signed cert.
+        let sender = MtaSender::new(MtaConfig::new("test.local").with_port(port));
+
+        let content = b"From: from@send.example\r\nSubject: hi\r\n\r\nbody\r\n";
+        let result = sender
+            .submit(
+                "127.0.0.1",
+                "from@send.example",
+                &["rcpt@example.com"],
+                content,
+                None,
+            )
+            .await;
+        assert!(
+            result.is_ok(),
+            "submit should succeed against the sink: {result:?}"
+        );
+
+        let cap = sink.await.unwrap();
+        assert!(
+            cap.mail_from.contains("from@send.example"),
+            "MAIL FROM seen: {}",
+            cap.mail_from
+        );
+        assert!(cap.rcpts.iter().any(|r| r.contains("rcpt@example.com")));
+        assert!(String::from_utf8_lossy(&cap.data).contains("Subject: hi"));
+    }
+
+    #[tokio::test]
+    async fn submit_signs_with_dkim_on_the_wire() {
+        use mail_auth::common::crypto::Ed25519Key;
+
+        let listener = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
+        let port = listener.local_addr().unwrap().port();
+        let sink = tokio::spawn(run_smtp_sink(listener, test_tls_acceptor()));
+
+        let pkcs8 = Ed25519Key::generate_pkcs8().expect("key generation succeeds");
+        let dkim = DkimConfig::ed25519("send.example", "sel", pkcs8);
+        let sender = MtaSender::new(MtaConfig::new("test.local").with_port(port).with_dkim(dkim));
+
+        let content = b"From: from@send.example\r\nSubject: hi\r\n\r\nbody\r\n";
+        let result = sender
+            .submit(
+                "127.0.0.1",
+                "from@send.example",
+                &["rcpt@example.com"],
+                content,
+                None,
+            )
+            .await;
+        assert!(result.is_ok(), "DKIM submit should succeed: {result:?}");
+
+        let cap = sink.await.unwrap();
+        let wire = String::from_utf8_lossy(&cap.data);
+        assert!(
+            wire.contains("DKIM-Signature:"),
+            "the message on the wire must carry a DKIM signature"
+        );
+    }
 }

--- a/docs/DEBT.md
+++ b/docs/DEBT.md
@@ -126,7 +126,13 @@ For current, actionable debt see the GitHub Issues board filtered by the
 - Expected removal: add a CI service container acting as a sink MTA and a
   fixture resolver, then de-`ignore` the protocol-path delivery test. Real
   external-MX delivery remains a manual gate on a host with port 25 egress.
-- Status: migrated to GitHub issue #153 (live tracking). Owning plan: RFC-0009 section 4.8. Target: Phase 4.6-B.
+- Status: migrated to GitHub issue #153 (live tracking). The ESMTP/STARTTLS/DKIM
+  protocol path is now exercised automatically: in-process unit tests stand up a
+  loopback SMTP sink that advertises STARTTLS and upgrades with a self-signed
+  cert, driving `MtaSender::submit` through EHLO -> STARTTLS -> MAIL -> RCPT ->
+  DATA (and asserting the DKIM-Signature on the wire). Real external-MX delivery
+  stays a manual gate (port 25 egress is blocked here and in hosted CI). Owning
+  plan: RFC-0009 section 4.8. Target: Phase 4.6-B.
 
 ## ag-cache
 

--- a/docs/pr-drafts/feat-pre-phase5-backlog.md
+++ b/docs/pr-drafts/feat-pre-phase5-backlog.md
@@ -49,6 +49,23 @@ adaptador opt-in con el camino nativo por defecto. Esta rama lo anade:
 - `crates/ag-cache/tests/redis_l2.rs` (nuevo): test live `#[ignore]` con `REDIS_URL`.
 - README (raiz EN+ES) y `crates/ag-cache/README.md` sincronizados.
 
+### Issue #153 — Native MTA: protocol-path delivery test (DEBT-022)
+
+El camino de entrega directa por MX (`MtaSender::submit`) solo estaba cubierto
+por tests `#[ignore]` que requieren DNS real y egress por puerto 25. Esta rama
+ejercita el camino ESMTP/STARTTLS/DKIM de forma automatica en CI, sin servicios
+externos ni Docker:
+
+- `crates/ag-mail/src/sender/mta/mod.rs`: dos unit tests que levantan un sink
+  SMTP de una sesion en loopback que anuncia STARTTLS y hace upgrade con un
+  certificado self-signed (`rcgen` + `rustls`/`tokio-rustls`), y conducen
+  `submit` por EHLO -> STARTTLS -> EHLO -> MAIL -> RCPT -> DATA. Un test afirma
+  el envelope/cuerpo; el otro afirma la cabecera `DKIM-Signature:` en el cable.
+- `crates/ag-mail/Cargo.toml`: dev-deps `rcgen`, `rustls`, `tokio-rustls` (solo
+  test) para el sink TLS.
+- `docs/DEBT.md`: DEBT-022 actualizado; la entrega real a un MX externo sigue
+  siendo una compuerta manual (puerto 25 bloqueado aqui y en CI hospedado).
+
 ## Plan de prueba
 
 ```sh
@@ -60,6 +77,11 @@ cargo test   -p ag-cache            # 24 tests, incluye los 4 de L2
 # Test live (requiere Redis):
 REDIS_URL=redis://localhost:6379 \
   cargo test -p ag-cache --features redis-l2 --test redis_l2 -- --ignored
+
+# Issue #153 (ag-mail MTA sink):
+cargo fmt --check -p ag-mail
+cargo clippy -p ag-mail --features mta --tests -- -D warnings
+cargo test   -p ag-mail --features mta   # 107 tests, incluye los 2 del sink STARTTLS
 ```
 
 ## Alcance de verificacion (honesto)
@@ -80,6 +102,7 @@ REDIS_URL=redis://localhost:6379 \
 ## Cierre de issues
 
 Closes #144
+Closes #153
 
 ## Checklist final
 

--- a/docs/pr-drafts/feat-pre-phase5-backlog.md
+++ b/docs/pr-drafts/feat-pre-phase5-backlog.md
@@ -1,0 +1,91 @@
+# Descriptor de PR
+
+## Resumen
+
+Backlog pre-Fase-5: features opt-in tras feature Cargo con el camino nativo por defecto (ag-cache Redis L2)
+
+## Fase afectada
+
+Endurecimiento pre-Fase-5 (Fase 4.x). Trabajo aditivo; cada feature es opt-in y
+conserva el comportamiento nativo por defecto (ADR-0009 regla 2). No avanza una
+fase de la Hoja de Ruta.
+
+## Tipo de cambio
+
+- [ ] Correccion de bug
+- [x] Nueva feature (adaptadores opt-in tras feature Cargo)
+- [x] Documentacion (cabeceras, README EN+ES, READMEs de crate)
+- [ ] CI / seguridad
+- [ ] Cambio que rompe compatibilidad
+
+## Contexto
+
+Esta rama acumula la resolucion de varias issues del backlog pre-Fase-5, cada
+una como un commit enfocado. Todas siguen el mismo patron honesto: el mecanismo
+agnostico del backend se verifica en proceso (tests que pasan aqui) y el backend
+externo real va tras una feature Cargo con su test live `#[ignore]` (el sandbox
+no tiene Docker ni servicios externos; CLAUDE.md section 29.2 admite
+`#[ignore]` + verificacion manual documentada para dependencias de servicio).
+
+### Issue #144 — ag-cache: capa L2 Redis externa
+
+`ag-cache` tenia solo L1 (moka) y el servidor RESP2 nativo; el L2 Redis externo
+estaba diferido (solo avisaba con `REDIS_URL`). RFC-0005 eligio el servidor RESP2
+nativo como L2 *por defecto*; ADR-0009 regla 2 permite Redis externo como
+adaptador opt-in con el camino nativo por defecto. Esta rama lo anade:
+
+- `crates/ag-cache/src/l2.rs` (nuevo): trait `L2Cache`, `InMemoryL2` (referencia
+  + tests) y `RedisL2` tras feature `redis-l2` (cliente `redis` con
+  `ConnectionManager`; tags como Redis sets).
+- `crates/ag-cache/src/lib.rs`: `AgCache` gana `l2: Option<Arc<dyn L2Cache>>`;
+  `get` hace read-through y puebla L1; `set`/`delete`/`invalidate_tag` escriben
+  write-through; `with_l2` para inyectar backing; `connect_l2` conecta Redis
+  cuando la feature esta activa y hay `redis_url`. Marcador TECH-DEBT eliminado.
+- Modelo de consistencia: el L2 es la fuente de verdad compartida; la
+  invalidacion cross-instancia se propaga por el read-through; el staleness de L1
+  esta acotado por `l1_ttl_secs` (documentado).
+- `crates/ag-cache/Cargo.toml`: feature `redis-l2 = ["dep:redis"]`, deps
+  `async-trait` y `redis` (opcional), descripcion sin la marca retirada.
+- `crates/ag-cache/tests/redis_l2.rs` (nuevo): test live `#[ignore]` con `REDIS_URL`.
+- README (raiz EN+ES) y `crates/ag-cache/README.md` sincronizados.
+
+## Plan de prueba
+
+```sh
+cargo fmt --check -p ag-cache
+cargo clippy -p ag-cache --tests -- -D warnings
+cargo clippy -p ag-cache --features redis-l2 --tests -- -D warnings
+cargo build  -p ag-cache --features redis-l2
+cargo test   -p ag-cache            # 24 tests, incluye los 4 de L2
+# Test live (requiere Redis):
+REDIS_URL=redis://localhost:6379 \
+  cargo test -p ag-cache --features redis-l2 --test redis_l2 -- --ignored
+```
+
+## Alcance de verificacion (honesto)
+
+- Verificado aqui: read-through + write-through + invalidacion distribuida (via
+  `InMemoryL2` compartido entre instancias) con `fmt`/`clippy`/24 tests en verde,
+  con y sin la feature; compila con `redis-l2`.
+- NO ejecutado aqui: el round-trip live contra Redis (sin Docker en el sandbox);
+  queda como test `#[ignore]` + `REDIS_URL` documentado.
+
+## Criterios de salida que avanza
+
+- L2 distribuido tras feature con el camino nativo por defecto (ADR-0009).
+- `REDIS_URL` + feature activa la L2; sin feature solo avisa.
+- Invalidacion distribuida cubierta por test (live `#[ignore]`).
+- Marcadores TECH-DEBT de `ag-cache` eliminados.
+
+## Cierre de issues
+
+Closes #144
+
+## Checklist final
+
+- [x] Pertenece a la fase correcta y respeta RFC-0005 + ADR-0009 regla 2.
+- [x] No rompe arquitectura; el camino L1-only por defecto es identico.
+- [x] No crea dependencias circulares; nueva dep `redis` justificada y tras feature.
+- [x] Compila; pasa fmt, clippy y tests con y sin features.
+- [x] Documentacion sincronizada (modulo, README raiz EN+ES, README del crate).
+- [x] Sin evidencia de herramientas IA; atribuido a la persona autora.


### PR DESCRIPTION
# Descriptor de PR

## Resumen

Backlog pre-Fase-5: features opt-in tras feature Cargo con el camino nativo por defecto (ag-cache Redis L2)

## Fase afectada

Endurecimiento pre-Fase-5 (Fase 4.x). Trabajo aditivo; cada feature es opt-in y
conserva el comportamiento nativo por defecto (ADR-0009 regla 2). No avanza una
fase de la Hoja de Ruta.

## Tipo de cambio

- [ ] Correccion de bug
- [x] Nueva feature (adaptadores opt-in tras feature Cargo)
- [x] Documentacion (cabeceras, README EN+ES, READMEs de crate)
- [ ] CI / seguridad
- [ ] Cambio que rompe compatibilidad

## Contexto

Esta rama acumula la resolucion de varias issues del backlog pre-Fase-5, cada
una como un commit enfocado. Todas siguen el mismo patron honesto: el mecanismo
agnostico del backend se verifica en proceso (tests que pasan aqui) y el backend
externo real va tras una feature Cargo con su test live `#[ignore]` (el sandbox
no tiene Docker ni servicios externos; CLAUDE.md section 29.2 admite
`#[ignore]` + verificacion manual documentada para dependencias de servicio).

### Issue #144 — ag-cache: capa L2 Redis externa

`ag-cache` tenia solo L1 (moka) y el servidor RESP2 nativo; el L2 Redis externo
estaba diferido (solo avisaba con `REDIS_URL`). RFC-0005 eligio el servidor RESP2
nativo como L2 *por defecto*; ADR-0009 regla 2 permite Redis externo como
adaptador opt-in con el camino nativo por defecto. Esta rama lo anade:

- `crates/ag-cache/src/l2.rs` (nuevo): trait `L2Cache`, `InMemoryL2` (referencia
  + tests) y `RedisL2` tras feature `redis-l2` (cliente `redis` con
  `ConnectionManager`; tags como Redis sets).
- `crates/ag-cache/src/lib.rs`: `AgCache` gana `l2: Option<Arc<dyn L2Cache>>`;
  `get` hace read-through y puebla L1; `set`/`delete`/`invalidate_tag` escriben
  write-through; `with_l2` para inyectar backing; `connect_l2` conecta Redis
  cuando la feature esta activa y hay `redis_url`. Marcador TECH-DEBT eliminado.
- Modelo de consistencia: el L2 es la fuente de verdad compartida; la
  invalidacion cross-instancia se propaga por el read-through; el staleness de L1
  esta acotado por `l1_ttl_secs` (documentado).
- `crates/ag-cache/Cargo.toml`: feature `redis-l2 = ["dep:redis"]`, deps
  `async-trait` y `redis` (opcional), descripcion sin la marca retirada.
- `crates/ag-cache/tests/redis_l2.rs` (nuevo): test live `#[ignore]` con `REDIS_URL`.
- README (raiz EN+ES) y `crates/ag-cache/README.md` sincronizados.

### Issue #153 — Native MTA: protocol-path delivery test (DEBT-022)

El camino de entrega directa por MX (`MtaSender::submit`) solo estaba cubierto
por tests `#[ignore]` que requieren DNS real y egress por puerto 25. Esta rama
ejercita el camino ESMTP/STARTTLS/DKIM de forma automatica en CI, sin servicios
externos ni Docker:

- `crates/ag-mail/src/sender/mta/mod.rs`: dos unit tests que levantan un sink
  SMTP de una sesion en loopback que anuncia STARTTLS y hace upgrade con un
  certificado self-signed (`rcgen` + `rustls`/`tokio-rustls`), y conducen
  `submit` por EHLO -> STARTTLS -> EHLO -> MAIL -> RCPT -> DATA. Un test afirma
  el envelope/cuerpo; el otro afirma la cabecera `DKIM-Signature:` en el cable.
- `crates/ag-mail/Cargo.toml`: dev-deps `rcgen`, `rustls`, `tokio-rustls` (solo
  test) para el sink TLS.
- `docs/DEBT.md`: DEBT-022 actualizado; la entrega real a un MX externo sigue
  siendo una compuerta manual (puerto 25 bloqueado aqui y en CI hospedado).

## Plan de prueba

```sh
cargo fmt --check -p ag-cache
cargo clippy -p ag-cache --tests -- -D warnings
cargo clippy -p ag-cache --features redis-l2 --tests -- -D warnings
cargo build  -p ag-cache --features redis-l2
cargo test   -p ag-cache            # 24 tests, incluye los 4 de L2
# Test live (requiere Redis):
REDIS_URL=redis://localhost:6379 \
  cargo test -p ag-cache --features redis-l2 --test redis_l2 -- --ignored

# Issue #153 (ag-mail MTA sink):
cargo fmt --check -p ag-mail
cargo clippy -p ag-mail --features mta --tests -- -D warnings
cargo test   -p ag-mail --features mta   # 107 tests, incluye los 2 del sink STARTTLS
```

## Alcance de verificacion (honesto)

- Verificado aqui: read-through + write-through + invalidacion distribuida (via
  `InMemoryL2` compartido entre instancias) con `fmt`/`clippy`/24 tests en verde,
  con y sin la feature; compila con `redis-l2`.
- NO ejecutado aqui: el round-trip live contra Redis (sin Docker en el sandbox);
  queda como test `#[ignore]` + `REDIS_URL` documentado.

## Criterios de salida que avanza

- L2 distribuido tras feature con el camino nativo por defecto (ADR-0009).
- `REDIS_URL` + feature activa la L2; sin feature solo avisa.
- Invalidacion distribuida cubierta por test (live `#[ignore]`).
- Marcadores TECH-DEBT de `ag-cache` eliminados.

## Cierre de issues

Closes #144
Closes #153

## Checklist final

- [x] Pertenece a la fase correcta y respeta RFC-0005 + ADR-0009 regla 2.
- [x] No rompe arquitectura; el camino L1-only por defecto es identico.
- [x] No crea dependencias circulares; nueva dep `redis` justificada y tras feature.
- [x] Compila; pasa fmt, clippy y tests con y sin features.
- [x] Documentacion sincronizada (modulo, README raiz EN+ES, README del crate).
- [x] Sin evidencia de herramientas IA; atribuido a la persona autora.
